### PR TITLE
Add future::pinned combinator

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -9,9 +9,11 @@ use futures_core::{Future, Stream};
 // Primitive futures
 mod empty;
 mod lazy;
+mod pinned;
 mod poll_fn;
 pub use self::empty::{empty, Empty};
 pub use self::lazy::{lazy, Lazy};
+pub use self::pinned::{pinned, PinnedFut};
 pub use self::poll_fn::{poll_fn, PollFn};
 
 // combinators

--- a/futures-util/src/future/pinned.rs
+++ b/futures-util/src/future/pinned.rs
@@ -11,9 +11,9 @@ pub trait PinnedFnLt<'a, Data: 'a, Output> {
     fn apply(self, data: PinMut<'a, Data>) -> Self::Future;
 }
 
-pub trait PinnedFn<Data, Output>: for<'a> PinnedFnLt<'a, Data, Output> {}
+pub trait PinnedFn<Data, Output>: for<'a> PinnedFnLt<'a, Data, Output> + 'static {}
 impl<Data, Output, T> PinnedFn<Data, Output> for T
-    where T: for<'a> PinnedFnLt<'a, Data, Output> {}
+    where T: for<'a> PinnedFnLt<'a, Data, Output> + 'static {}
 
 impl<'a, Data, Output, Fut, T> PinnedFnLt<'a, Data, Output> for T
 where
@@ -32,21 +32,21 @@ where
 /// Created by the `borrowed` function.
 #[must_use = "futures do nothing unless polled"]
 #[allow(missing_debug_implementations)]
-pub struct PinnedFut<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> {
-    fn_or_fut: FnOrFut<'any, Data, Output, F>,
+pub struct PinnedFut<Data: 'static, Output, F: PinnedFn<Data, Output>> {
+    fn_or_fut: FnOrFut<Data, Output, F>,
     // TODO:
     // marker: Pinned,
     // Data, which may be borrowed by `fn_or_fut`, must be dropped last
     data: Data,
 }
 
-enum FnOrFut<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> {
+enum FnOrFut<Data: 'static, Output, F: PinnedFn<Data, Output>> {
     F(F),
-    Fut(<F as PinnedFnLt<'any, Data, Output>>::Future),
+    Fut(<F as PinnedFnLt<'static, Data, Output>>::Future),
     None,
 }
 
-impl<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> FnOrFut<'any, Data, Output, F> {
+impl<Data: 'static, Output, F: PinnedFn<Data, Output>> FnOrFut<Data, Output, F> {
     fn is_fn(&self) -> bool {
         if let FnOrFut::F(_) = self {
             true
@@ -58,9 +58,9 @@ impl<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> FnOrFut<'any, D
 
 /// Creates a new future which pins some data and borrows it for an
 /// asynchronous lifetime.
-pub fn pinned<'any, Data, Output, F>(data: Data, f: F) -> PinnedFut<'any, Data, Output, F>
-    where F: PinnedFn<Data, Output> + 'any,
-          Data: 'any,
+pub fn pinned<Data, Output, F>(data: Data, f: F) -> PinnedFut<Data, Output, F>
+    where F: PinnedFn<Data, Output>,
+          Data: 'static,
 {
     PinnedFut {
         fn_or_fut: FnOrFut::F(f),
@@ -72,11 +72,11 @@ unsafe fn transmute_lt<'input, 'output, T>(x: &'input mut T) -> &'output mut T {
     ::std::mem::transmute(x)
 }
 
-impl<'any, Data, Output, F> Future for PinnedFut<'any, Data, Output, F>
-    where F: PinnedFn<Data, Output> + 'any,
-          Data: 'any,
+impl<Data, Output, F> Future for PinnedFut<Data, Output, F>
+    where F: PinnedFn<Data, Output>,
+          Data: 'static,
 {
-    type Output = <<F as PinnedFnLt<'any, Data, Output>>::Future as Future>::Output;
+    type Output = <<F as PinnedFnLt<'static, Data, Output>>::Future as Future>::Output;
 
     fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
         unsafe {

--- a/futures-util/src/future/pinned.rs
+++ b/futures-util/src/future/pinned.rs
@@ -1,0 +1,116 @@
+//! Definition of the `PinnedFut` adapter combinator
+
+// TODO: import `Pinned` and use it to make `Borrowed` immovable.
+use core::mem::PinMut;
+
+use futures_core::{Future, Poll};
+use futures_core::task;
+
+pub trait PinnedFnLt<'a, Data: 'a, Output> {
+    type Future: Future<Output = Output> + 'a;
+    fn apply(self, data: PinMut<'a, Data>) -> Self::Future;
+}
+
+pub trait PinnedFn<Data, Output>: for<'a> PinnedFnLt<'a, Data, Output> {}
+impl<Data, Output, T> PinnedFn<Data, Output> for T
+    where T: for<'a> PinnedFnLt<'a, Data, Output> {}
+
+impl<'a, Data, Output, Fut, T> PinnedFnLt<'a, Data, Output> for T
+where
+    Data: 'a,
+    T: FnOnce(PinMut<'a, Data>) -> Fut,
+    Fut: Future<Output = Output> + 'a,
+{
+    type Future = Fut;
+    fn apply(self, data: PinMut<'a, Data>) -> Self::Future {
+        (self)(data)
+    }
+}
+
+/// A future which borrows a value for an asynchronous lifetime.
+///
+/// Created by the `borrowed` function.
+#[must_use = "futures do nothing unless polled"]
+#[allow(missing_debug_implementations)]
+pub struct PinnedFut<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> {
+    fn_or_fut: FnOrFut<'any, Data, Output, F>,
+    // TODO:
+    // marker: Pinned,
+    // Data, which may be borrowed by `fn_or_fut`, must be dropped last
+    data: Data,
+}
+
+enum FnOrFut<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> {
+    F(F),
+    Fut(<F as PinnedFnLt<'any, Data, Output>>::Future),
+    None,
+}
+
+impl<'any, Data: 'any, Output, F: PinnedFn<Data, Output> + 'any> FnOrFut<'any, Data, Output, F> {
+    fn is_fn(&self) -> bool {
+        if let FnOrFut::F(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Creates a new future which pins some data and borrows it for an
+/// asynchronous lifetime.
+pub fn pinned<'any, Data, Output, F>(data: Data, f: F) -> PinnedFut<'any, Data, Output, F>
+    where F: PinnedFn<Data, Output> + 'any,
+          Data: 'any,
+{
+    PinnedFut {
+        fn_or_fut: FnOrFut::F(f),
+        data,
+    }
+}
+
+unsafe fn transmute_lt<'input, 'output, T>(x: &'input mut T) -> &'output mut T {
+    ::std::mem::transmute(x)
+}
+
+impl<'any, Data, Output, F> Future for PinnedFut<'any, Data, Output, F>
+    where F: PinnedFn<Data, Output> + 'any,
+          Data: 'any,
+{
+    type Output = <<F as PinnedFnLt<'any, Data, Output>>::Future as Future>::Output;
+
+    fn poll(self: PinMut<Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+        unsafe {
+            let this = PinMut::get_mut(self);
+            if this.fn_or_fut.is_fn() {
+                if let FnOrFut::F(f) = ::std::mem::replace(&mut this.fn_or_fut, FnOrFut::None) {
+                    let fut = f.apply(PinMut::new_unchecked(transmute_lt(&mut this.data)));
+                    this.fn_or_fut = FnOrFut::Fut(fut);
+                } else {
+                    unreachable!()
+                }
+            }
+
+            let res = if let FnOrFut::Fut(fut) = &mut this.fn_or_fut { 
+                PinMut::new_unchecked(fut).poll(cx)
+            } else {
+                panic!("polled PinnedFut after completion")
+            };
+
+            if let Poll::Ready(_) = &res {
+                this.fn_or_fut = FnOrFut::None;
+            }
+
+            res
+        }
+    }
+}
+
+#[allow(unused)]
+fn does_compile() -> impl Future<Output = u8> {
+    pinned(5, |x: PinMut<_>| { // This type annotation is *required* to compile
+        ::future::lazy(move |_cx| {
+            // we can use (copy from) the asynchronously borrowed data here
+            *x
+        })
+    })
+}


### PR DESCRIPTION
This is a preliminary attempt at a massively unsafe manual self-borrowing future to allow working with borrowing `futures` combinators without relying on `async`/`await`. I'm uncomfortable about the number of different crazy hacks happening here-- hopefully we can whittle those down. Ideally this wouldn't be replaced entirely by async/await someday, at which point we can remove this, but it could allow moving stable code over to the new borrowing versions of e.g. `Stream::next` and `AsyncRead::read`.

I'm not even sure that this is possible to express correctly in Rust's surface syntax, since the `Self` type contains a value as well as a live field with a live `&mut` inside of it. `UnsafeCell` isn't enough here, and I don't know what is. Perhaps it's enough to know that we never create an `&mut` reference to `self.data` while `self.fn_or_fut` holds a future containing a reference to `self.data`? I wouldn't have thought so, but I don't know what to do otherwise. cc @Zoxc and @alexcrichton, who know how self-referential generators are implemented-- do they rely on special magic for this? cc also @ralfjung, primarily so they're aware of the crazy pinning shenanigans happening here.