### PR TITLE
Add `Stream::select2` to support short-circuited select

### DIFF
--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -20,3 +20,22 @@ fn select() {
     select_and_compare(vec![1, 2, 3], vec![4, 5], vec![1, 4, 2, 5, 3]);
     select_and_compare(vec![1, 2], vec![4, 5, 6], vec![1, 4, 2, 5, 6]);
 }
+
+#[test]
+fn select2() {
+    fn select_and_compare(a: Vec<u32>, b: Vec<u32>, short_circuit: bool, expected: Vec<u32>) {
+        let a = stream::iter(a);
+        let b = stream::iter(b);
+        let vec = block_on(a.select2(b, short_circuit).collect::<Vec<_>>());
+        assert_eq!(vec, expected);
+    }
+
+    select_and_compare(vec![1, 2, 3], vec![4, 5, 6], false, vec![1, 4, 2, 5, 3, 6]);
+    select_and_compare(vec![1, 2, 3], vec![4, 5], false, vec![1, 4, 2, 5, 3]);
+    select_and_compare(vec![1, 2], vec![4, 5, 6], false, vec![1, 4, 2, 5, 6]);
+
+    select_and_compare(vec![1, 2, 3], vec![4, 5, 6], true, vec![1, 4, 2, 5, 3, 6]);
+    select_and_compare(vec![1, 2, 3], vec![4, 5], true, vec![1, 4, 2, 5, 3]);
+    // `a` completes first and `b` is short-circuited
+    select_and_compare(vec![1, 2], vec![4, 5, 6], true, vec![1, 4, 2, 5]);
+}


### PR DESCRIPTION
As discussed in https://github.com/websockets-rs/rust-websocket/issues/136

Often, we have two streams combined by `select`:
1. the steam we care about, e.g. a steam of network events, as in the case of websocket connection.
2. an auxiliary stream, e.g. stream of timeouts or as in the discussion above, a stream of user inputs.

The stream of network events will complete when there is a network failure or something else, but the auxiliary stream often never completes. 

When network steam completes, some actions should be take, such as a retry. But because the combined stream doesn't complete, we have no means to know whether the network steam have completed.

With the added `Stream::select2` and `short_circuit` being `true`, the returned stream completes when one of the two input stream completes, which is suitable for situations like this.
