### PR TITLE
Document AsyncWrite

### DIFF
--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -133,7 +133,7 @@ mod if_std {
     /// This trait is analogous to the `std::io::Write` trait, but integrates
     /// with the asynchronous task system. In particular, the `poll_write`
     /// method, unlike `Write::write`, will automatically queue the current task
-    /// for wakeup and return if data is not yet available, rather than blocking
+    /// for wakeup and return if the writer cannot take more data, rather than blocking
     /// the calling thread.
     pub trait AsyncWrite {
         /// Attempt to write bytes from `buf` into the object.

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -208,6 +208,8 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
+        ///
+        /// It only makes sense to do anything here if you actually buffer data.
         fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
 
         /// Attempt to close the object.

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -151,6 +151,9 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
+        ///
+        /// `poll_write` must try to make progress by flushing the underlying object if
+        /// that is the only way the underlying object can become writable again.
         fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
             -> Poll<Result<usize>>;
 


### PR DESCRIPTION
When implementing `AsyncWrite` I found it unclear what behavior is expected from a type that implements it. The main question is when to flush the underlying object.

This PR is intended to settle on that issue and then document it to avoid confusion for further users. It follows up from #1828. Some further discussion is required to come to a conclusion before documenting.

## Explanation

Imagine we implement `AsyncWrite` on some type that does some internal buffering. Eg. this type will have data hanging in transit unless we call `poll_flush` on it. 

The questions occurred when using `AsyncReadExt::copy_buf_into` to create an echo server that just forwards all incoming data back out. The future returned by this method will only flush the `AsyncWrite` when the stream has completely ended. Until then, it will only call `poll_write`. So if some data comes in, then there is a pause, this data will now just sit in the writer without getting flushed out. 

The question is thus, should implementers sometimes flush in `poll_write` or not? If so, which context to pass to `poll_flush`? If any bytes have been written, `poll_write` needs to return `Poll::Ready(n)`, so a Pending from the `poll_flush` cannot be bubbled up unless no bytes where written...