### PR TITLE
Remove #[allow(clippy::new_ret_no_self)]

### DIFF
--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -81,7 +81,6 @@ unsafe impl<T: Send> Send for Queue<T> { }
 unsafe impl<T: Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
-    #[allow(clippy::new_ret_no_self)]
     unsafe fn new(v: Option<T>) -> *mut Node<T> {
         Box::into_raw(Box::new(Node {
             next: AtomicPtr::new(ptr::null_mut()),

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -72,7 +72,6 @@ impl ThreadPool {
     /// See documentation for the methods in
     /// [`ThreadPoolBuilder`](ThreadPoolBuilder) for details on the default
     /// configuration.
-    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Result<ThreadPool, io::Error> {
         ThreadPoolBuilder::new().create()
     }

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -59,7 +59,6 @@ impl<T> BiLock<T> {
     /// will only be available through `Pin<&mut T>` (not `&mut T`) unless `T` is `Unpin`.
     /// Similarly, reuniting the lock and extracting the inner value is only
     /// possible when `T` is `Unpin`.
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(t: T) -> (BiLock<T>, BiLock<T>) {
         let arc = Arc::new(Inner {
             state: AtomicUsize::new(0),


### PR DESCRIPTION
It was fixed in rust-lang/rust-clippy#3338.