### PR TITLE
Park trait, ParkThread implementation and using it in LocalPool

### DIFF
--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -73,3 +73,8 @@ pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 mod enter;
 #[cfg(feature = "std")]
 pub use crate::enter::{Enter, EnterError, enter};
+
+#[cfg(feature = "std")]
+mod park;
+#[cfg(feature = "std")]
+pub use crate::park::{Park, ParkDuration, ParkPoll};

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -55,7 +55,9 @@ extern crate std;
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
-pub use crate::local_pool::{BlockingStream, LocalPool, LocalSpawner, block_on, block_on_stream};
+pub use crate::local_pool::{
+    BlockingStream, LocalPool, LocalPoolGen, LocalSpawner, block_on, block_on_stream,
+};
 
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -78,3 +78,8 @@ pub use crate::enter::{Enter, EnterError, enter};
 mod park;
 #[cfg(feature = "std")]
 pub use crate::park::{Park, ParkDuration, ParkPoll};
+
+#[cfg(feature = "std")]
+mod park_thread;
+#[cfg(feature = "std")]
+pub use crate::park_thread::ParkThread;

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -1,273 +1,35 @@
 use alloc::{
     rc::{Rc, Weak},
-    sync::Arc,
     vec::Vec,
 };
 use core::{
     cell::RefCell,
     ops::{Deref, DerefMut},
     pin::pin,
-    sync::atomic::{AtomicBool, Ordering},
 };
-use std::thread::{self, Thread};
 
 use futures_core::{
     future::Future,
     stream::Stream,
     task::{Context, Poll},
 };
-use futures_task::{ArcWake, FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, waker_ref};
+use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
 use futures_util::stream::{FuturesUnordered, StreamExt};
 
-use crate::enter;
+use crate::{
+    Enter, enter,
+    park::{Park, ParkDuration, ParkPoll},
+    park_thread::ParkThread,
+};
 
-/// A single-threaded task pool for polling futures to completion.
-///
-/// This executor allows you to multiplex any number of tasks onto a single
-/// thread. It's appropriate to poll strictly I/O-bound futures that do very
-/// little work in between I/O actions.
-///
-/// To get a handle to the pool that implements [`Spawn`], use the
-/// [`spawner()`](LocalPool::spawner) method. Because the executor is
-/// single-threaded, it supports a special form of task spawning for non-`Send`
-/// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
+// state outside park
 #[derive(Debug)]
-pub struct LocalPool {
+struct State {
     pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
     incoming: Rc<Incoming>,
 }
 
-/// A handle to a [`LocalPool`] that implements [`Spawn`].
-#[derive(Clone, Debug)]
-pub struct LocalSpawner {
-    incoming: Weak<Incoming>,
-}
-
-type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
-
-pub(crate) struct ThreadNotify {
-    /// The (single) executor thread.
-    thread: Thread,
-    /// A flag to ensure a wakeup (i.e. `unpark()`) is not "forgotten"
-    /// before the next `park()`, which may otherwise happen if the code
-    /// being executed as part of the future(s) being polled makes use of
-    /// park / unpark calls of its own, i.e. we cannot assume that no other
-    /// code uses park / unpark on the executing `thread`.
-    unparked: AtomicBool,
-}
-
-std::thread_local! {
-    static CURRENT_THREAD_NOTIFY: Arc<ThreadNotify> = Arc::new(ThreadNotify {
-        thread: thread::current(),
-        unparked: AtomicBool::new(false),
-    });
-}
-
-impl ArcWake for ThreadNotify {
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        // Make sure the wakeup is remembered until the next `park()`.
-        let unparked = arc_self.unparked.swap(true, Ordering::Release);
-        if !unparked {
-            // If the thread has not been unparked yet, it must be done
-            // now. If it was actually parked, it will run again,
-            // otherwise the token made available by `unpark`
-            // may be consumed before reaching `park()`, but `unparked`
-            // ensures it is not forgotten.
-            arc_self.thread.unpark();
-        }
-    }
-}
-
-// Set up and run a basic single-threaded spawner loop, invoking `f` on each
-// turn.
-fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(mut f: F) -> T {
-    let _enter = enter().expect(
-        "cannot execute `LocalPool` executor from within \
-         another executor",
-    );
-
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
-        let waker = waker_ref(thread_notify);
-        let mut cx = Context::from_waker(&waker);
-        loop {
-            if let Poll::Ready(t) = f(&mut cx) {
-                return t;
-            }
-
-            // Wait for a wakeup.
-            while !thread_notify.unparked.swap(false, Ordering::Acquire) {
-                // No wakeup occurred. It may occur now, right before parking,
-                // but in that case the token made available by `unpark()`
-                // is guaranteed to still be available and `park()` is a no-op.
-                thread::park();
-            }
-        }
-    })
-}
-
-/// Check for a wakeup, but don't consume it.
-fn woken() -> bool {
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| thread_notify.unparked.load(Ordering::Acquire))
-}
-
-impl LocalPool {
-    /// Create a new, empty pool of tasks.
-    pub fn new() -> Self {
-        Self { pool: FuturesUnordered::new(), incoming: Default::default() }
-    }
-
-    /// Get a clonable handle to the pool as a [`Spawn`].
-    pub fn spawner(&self) -> LocalSpawner {
-        LocalSpawner { incoming: Rc::downgrade(&self.incoming) }
-    }
-
-    /// Run all tasks in the pool to completion.
-    ///
-    /// ```
-    /// use futures::executor::LocalPool;
-    ///
-    /// let mut pool = LocalPool::new();
-    ///
-    /// // ... spawn some initial tasks using `spawn.spawn()` or `spawn.spawn_local()`
-    ///
-    /// // run *all* tasks in the pool to completion, including any newly-spawned ones.
-    /// pool.run();
-    /// ```
-    ///
-    /// The function will block the calling thread until *all* tasks in the pool
-    /// are complete, including any spawned while running existing tasks.
-    pub fn run(&mut self) {
-        run_executor(|cx| self.poll_pool(cx))
-    }
-
-    /// Runs all the tasks in the pool until the given future completes.
-    ///
-    /// ```
-    /// use futures::executor::LocalPool;
-    ///
-    /// let mut pool = LocalPool::new();
-    /// # let my_app  = async {};
-    ///
-    /// // run tasks in the pool until `my_app` completes
-    /// pool.run_until(my_app);
-    /// ```
-    ///
-    /// The function will block the calling thread *only* until the future `f`
-    /// completes; there may still be incomplete tasks in the pool, which will
-    /// be inert after the call completes, but can continue with further use of
-    /// one of the pool's run or poll methods. While the function is running,
-    /// however, all tasks in the pool will try to make progress.
-    pub fn run_until<F: Future>(&mut self, future: F) -> F::Output {
-        let mut future = pin!(future);
-
-        run_executor(|cx| {
-            {
-                // if our main task is done, so are we
-                let result = future.as_mut().poll(cx);
-                if let Poll::Ready(output) = result {
-                    return Poll::Ready(output);
-                }
-            }
-
-            let _ = self.poll_pool(cx);
-            Poll::Pending
-        })
-    }
-
-    /// Runs all tasks and returns after completing one future or until no more progress
-    /// can be made. Returns `true` if one future was completed, `false` otherwise.
-    ///
-    /// ```
-    /// use futures::executor::LocalPool;
-    /// use futures::task::LocalSpawnExt;
-    /// use futures::future::{ready, pending};
-    ///
-    /// let mut pool = LocalPool::new();
-    /// let spawner = pool.spawner();
-    ///
-    /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(pending()).unwrap();
-    ///
-    /// // Run the two ready tasks and return true for them.
-    /// pool.try_run_one(); // returns true after completing one of the ready futures
-    /// pool.try_run_one(); // returns true after completing the other ready future
-    ///
-    /// // the remaining task can not be completed
-    /// assert!(!pool.try_run_one()); // returns false
-    /// ```
-    ///
-    /// This function will not block the calling thread and will return the moment
-    /// that there are no tasks left for which progress can be made or after exactly one
-    /// task was completed; Remaining incomplete tasks in the pool can continue with
-    /// further use of one of the pool's run or poll methods.
-    /// Though only one task will be completed, progress may be made on multiple tasks.
-    pub fn try_run_one(&mut self) -> bool {
-        run_executor(|cx| {
-            loop {
-                self.drain_incoming();
-
-                match self.pool.poll_next_unpin(cx) {
-                    // Success!
-                    Poll::Ready(Some(())) => return Poll::Ready(true),
-                    // The pool was empty.
-                    Poll::Ready(None) => return Poll::Ready(false),
-                    Poll::Pending => (),
-                }
-
-                if !self.incoming.borrow().is_empty() {
-                    // New tasks were spawned; try again.
-                    continue;
-                } else if woken() {
-                    // The pool yielded to us, but there's more progress to be made.
-                    return Poll::Pending;
-                } else {
-                    return Poll::Ready(false);
-                }
-            }
-        })
-    }
-
-    /// Runs all tasks in the pool and returns if no more progress can be made
-    /// on any task.
-    ///
-    /// ```
-    /// use futures::executor::LocalPool;
-    /// use futures::task::LocalSpawnExt;
-    /// use futures::future::{ready, pending};
-    ///
-    /// let mut pool = LocalPool::new();
-    /// let spawner = pool.spawner();
-    ///
-    /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(ready(())).unwrap();
-    /// spawner.spawn_local(pending()).unwrap();
-    ///
-    /// // Runs the two ready task and returns.
-    /// // The empty task remains in the pool.
-    /// pool.run_until_stalled();
-    /// ```
-    ///
-    /// This function will not block the calling thread and will return the moment
-    /// that there are no tasks left for which progress can be made;
-    /// remaining incomplete tasks in the pool can continue with further use of one
-    /// of the pool's run or poll methods. While the function is running, all tasks
-    /// in the pool will try to make progress.
-    pub fn run_until_stalled(&mut self) {
-        run_executor(|cx| match self.poll_pool(cx) {
-            // The pool is empty.
-            Poll::Ready(()) => Poll::Ready(()),
-            Poll::Pending => {
-                if woken() {
-                    Poll::Pending
-                } else {
-                    // We're stalled for now.
-                    Poll::Ready(())
-                }
-            }
-        });
-    }
-
+impl State {
     /// Poll `self.pool`, re-filling it with any newly-spawned tasks.
     /// Repeat until either the pool is empty, or it returns `Pending`.
     ///
@@ -301,11 +63,292 @@ impl LocalPool {
             self.pool.push(task)
         }
     }
+
+    /// Runs all tasks and returns after completing one future or until no more progress
+    /// can be made. Returns `Ready` if one future was completed, `Pending` otherwise.
+    fn poll_pool_one(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        loop {
+            self.drain_incoming();
+
+            match self.pool.poll_next_unpin(cx) {
+                // Success!
+                Poll::Ready(Some(())) => return Poll::Ready(()),
+                // The pool was empty.
+                Poll::Ready(None) => return Poll::Pending,
+                Poll::Pending => (),
+            }
+
+            if !self.incoming.borrow().is_empty() {
+                // New tasks were spawned; try again.
+                continue;
+            } else {
+                // No more progress for now (but caller should check cx)
+                return Poll::Pending;
+            }
+        }
+    }
 }
 
-impl Default for LocalPool {
+/// A generic single-threaded task pool for polling futures to completion.
+///
+/// This executor allows you to multiplex any number of tasks onto a single
+/// thread. It's appropriate to poll strictly I/O-bound futures that do very
+/// little work in between I/O actions.
+///
+/// To get a handle to the pool that implements [`Spawn`], use the
+/// [`spawner()`](LocalPoolGen::spawner) method. Because the executor is
+/// single-threaded, it supports a special form of task spawning for non-`Send`
+/// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
+#[derive(Debug)]
+pub struct LocalPoolGen<P> {
+    park: P,
+    state: State,
+}
+
+/// A single-threaded task pool for polling futures to completion.
+///
+/// See [`LocalPoolGen`].
+pub type LocalPool = LocalPoolGen<ParkThread>;
+
+/// A handle to a [`LocalPoolGen`] that implements [`Spawn`].
+#[derive(Clone, Debug)]
+pub struct LocalSpawner {
+    incoming: Weak<Incoming>,
+}
+
+type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
+
+fn local_pool_enter() -> Enter {
+    enter().expect("cannot execute `LocalPool` executor from within another executor")
+}
+
+// Set up and run a basic task / park loop, polling `f` on each
+// turn until it completes and parking between.
+fn run_executor<P: Park, T, F: FnMut(&mut Context<'_>) -> Poll<T>>(park: &mut P, mut f: F) -> T {
+    let mut enter = local_pool_enter();
+
+    loop {
+        let waker = park.waker();
+        let mut cx = Context::from_waker(&waker);
+
+        if let Poll::Ready(t) = f(&mut cx) {
+            return t;
+        }
+        park.park(&mut enter, ParkDuration::Block);
+    }
+}
+
+impl<P> LocalPoolGen<P>
+where
+    P: Park,
+{
+    /// Create a new, empty pool of tasks.
+    pub fn new() -> Self
+    where
+        P: Default,
+    {
+        Self::new_with_park(P::default())
+    }
+
+    /// Create a new, empty pool of tasks.
+    pub fn new_with_park(park: P) -> Self {
+        Self { park, state: State { pool: FuturesUnordered::new(), incoming: Default::default() } }
+    }
+
+    /// Returns a reference to the underlying Park instance.
+    pub fn get_park(&self) -> &P {
+        &self.park
+    }
+
+    /// Returns a mutable reference to the underlying Park instance.
+    pub fn get_park_mut(&mut self) -> &mut P {
+        &mut self.park
+    }
+
+    /// Get a clonable handle to the pool as a [`Spawn`].
+    pub fn spawner(&self) -> LocalSpawner {
+        LocalSpawner { incoming: Rc::downgrade(&self.state.incoming) }
+    }
+
+    /// Run all tasks in the pool to completion.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    ///
+    /// let mut pool = LocalPool::new();
+    ///
+    /// // ... spawn some initial tasks using `spawn.spawn()` or `spawn.spawn_local()`
+    ///
+    /// // run *all* tasks in the pool to completion, including any newly-spawned ones.
+    /// pool.run();
+    /// ```
+    ///
+    /// The function will block the calling thread until *all* tasks in the pool
+    /// are complete, including any spawned while running existing tasks.
+    pub fn run(&mut self) {
+        let park = &mut self.park;
+        let state = &mut self.state;
+        run_executor(park, |cx| state.poll_pool(cx))
+    }
+
+    /// Runs all the tasks in the pool until the given future completes.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    ///
+    /// let mut pool = LocalPool::new();
+    /// # let my_app  = async {};
+    ///
+    /// // run tasks in the pool until `my_app` completes
+    /// pool.run_until(my_app);
+    /// ```
+    ///
+    /// The function will block the calling thread *only* until the future `f`
+    /// completes; there may still be incomplete tasks in the pool, which will
+    /// be inert after the call completes, but can continue with further use of
+    /// one of the pool's run or poll methods. While the function is running,
+    /// however, all tasks in the pool will try to make progress.
+    pub fn run_until<F: Future>(&mut self, future: F) -> F::Output {
+        let mut future = pin!(future);
+        let park = &mut self.park;
+        let state = &mut self.state;
+
+        run_executor(park, |cx| {
+            // if our main task is done, so are we
+            let result = future.as_mut().poll(cx);
+            if let Poll::Ready(output) = result {
+                return Poll::Ready(output);
+            }
+
+            let _ = state.poll_pool(cx);
+            Poll::Pending
+        })
+    }
+}
+
+impl<P> LocalPoolGen<P>
+where
+    P: ParkPoll,
+{
+    /// Runs all tasks and returns after completing one future or until no more progress
+    /// can be made. Returns `true` if one future was completed, `false` otherwise.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    /// use futures::task::LocalSpawnExt;
+    /// use futures::future::{ready, pending};
+    ///
+    /// let mut pool = LocalPool::new();
+    /// let spawner = pool.spawner();
+    ///
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
+    ///
+    /// // Run the two ready tasks and return true for them.
+    /// pool.try_run_one(); // returns true after completing one of the ready futures
+    /// pool.try_run_one(); // returns true after completing the other ready future
+    ///
+    /// // the remaining task can not be completed
+    /// assert!(!pool.try_run_one()); // returns false
+    /// ```
+    ///
+    /// This function will not block the calling thread and will return the moment
+    /// that there are no tasks left for which progress can be made or after exactly one
+    /// task was completed; Remaining incomplete tasks in the pool can continue with
+    /// further use of one of the pool's run or poll methods.
+    /// Though only one task will be completed, progress may be made on multiple tasks.
+    pub fn try_run_one(&mut self) -> bool {
+        let mut enter = local_pool_enter();
+
+        loop {
+            let waker = self.park.waker();
+            let mut cx = Context::from_waker(&waker);
+
+            // progress as much as needed to finish single task
+            if let Poll::Ready(()) = self.state.poll_pool_one(&mut cx) {
+                // finished single task
+                return true;
+            }
+            if self.park.poll(&mut enter).is_pending() {
+                // can't make more progress; park() would block now.
+                return false;
+            }
+        }
+    }
+
+    /// Runs all tasks in the pool and returns if no more progress can be made
+    /// on any task.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    /// use futures::task::LocalSpawnExt;
+    /// use futures::future::{ready, pending};
+    ///
+    /// let mut pool = LocalPool::new();
+    /// let spawner = pool.spawner();
+    ///
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
+    ///
+    /// // Runs the two ready task and returns.
+    /// // The empty task remains in the pool.
+    /// pool.run_until_stalled();
+    /// ```
+    ///
+    /// This function will not block the calling thread and will return the moment
+    /// that there are no tasks left for which progress can be made;
+    /// remaining incomplete tasks in the pool can continue with further use of one
+    /// of the pool's run or poll methods. While the function is running, all tasks
+    /// in the pool will try to make progress.
+    pub fn run_until_stalled(&mut self) {
+        let mut enter = local_pool_enter();
+
+        loop {
+            if self.poll(&mut enter).is_pending() {
+                // can't make more progress; park() would block now.
+                return;
+            }
+        }
+    }
+}
+
+impl<P: Park + Default> Default for LocalPoolGen<P> {
     fn default() -> Self {
-        Self::new()
+        Self::new_with_park(P::default())
+    }
+}
+
+impl<P: Park> Park for LocalPoolGen<P> {
+    fn waker(&self) -> futures_task::WakerRef<'_> {
+        self.park.waker()
+    }
+
+    fn park(&mut self, enter: &mut crate::Enter, duration: ParkDuration) {
+        let waker = self.park.waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // make as much progress as possible; if this "completes" (`Ready`)
+        // the task pool is empty, if it just yielded it will have triggered
+        // the waker.
+        let _ = self.state.poll_pool(&mut cx);
+
+        self.park.park(enter, duration);
+    }
+}
+
+impl<P: ParkPoll> ParkPoll for LocalPoolGen<P> {
+    fn poll(&mut self, enter: &mut Enter) -> Poll<()> {
+        let waker = self.park.waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // make as much progress as possible; if this "completes" (`Ready`)
+        // the task pool is empty, if it just yielded it will have triggered
+        // the waker.
+        let _ = self.state.poll_pool(&mut cx);
+
+        self.park.poll(enter)
     }
 }
 
@@ -313,10 +356,10 @@ impl Default for LocalPool {
 ///
 /// This function will block the caller until the given future has completed.
 ///
-/// Use a [`LocalPool`] if you need finer-grained control over spawned tasks.
+/// Use a [`LocalPoolGen`] if you need finer-grained control over spawned tasks.
 pub fn block_on<F: Future>(f: F) -> F::Output {
     let mut f = pin!(f);
-    run_executor(|cx| f.as_mut().poll(cx))
+    run_executor(&mut ParkThread::new(), |cx| f.as_mut().poll(cx))
 }
 
 /// Turn a stream into a blocking iterator.

--- a/futures-executor/src/park.rs
+++ b/futures-executor/src/park.rs
@@ -1,0 +1,154 @@
+use core::{task::Poll, time::Duration};
+
+use futures_util::task::WakerRef;
+
+use crate::enter::Enter;
+
+/// Determines how long [`Park::park`] will block
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+pub enum ParkDuration {
+    /// Don't block at all
+    Poll,
+    /// Block at most for given [`Duration`]; might get rounded up to some
+    /// minimum "sleepable" value by [`Park`] implementation if timeout is
+    /// too small (including zero).
+    Timeout(Duration),
+    /// Block until explicit (possibly spurious) unpark
+    Block,
+}
+
+impl ParkDuration {
+    /// Create a new duration specification which doesn't block longer
+    /// than the passed limit.
+    pub fn limit(self, max_duration: Duration) -> Self {
+        core::cmp::min(self, ParkDuration::Timeout(max_duration))
+    }
+}
+
+/// Convert zero duration to [`ParkDuration::Poll`]; other durations are
+/// wrapped in [`ParkDuration::Timeout`].
+impl From<Duration> for ParkDuration {
+    fn from(duration: Duration) -> Self {
+        if duration == Duration::from_secs(0) {
+            ParkDuration::Poll
+        } else {
+            ParkDuration::Timeout(duration)
+        }
+    }
+}
+
+/// Convert [`None`] to [`ParkDuration::Block`], zero durations to
+/// [`ParkDuration::Poll`] and other durations are wrapped in
+/// [`ParkDuration::Timeout`].
+impl From<Option<Duration>> for ParkDuration {
+    fn from(duration: Option<Duration>) -> Self {
+        match duration {
+            Some(duration) => ParkDuration::from(duration),
+            None => ParkDuration::Block,
+        }
+    }
+}
+
+/// Block the current thread until some event occured.
+///
+/// The basic idea is that a `Park` implementation sleeps until the
+/// waker is triggered; but before it sleeps it could also check
+/// IO events and limit the duration to the next timeout event.
+///
+/// A timer handling `Park` implementation could forward the actual
+/// parking to a nested `Park` member (which could be either an IO
+/// event handler or a simple thread sleep).
+///
+/// Each `Park` instance should have an internal "woken" flag; it
+/// is set when `Park::waker().wake()` (or similar) is called, and
+/// reset when [`Park::park`] returns.
+pub trait Park {
+    /// Get the [`Waker`] associated with this [`Park`] instance.
+    ///
+    /// Waking this must interrupt a pending `park` call or prevent
+    /// the next `park` call from blocking.
+    ///
+    /// [`Waker`]: std::task::Waker
+    fn waker(&self) -> WakerRef<'_>;
+
+    /// Block the current thread unless "woken"; `duration` determines
+    /// for how long.
+    ///
+    /// A call to `park` does not guarantee that the thread will remain
+    /// blocked forever (even when the waker isn't triggered), and
+    /// callers should be prepared for this possibility. This function
+    /// may wakeup spuriously for any reason.
+    ///
+    /// # Panics
+    ///
+    /// This function **should** not panic, but ultimately, panics are
+    /// left as an implementation detail. Refer to the documentation for
+    /// the specific [Park] implementation.
+    ///
+    fn park(&mut self, enter: &mut Enter, duration: ParkDuration);
+}
+
+/// Non-blocking poll for [Park]
+///
+/// Used for [`LocalPool::try_run_one`] and
+/// [`LocalPool::run_until_stalled`]; those are not really useful, as
+/// you can only poll them in a busy loop - there is no interface to
+/// register another [`Waker`] to be triggered once progress could be
+/// made.
+///
+/// [`LocalPool::try_run_one`]: super::LocalPool::try_run_one
+/// [`LocalPool::run_until_stalled`]: super::LocalPool::run_until_stalled
+/// [`Waker`]: std::task::Waker
+pub trait ParkPoll: Park {
+    /// Similar to calling [`Park::park(ParkDuration::Poll)`][Park::park].
+    ///
+    /// # Return value
+    ///
+    /// Similar to [`Park::park`] this resets the "woken" flag.
+    ///
+    /// Returns [`Poll::Ready`] when the "woken" flag was set,
+    /// otherwise return [`Poll::Pending`].
+    ///
+    /// The "woken" flag might be set by some internal additional
+    /// handling (e.g. checking if a timer fired) before it gets reset;
+    /// this too should result in [`Poll::Ready`].
+    ///
+    /// A [`Poll::Pending`] result indicates that there currently is
+    /// nothing more to do, while [`Poll::Ready`] indicates that some
+    /// task should be able to make progress.
+    fn poll(&mut self, enter: &mut Enter) -> Poll<()>;
+}
+
+impl<P: Park> Park for &'_ mut P {
+    fn waker(&self) -> WakerRef<'_> {
+        (**self).waker()
+    }
+
+    fn park(&mut self, enter: &mut Enter, duration: ParkDuration) {
+        (**self).park(enter, duration)
+    }
+}
+
+impl<P: ParkPoll> ParkPoll for &'_ mut P {
+    fn poll(&mut self, enter: &mut Enter) -> Poll<()> {
+        (**self).poll(enter)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use super::ParkDuration;
+
+    #[test]
+    fn duration_order() {
+        assert!(ParkDuration::Poll < ParkDuration::Block);
+        assert!(ParkDuration::Poll < ParkDuration::Timeout(Duration::from_millis(100)));
+        assert!(
+            ParkDuration::Timeout(Duration::from_millis(100))
+                < ParkDuration::Timeout(Duration::from_millis(200))
+        );
+        assert!(ParkDuration::Timeout(Duration::from_millis(200)) < ParkDuration::Block);
+    }
+}

--- a/futures-executor/src/park_thread.rs
+++ b/futures-executor/src/park_thread.rs
@@ -1,0 +1,97 @@
+use alloc::sync::Arc;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::Poll,
+};
+use std::thread;
+
+use futures_util::task::{ArcWake, WakerRef, waker_ref};
+
+use crate::{
+    enter::Enter,
+    park::{Park, ParkDuration, ParkPoll},
+};
+
+/// Implements [Park] using [thread::park] to put the thread to sleep.
+#[derive(Debug)]
+pub struct ParkThread {
+    // store a copy of TLS data here so `waker()` below can return a
+    // reference to it
+    notify: Arc<ThreadNotify>,
+}
+
+impl ParkThread {
+    /// Create new `ParkThread` instance.
+    pub fn new() -> Self {
+        ParkThread { notify: CURRENT_THREAD_NOTIFY.with(Arc::clone) }
+    }
+}
+
+impl Default for ParkThread {
+    fn default() -> Self {
+        ParkThread::new()
+    }
+}
+
+impl Park for ParkThread {
+    fn waker(&self) -> WakerRef<'_> {
+        waker_ref(&self.notify)
+    }
+
+    fn park(&mut self, enter: &mut Enter, duration: ParkDuration) {
+        // Wait for (and reset if it happend) a wakeup.
+        if !self.poll(enter).is_ready() {
+            // No wakeup occurred. It may occur now, right before parking,
+            // but in that case the token made available by `unpark()`
+            // is guaranteed to still be available and `park()` is a no-op.
+            match duration {
+                ParkDuration::Poll => (),
+                ParkDuration::Block => thread::park(),
+                ParkDuration::Timeout(duration) => thread::park_timeout(duration),
+            }
+        }
+    }
+}
+
+impl ParkPoll for ParkThread {
+    fn poll(&mut self, _enter: &mut Enter) -> Poll<()> {
+        let unparked = CURRENT_THREAD_NOTIFY
+            .with(|thread_notify| thread_notify.unparked.swap(false, Ordering::Acquire));
+
+        if unparked { Poll::Ready(()) } else { Poll::Pending }
+    }
+}
+
+std::thread_local! {
+    static CURRENT_THREAD_NOTIFY: Arc<ThreadNotify> = Arc::new(ThreadNotify {
+        thread: thread::current(),
+        unparked: AtomicBool::new(false),
+    });
+}
+
+#[derive(Debug)]
+struct ThreadNotify {
+    /// The (single) executor thread.
+    thread: thread::Thread,
+    /// A flag to ensure a wakeup (i.e. `unpark()`) is not "forgotten"
+    /// before the next `park()`, which may otherwise happen if the code
+    /// being executed as part of the future(s) being polled makes use of
+    /// park / unpark calls of its own, i.e. we cannot assume that no other
+    /// code uses park / unpark on the executing `thread`.
+    unparked: AtomicBool,
+}
+
+impl ArcWake for ThreadNotify {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        // Make sure the wakeup is remembered until the next `park()`.
+        let unparked = arc_self.unparked.swap(true, Ordering::Release);
+        if !unparked {
+            // If the thread has not been unparked yet, it must be done
+            // now. If it was actually parked, it will run again,
+            // otherwise the token made available by `unpark`
+            // may be consumed before reaching `park()`, but `unparked`
+            // ensures it is not forgotten.
+            arc_self.thread.unpark();
+        }
+    }
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -181,8 +181,8 @@ pub mod executor {
     //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
     pub use futures_executor::{
-        BlockingStream, Enter, EnterError, LocalPool, LocalSpawner, block_on, block_on_stream,
-        enter,
+        BlockingStream, Enter, EnterError, LocalPool, LocalPoolGen, LocalSpawner, block_on,
+        block_on_stream, enter,
     };
     #[cfg(feature = "thread-pool")]
     #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]


### PR DESCRIPTION
Hi,

I think it would be good to have a `Park` abstration (like the one in tokio) in `futures-executor` (this has already been proposed and merged in #665 for the tokio-reform branch, which has been abonded in #645).

In #665 `Park` was renamed to `Sleep`, but I think `Park` is the better choice:
- `std` lib provides [`thread::park`](https://doc.rust-lang.org/std/thread/fn.park.html) for a sleeping mechanism that can be cancelled ("unparked").
- tokio users already know it by that name
- it is not just a "sleep" mechanism due to the "wakeup" part

Apart from the names `Sleep` from #665 is basically the same as tokio `Park`; further changes to the API (compared to tokio):
- merge `Park::park_timeout` into `Park::park`, now taking a `ParkDuration` enum: most implementations I've seen used shared code anyway.
- `Park::park` now also includes a `&mut Enter` argument
- Removed `Unpark` trait, `Park` no longer has an associated `Unpark` type.  Using `futures_util::task::WakerRef` instead for the result of the `waker` function (renamed from `unpark`).

I think reusing the `Waker` abstraction is rather obvious; but there are probably two open questions:
- Use `Waker` instead of `WakerRef`?
- Remove `ParkDuration::Poll` and interpret a zero duration in `ParkDuration::Duration(..)` as "poll only but don't yield"?

This pull request also contains a `ParkThread` implementation of `Park` (based on `std::thread::park` and similar to what `LocalPool` was using) and supports using `LocalPool` with custom `Park` implentations (defaulting to `ParkThread`).  This way `LocalPool` can be combined into a "local-thread runtime" with a timer and a reactor.

References:
- [`tokio_executor::park`](https://docs.rs/tokio-executor/0.1.7/tokio_executor/park/index.html)
- [`std::thread::park`](https://doc.rust-lang.org/std/thread/fn.park.html)
