### PR TITLE
Remote completion

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -297,6 +297,37 @@ impl<T> Inner<T> {
         }
     }
 
+    fn poll_complete(&self, cx: &mut Context<'_>) -> Poll<()> {
+        // Check to see if some data has arrived. If it hasn't then we need to
+        // block our task.
+        //
+        // Note that the acquisition of the `rx_task` lock might fail below, but
+        // the only situation where this can happen is during `Sender::drop`
+        // when we are indeed completed already. If that's happening then we
+        // know we're completed so keep going.
+        let done = if self.complete.load(SeqCst) {
+            true
+        } else {
+            let task = cx.waker().clone();
+            match self.rx_task.try_lock() {
+                Some(mut slot) => {
+                    *slot = Some(task);
+                    false
+                }
+                None => true,
+            }
+        };
+
+        // If we're `done` via one of the paths above, then we're ready.
+        // If, however, we stored `rx_task` successfully above we need
+        // to check again if we're completed in case a message was sent
+        // while `rx_task` was locked and couldn't notify us otherwise.
+        //
+        // If we're not done, and we're not complete, though, then we've
+        // successfully blocked our task and we return `Pending`.
+        if done || self.complete.load(SeqCst) { Poll::Ready(()) } else { Poll::Pending }
+    }
+
     fn drop_rx(&self) {
         // Indicate to the `Sender` that we're done, so any future calls to
         // `poll_canceled` are weeded out.
@@ -449,6 +480,11 @@ impl<T> Receiver<T> {
     /// Returns an error if the sender was dropped.
     pub fn try_recv(&mut self) -> Result<Option<T>, Canceled> {
         self.inner.try_recv()
+    }
+
+    /// Poll whether result is available, but do not extract result.
+    pub fn poll_complete(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        self.inner.poll_complete(cx)
     }
 }
 

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -109,7 +109,7 @@ mod remote_handle;
 #[cfg(feature = "channel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 #[cfg(feature = "std")]
-pub use self::remote_handle::{Remote, RemoteHandle};
+pub use self::remote_handle::{Remote, RemoteCompletionHandle, RemoteHandle};
 
 #[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 mod shared;

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -66,6 +66,15 @@ impl<T> RemoteHandle<T> {
         self.rx.poll_complete(cx)
     }
 
+    /// Create a future only polling for completion without returning the result
+    ///
+    /// Use [`try_recv`] to extract final result after completion is ready.
+    ///
+    /// [`try_recv`]: [RemoteHandle::try_recv]
+    pub fn completion_handle(&mut self) -> RemoteCompletionHandle<'_> {
+        RemoteCompletionHandle { remote_handle: self }
+    }
+
     /// Try to extract final result
     ///
     /// Returns `None` if underlying future is still running.
@@ -83,6 +92,38 @@ impl<T: 'static> Future for RemoteHandle<T> {
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
         Poll::Ready(unwrap_result(ready!(self.rx.poll_unpin(cx))))
+    }
+}
+
+trait Completion {
+    fn poll_unpin(&mut self, cx: &mut Context<'_>) -> Poll<()>;
+}
+
+impl<T> Completion for RemoteHandle<T> {
+    fn poll_unpin(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        Pin::new(self).poll_complete(cx)
+    }
+}
+
+/// A completion handle for a [RemoteHandle]
+///
+/// Only waits for completion, but doesn't return the actual result.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct RemoteCompletionHandle<'a> {
+    remote_handle: &'a mut dyn Completion,
+}
+
+impl fmt::Debug for RemoteCompletionHandle<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("RemoteCompletionHandle").finish()
+    }
+}
+
+impl Future for RemoteCompletionHandle<'_> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.remote_handle.poll_unpin(cx)
     }
 }
 

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -8,7 +8,7 @@ use core::{
 };
 use std::{panic, thread};
 
-use futures_channel::oneshot::{self, Receiver, Sender};
+use futures_channel::oneshot::{self, Canceled, Receiver, Sender};
 use futures_core::{
     future::Future,
     ready,
@@ -17,6 +17,16 @@ use futures_core::{
 use pin_project_lite::pin_project;
 
 use crate::future::{CatchUnwind, FutureExt};
+
+fn unwrap_result<T>(result: Result<thread::Result<T>, Canceled>) -> T {
+    match result {
+        Ok(Ok(output)) => output,
+        // the remote future panicked.
+        Ok(Err(e)) => panic::resume_unwind(e),
+        // The oneshot sender was dropped.
+        Err(e) => panic::resume_unwind(Box::new(e)),
+    }
+}
 
 /// The handle to a remote future returned by
 /// [`remote_handle`](crate::future::FutureExt::remote_handle). When you drop this,
@@ -50,19 +60,29 @@ impl<T> RemoteHandle<T> {
     pub fn forget(self) {
         self.keep_running.store(true, Ordering::SeqCst);
     }
+
+    /// Poll whether result is available, but do not extract result.
+    pub fn poll_complete(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        self.rx.poll_complete(cx)
+    }
+
+    /// Try to extract final result
+    ///
+    /// Returns `None` if underlying future is still running.
+    ///
+    /// # Panics
+    ///
+    /// Panics in the same way as polling [RemoteHandle].
+    pub fn try_recv(&mut self) -> Option<T> {
+        Some(unwrap_result(self.rx.try_recv().transpose()?))
+    }
 }
 
 impl<T: 'static> Future for RemoteHandle<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        match ready!(self.rx.poll_unpin(cx)) {
-            Ok(Ok(output)) => Poll::Ready(output),
-            // the remote future panicked.
-            Ok(Err(e)) => panic::resume_unwind(e),
-            // The oneshot sender was dropped.
-            Err(e) => panic::resume_unwind(Box::new(e)),
-        }
+        Poll::Ready(unwrap_result(ready!(self.rx.poll_unpin(cx))))
     }
 }
 

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -30,7 +30,7 @@ pub use self::future::{
 #[cfg(feature = "channel")]
 #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 #[cfg(feature = "std")]
-pub use self::future::{Remote, RemoteHandle};
+pub use self::future::{Remote, RemoteCompletionHandle, RemoteHandle};
 #[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 pub use self::future::{Shared, WeakShared};
 


### PR DESCRIPTION
Allow polling remote handles (and oneshot channels) for "completion", i.e. when the result is available (`poll_ready` is used for "ready to send", so I used `poll_complete` - open to other suggestions), and to extract results without async context.

Add `RemoteCompletionHandle<'_>` to poll only for completion without extracting the result: can be passed to trait (object) methods as the underlying result type is erased (would be useful in https://github.com/rustasync/runtime/pull/73).