### PR TITLE
change context.waker() to return a &Waker

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -608,7 +608,7 @@ impl<T> Sender<T> {
     fn park(&mut self, cx: Option<&mut task::Context>) {
         // TODO: clean up internal state if the task::current will fail
 
-        let task = cx.map(|cx| cx.waker());
+        let task = cx.map(|cx| cx.waker().clone());
 
         {
             let mut sender = self.sender_task.lock().unwrap();
@@ -680,7 +680,7 @@ impl<T> Sender<T> {
             //
             // Update the task in case the `Sender` has been moved to another
             // task
-            task.task = cx.map(|cx| cx.waker());
+            task.task = cx.map(|cx| cx.waker().clone());
 
             Async::Pending
         } else {
@@ -905,7 +905,7 @@ impl<T> Receiver<T> {
             return TryPark::NotEmpty;
         }
 
-        recv_task.task = Some(cx.waker());
+        recv_task.task = Some(cx.waker().clone());
         TryPark::Parked
     }
 

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -179,7 +179,7 @@ impl<T> Inner<T> {
         // may have been dropped. The first thing it does is set the flag, and
         // if it fails to acquire the lock it assumes that we'll see the flag
         // later on. So... we then try to see the flag later on!
-        let handle = cx.waker();
+        let handle = cx.waker().clone();
         match self.tx_task.try_lock() {
             Some(mut p) => *p = Some(handle),
             None => return Ok(Async::Ready(())),
@@ -250,7 +250,7 @@ impl<T> Inner<T> {
         if self.complete.load(SeqCst) {
             done = true;
         } else {
-            let task = cx.waker();
+            let task = cx.waker().clone();
             match self.rx_task.try_lock() {
                 Some(mut slot) => *slot = Some(task),
                 None => done = true,

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -31,8 +31,8 @@ impl<'a> Context<'a> {
     ///
     /// The waker can subsequently be used to wake up the task when some
     /// event of interest has happened.
-    pub fn waker(&self) -> Waker {
-        self.waker.clone()
+    pub fn waker(&self) -> &Waker {
+        self.waker
     }
 
     /// Produce a context like the current one, but using the given waker

--- a/futures-executor/benches/poll.rs
+++ b/futures-executor/benches/poll.rs
@@ -44,7 +44,7 @@ fn task_init(b: &mut Bencher) {
                     return Ok(Async::Pending);
                 }
 
-                let t = cx.waker();
+                let t = cx.waker().clone();
                 t.wake();
                 self.task = Some(t);
 

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -93,7 +93,7 @@ fn thread_yield_multi_thread(b: &mut Bencher) {
                 Ok(Async::Ready(()))
             } else {
                 self.rem -= 1;
-                self.tx.send(cx.waker()).unwrap();
+                self.tx.send(cx.waker().clone()).unwrap();
                 Ok(Async::Pending)
             }
         }

--- a/futures-util/src/future/shared.rs
+++ b/futures-util/src/future/shared.rs
@@ -99,7 +99,7 @@ impl<F> Shared<F> where F: Future {
 
     fn set_waiter(&mut self, cx: &mut task::Context) {
         let mut waiters = self.inner.notifier.waiters.lock().unwrap();
-        waiters.insert(self.waiter, cx.waker());
+        waiters.insert(self.waiter, cx.waker().clone());
     }
 
     unsafe fn clone_result(&self) -> Result<SharedItem<F::Item>, SharedError<F::Error>> {

--- a/futures-util/src/lock.rs
+++ b/futures-util/src/lock.rs
@@ -95,7 +95,8 @@ impl<T> BiLock<T> {
                 }
             }
 
-            let me = Box::new(cx.waker());
+            // type ascription for safety's sake!
+            let me: Box<Waker> = Box::new(cx.waker().clone());
             let me = Box::into_raw(me) as usize;
 
             match self.inner.state.compare_exchange(1, me, SeqCst, SeqCst) {


### PR DESCRIPTION
There a few reasons someone may want just a reference to the current `Waker`, without cloning it first.

- If one already has a previous `Waker`, and wants to know if it should be replaced, there is `Waker::will_wake(other)`. However, before this change, one could only get `other` *after* the clone, reducing the usefulness of this optimization.
- For futures that want to notify the current task immediately, without saving the waker, they never need the clone (`cx.waker().wake()`).