### PR TITLE
Add SharedSpawn.

### DIFF
--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -4,7 +4,7 @@
 mod poll;
 
 mod spawn;
-pub use self::spawn::{Spawn, LocalSpawn, SpawnError};
+pub use self::spawn::{Spawn, SharedSpawn, LocalSpawn, SharedLocalSpawn, SpawnError};
 
 #[doc(hidden)]
 pub mod __internal;

--- a/futures-core/src/task/spawn.rs
+++ b/futures-core/src/task/spawn.rs
@@ -27,6 +27,26 @@ pub trait Spawn {
     }
 }
 
+/// The `SharedSpawn` trait allows for pushing futures onto an executor that will
+/// run them to completion.
+///
+/// # Relationship with `Spawn`
+///
+/// `SharedSpawn` accepts `&self`, whereas `Spawn` accepts `&mut self`.
+/// Therefore `SharedSpawn` can be shared between multiple entities.
+pub trait SharedSpawn: Spawn {
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn shared_spawn_obj(&self, future: FutureObj<'static, ()>)
+        -> Result<(), SpawnError>;
+}
+
 /// The `LocalSpawn` is similar to [`Spawn`], but allows spawning futures
 /// that don't implement `Send`.
 pub trait LocalSpawn {
@@ -51,6 +71,20 @@ pub trait LocalSpawn {
     fn status_local(&self) -> Result<(), SpawnError> {
         Ok(())
     }
+}
+/// The `SharedLocalSpawn` is similar to [`SharedSpawn`], but allows spawning futures
+/// that don't implement `Send`.
+pub trait SharedLocalSpawn: LocalSpawn {
+    /// Spawns a future that will be run to completion.
+    ///
+    /// # Errors
+    ///
+    /// The executor may be unable to spawn tasks. Spawn errors should
+    /// represent relatively rare scenarios, such as the executor
+    /// having been shut down so that it is no longer able to accept
+    /// tasks.
+    fn shared_spawn_local_obj(&self, future: LocalFutureObj<'static, ()>)
+        -> Result<(), SpawnError>;
 }
 
 /// An error that occurred during spawning.
@@ -98,6 +132,31 @@ impl<Sp: ?Sized + Spawn> Spawn for &mut Sp {
     }
 }
 
+impl<Sp: ?Sized + SharedSpawn> SharedSpawn for &mut Sp {
+    fn shared_spawn_obj(&self, future: FutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_obj(self, future)
+    }
+}
+
+impl<Sp: ?Sized + SharedSpawn> Spawn for &Sp {
+    fn spawn_obj(&mut self, future: FutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_obj(self, future)
+    }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        Sp::status(self)
+    }
+}
+
+impl<Sp: ?Sized + SharedSpawn> SharedSpawn for &Sp {
+    fn shared_spawn_obj(&self, future: FutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_obj(self, future)
+    }
+}
+
 impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
     fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>)
     -> Result<(), SpawnError> {
@@ -106,6 +165,31 @@ impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
 
     fn status_local(&self) -> Result<(), SpawnError> {
         Sp::status_local(self)
+    }
+}
+
+impl<Sp: ?Sized + SharedLocalSpawn> SharedLocalSpawn for &mut Sp {
+    fn shared_spawn_local_obj(&self, future: LocalFutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_local_obj(self, future)
+    }
+}
+
+impl<Sp: ?Sized + SharedLocalSpawn> LocalSpawn for &Sp {
+    fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_local_obj(self, future)
+    }
+
+    fn status_local(&self) -> Result<(), SpawnError> {
+        Sp::status_local(self)
+    }
+}
+
+impl<Sp: ?Sized + SharedLocalSpawn> SharedLocalSpawn for &Sp {
+    fn shared_spawn_local_obj(&self, future: LocalFutureObj<'static, ()>)
+    -> Result<(), SpawnError> {
+        Sp::shared_spawn_local_obj(self, future)
     }
 }
 
@@ -125,6 +209,13 @@ mod if_alloc {
         }
     }
 
+    impl<Sp: ?Sized + SharedSpawn> SharedSpawn for Box<Sp> {
+        fn shared_spawn_obj(&self, future: FutureObj<'static, ()>)
+        -> Result<(), SpawnError> {
+            (**self).shared_spawn_obj(future)
+        }
+    }
+
     impl<Sp: ?Sized + LocalSpawn> LocalSpawn for Box<Sp> {
         fn spawn_local_obj(&mut self, future: LocalFutureObj<'static, ()>)
         -> Result<(), SpawnError> {
@@ -133,6 +224,13 @@ mod if_alloc {
 
         fn status_local(&self) -> Result<(), SpawnError> {
             (**self).status_local()
+        }
+    }
+
+    impl<Sp: ?Sized + SharedLocalSpawn> SharedLocalSpawn for Box<Sp> {
+        fn shared_spawn_local_obj(&self, future: LocalFutureObj<'static, ()>)
+        -> Result<(), SpawnError> {
+            (**self).shared_spawn_local_obj(future)
         }
     }
 }

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -1,7 +1,7 @@
 use crate::enter;
 use crate::unpark_mutex::UnparkMutex;
 use futures_core::future::{Future, FutureObj};
-use futures_core::task::{Context, Poll, Spawn, SpawnError};
+use futures_core::task::{Context, Poll, Spawn, SharedSpawn, SpawnError};
 use futures_util::future::FutureExt;
 use futures_util::task::{ArcWake, waker_ref};
 use std::io;
@@ -145,9 +145,9 @@ impl Spawn for ThreadPool {
     }
 }
 
-impl Spawn for &ThreadPool {
-    fn spawn_obj(
-        &mut self,
+impl SharedSpawn for ThreadPool {
+    fn shared_spawn_obj(
+        &self,
         future: FutureObj<'static, ()>,
     ) -> Result<(), SpawnError> {
         self.spawn_obj_ok(future);


### PR DESCRIPTION
As a solution to #1669. It's sometimes convenient to have something like `Arc<dyn Spawn>` but `Spawn` isn't useful in this case because it accepts `&mut self`. I propose to have `SharedSpawn`/`Spawn` pair which work like the well-known `Fn`/`FnMut` pair.