### PR TITLE
Improve location of Option wrappers in Map/Chain

### DIFF
--- a/futures-util/src/future/map.rs
+++ b/futures-util/src/future/map.rs
@@ -1,4 +1,6 @@
+use core::mem;
 use core::pin::Pin;
+use core::ptr;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -7,17 +9,56 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Map<Fut, F> {
+    inner : Option<Inner<Fut, F>>,
+}
+
+#[derive(Debug)]
+struct Inner<Fut, F> {
     future: Fut,
-    f: Option<F>,
+    f: F,
+}
+
+struct UnsafeSetNoneOnDrop<T>(*mut Option<T>);
+
+impl<T> Drop for UnsafeSetNoneOnDrop<T> {
+    fn drop(&mut self) {
+        unsafe {
+            ptr::write(self.0, None);
+        }
+    }
+}
+
+impl<Fut, F> Inner<Fut, F> {
+    unsafe_pinned!(future: Fut);
+    unsafe_unpinned!(f: F);
+
+    /// Extracts the map function while dropping the future without violating
+    /// the Pin guarantee like a simple Option::take would
+    fn take_f(me: Pin<&mut Option<Inner<Fut, F>>>) -> Option<F> {
+        unsafe {
+            let opt = me.get_unchecked_mut();
+            let opt_ptr : *mut Option<Inner<Fut, F>> = opt;
+            match opt {
+                None => None,
+                Some(Inner { future, f }) => {
+                    // clean up invalid state if future::drop() panics
+                    let auto_take = UnsafeSetNoneOnDrop(opt_ptr);
+                    ptr::drop_in_place(future);
+                    let rv = ptr::read(f);
+                    mem::drop(auto_take);
+                    Some(rv)
+                }
+            }
+        }
+    }
 }
 
 impl<Fut, F> Map<Fut, F> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(f: Option<F>);
+    unsafe_pinned!(inner: Option<Inner<Fut, F>>);
 
     /// Creates a new Map.
     pub(super) fn new(future: Fut, f: F) -> Map<Fut, F> {
-        Map { future, f: Some(f) }
+        Map { inner : Some(Inner { future, f }) }
     }
 }
 
@@ -27,7 +68,7 @@ impl<Fut, F, T> FusedFuture for Map<Fut, F>
     where Fut: Future,
           F: FnOnce(Fut::Output) -> T,
 {
-    fn is_terminated(&self) -> bool { self.f.is_none() }
+    fn is_terminated(&self) -> bool { self.inner.is_none() }
 }
 
 impl<Fut, F, T> Future for Map<Fut, F>
@@ -36,14 +77,15 @@ impl<Fut, F, T> Future for Map<Fut, F>
 {
     type Output = T;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        self.as_mut()
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        let mut inner = self.inner();
+        let output = ready!(inner
+            .as_mut()
+            .as_pin_mut()
+            .expect("Map must not be polled after it returned `Poll::Ready`")
             .future()
-            .poll(cx)
-            .map(|output| {
-                let f = self.f().take()
-                    .expect("Map must not be polled after it returned `Poll::Ready`");
-                f(output)
-            })
+            .poll(cx));
+        let f = Inner::take_f(inner).unwrap();
+        Poll::Ready(f(output))
     }
 }


### PR DESCRIPTION
If the closure for Map or data for Chain is zero-size, this will avoid
expanding the size of the resulting Future as long as rustc can find a
usable hole in the original future.