### PR TITLE
Allow async-await macros to be used without std

### DIFF
--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -31,8 +31,10 @@ mod select_mod;
 #[cfg(feature = "async-await-macro")]
 pub use self::select_mod::*;
 
+#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 mod random;
+#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 pub use self::random::*;
 

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -306,6 +306,7 @@ macro_rules! document_select_macro {
 }
 
 document_select_macro! {
+    #[cfg(feature = "std")]
     #[proc_macro_hack(support_nested)]
     pub use futures_macro::select;
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -39,12 +39,10 @@ pub use futures_core::ready;
 pub use pin_utils::pin_mut;
 
 // Not public API.
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 #[macro_use]
 #[doc(hidden)]
 pub mod async_await;
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub use self::async_await::*;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -542,23 +542,21 @@ pub mod never {
 pub use futures_core::core_reexport;
 
 // Not public API.
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub use futures_util::async_await;
 
 // Not public API.
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod inner_macro {
     pub use futures_util::join;
     pub use futures_util::try_join;
+    #[cfg(feature = "std")]
     pub use futures_util::select;
     pub use futures_util::select_biased;
 }
 
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 futures_util::document_join_macro! {
     #[macro_export]
@@ -582,9 +580,9 @@ futures_util::document_join_macro! {
     }
 }
 
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 futures_util::document_select_macro! {
+    #[cfg(feature = "std")]
     #[macro_export]
     macro_rules! select { // replace `::futures_util` with `::futures` as the crate path
         ($($tokens:tt)*) => {


### PR DESCRIPTION
`select!()` is the only macro that requires std due to implementation details, so allow everything else through.