### PR TITLE
Iteration policy API for eager polling loops

### DIFF
--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -26,7 +26,7 @@ pub trait LoopPolicy {
 /// an asynchronous source is pending or the poll resolves with an output
 /// value).
 #[derive(Debug)]
-pub struct Unlimited {}
+pub struct Unlimited;
 
 impl LoopPolicy for Unlimited {
     type State = ();

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -1,6 +1,5 @@
 //! Utilities for implementing iterative polling in a cooperative way.
 
-use core::mem;
 use core::num::NonZeroU32;
 
 /// Iteration policy checker for eager polling loops.
@@ -16,92 +15,7 @@ pub trait Policy {
     /// and decide whether the poll function should yield, that is,
     /// wake up the task and return
     /// [`Pending`](core::task::poll::Poll::Pending).
-    fn yield_check(&self, state: &mut Self::State) -> bool;
-
-    /// Called when the loop ends before `self` has returned true from
-    /// its [`yield_check`] method.
-    /// `state` refers to the loop check state as created by [`begin`]
-    /// and modified by `yield_check` over the iterations of the loop.
-    /// Note that another iteration has been partially executed since the
-    /// last call to `yield_check` when this method is called.
-    ///
-    /// [`begin`]: Policy::begin
-    /// [`yield_check`]: Policy::yield_check
-    ///
-    /// The default implementation of this method does nothing.
-    /// Some advanced `Policy` implementations may use this method to collect
-    /// statistics or implement adaptive behaviors.
-    #[allow(unused_variables)]
-    fn when_ended_early(&mut self, state: &mut Self::State) {}
-
-    /// Called immediately after `self` has returned true from its
-    /// [`yield_check`] method, before returning from the poll function.
-    /// `state` refers to the loop check state as it is left by the call
-    /// to `yield_check`.
-    ///
-    /// [`begin`]: Policy::begin
-    /// [`yield_check`]: Policy::yield_check
-    ///
-    /// The default implementation of this method does nothing.
-    /// Some advanced `Policy` implementations may use this method to collect
-    /// statistics or implement adaptive behaviors.
-    #[allow(unused_variables)]
-    fn when_yielded(&mut self, state: &mut Self::State) {}
-}
-
-/// A RAII guard around [`Policy`] and its state created to check iterations
-/// of a polling loop.
-///
-/// This type is used by the [`poll_loop!`] macro, so the programmer of a
-/// polling loop does not need to use it directly.
-#[derive(Debug)]
-pub struct LoopGuard<'a, P>
-where
-    P: ?Sized + Policy,
-{
-    policy: &'a mut P,
-    state: P::State,
-}
-
-impl<'a, P> LoopGuard<'a, P>
-where
-    P: ?Sized + Policy,
-{
-    /// Wraps a lifetime-scoped guard around a reference to the policy
-    /// checker object and initializes the iteration check state.
-    pub fn new(policy: &'a mut P) -> Self {
-        let state = policy.begin();
-        LoopGuard { policy, state }
-    }
-
-    /// Calls the [`yield_check`](Policy::yield_check) method on the wrapped
-    /// [`Policy`] reference with its internal state object.
-    pub fn yield_check(&mut self) -> bool {
-        self.policy.yield_check(&mut self.state)
-    }
-
-    /// Called immediately after [`yield_check`](Policy::yield_check)
-    /// has returned `true`, to call [`when_yielded`](Policy::when_yielded)
-    /// on the wrapped [`Policy`] reference with its internal state object.
-    /// The normal destructor of `LoopGuard` is then bypassed.
-    pub fn process_yield(mut self) {
-        self.policy.when_yielded(&mut self.state);
-        mem::forget(self);
-    }
-}
-
-impl<P> Drop for LoopGuard<'_, P>
-where
-    P: ?Sized + Policy,
-{
-    /// Calls [`when_ended_early`] on the wrapped [`Policy`] reference
-    /// with its internal state object.
-    ///
-    /// [`Policy`]: crate::iteration::Policy
-    /// [`when_ended_early`]: crate::iteration::Policy::when_ended_early
-    fn drop(&mut self) {
-        self.policy.when_ended_early(&mut self.state);
-    }
+    fn yield_check(&mut self, state: &mut Self::State) -> bool;
 }
 
 /// An unlimited iteration policy.
@@ -121,7 +35,7 @@ impl Policy for Unlimited {
     fn begin(&mut self) {}
 
     #[inline]
-    fn yield_check(&self, _: &mut ()) -> bool {
+    fn yield_check(&mut self, _: &mut ()) -> bool {
         false
     }
 }
@@ -151,7 +65,7 @@ impl Policy for Limit {
     }
 
     #[inline]
-    fn yield_check(&self, counter: &mut u32) -> bool {
+    fn yield_check(&mut self, counter: &mut u32) -> bool {
         *counter -= 1;
         *counter == 0
     }

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -92,8 +92,11 @@ impl<P> Drop for LoopGuard<'_, P>
 where
     P: ?Sized + Policy,
 {
-    /// Calls [`when_ended_early`](Policy::when_ended_early)
-    /// on the wrapped [`Policy`] reference with its internal state object.
+    /// Calls [`when_ended_early`] on the wrapped [`Policy`] reference
+    /// with its internal state object.
+    ///
+    /// [`Policy`]: crate::iteration::Policy
+    /// [`when_ended_early`]: crate::iteration::Policy::when_ended_early
     fn drop(&mut self) {
         self.policy.when_ended_early(&mut self.state);
     }
@@ -104,7 +107,7 @@ where
 /// The [`Policy`] implementation for a value of this token type bypasses
 /// any checking on iterations of a polling loop, allowing it to continue
 /// indefinitely until ended by logic in the loop body (normally when
-/// an asyncrhonous source is pending or the poll resolves with a return
+/// an asynchronous source is pending or the poll resolves with an output
 /// value).
 #[derive(Debug)]
 pub struct Unlimited {}

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -31,7 +31,8 @@ pub trait Policy {
     /// The default implementation of this method does nothing.
     /// Some advanced `Policy` implementations may use this method to collect
     /// statistics or implement adaptive behaviors.
-    fn when_ended_early(&mut self, #[allow(unused_variables)] state: &mut Self::State) {}
+    #[allow(unused_variables)]
+    fn when_ended_early(&mut self, state: &mut Self::State) {}
 
     /// Called immediately after `self` has returned true from its
     /// [`yield_check`] method, before returning from the poll function.
@@ -44,7 +45,8 @@ pub trait Policy {
     /// The default implementation of this method does nothing.
     /// Some advanced `Policy` implementations may use this method to collect
     /// statistics or implement adaptive behaviors.
-    fn when_yielded(&mut self, #[allow(unused_variables)] state: &mut Self::State) {}
+    #[allow(unused_variables)]
+    fn when_yielded(&mut self, state: &mut Self::State) {}
 }
 
 /// A RAII guard around [`Policy`] and its state created to check iterations

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -1,20 +1,125 @@
-//! Helpers for cooperative polling behavior.
+//! Utilities to implement iterative polling in a cooperative way.
+//!
+//! This module provides trait [`Policy`] and its implementations that can
+//! be used to tune behavior of eager polling loops in a polymorphic way.
+//!
+//! An object implementing `Policy` is used by the [`poll_loop!`] macro,
+//! normally as a member of a future, stream, or sink object that runs a
+//! loop in its polling function that can potentially be saturated
+//! by asynchronous sources readily providing data for
+//! many consecutive iterations.
 
+use core::mem;
 use core::num::NonZeroU32;
 
+/// Iteration policy checker for eager polling loops.
 pub trait Policy {
-    type Guard;
+    /// State for checking iterations over the lifetime of a polling loop.
+    type State;
 
-    fn begin(&mut self) -> Self::Guard;
+    /// Called before entering the loop to initialize state for
+    /// iteration checks.
+    fn begin(&mut self) -> Self::State;
 
-    fn yield_check(&self, guard: &mut Self::Guard) -> bool;
+    /// Called at the end of each iteration to update the check state
+    /// and decide whether the poll function should yield, that is,
+    /// wake up the task and return
+    /// [`Pending`](core::task::poll::Poll::Pending).
+    fn yield_check(&self, state: &mut Self::State) -> bool;
+
+    /// Called when the loop ends before `self` has returned true from
+    /// its [`yield_check`] method.
+    /// `state` refers to the loop check state as created by [`begin`]
+    /// and modified by `yield_check` over the iterations of the loop.
+    /// Note that another iteration has been partially executed since the
+    /// last call to `yield_check` when this method is called.
+    ///
+    /// [`begin`]: Policy::begin
+    /// [`yield_check`]: Policy::yield_check
+    ///
+    /// The default implementation of this method does nothing.
+    /// Some advanced `Policy` implementations may use this method to collect
+    /// statistics or implement adaptive behaviors.
+    fn when_ended_early(&mut self, #[allow(unused_variables)] state: &mut Self::State) {}
+
+    /// Called immediately after `self` has returned true from its
+    /// [`yield_check`] method, before returning from the poll function.
+    /// `state` refers to the loop check state as it is left by the call
+    /// to `yield_check`.
+    ///
+    /// [`begin`]: Policy::begin
+    /// [`yield_check`]: Policy::yield_check
+    ///
+    /// The default implementation of this method does nothing.
+    /// Some advanced `Policy` implementations may use this method to collect
+    /// statistics or implement adaptive behaviors.
+    fn when_yielded(&mut self, #[allow(unused_variables)] state: &mut Self::State) {}
 }
 
+/// A RAII guard around [`Policy`] and its state created to check iterations
+/// of a polling loop.
+///
+/// This type is used by the [`poll_loop!`] macro, so the programmer of a
+/// polling loop does not need to use it directly.
+#[derive(Debug)]
+pub struct LoopGuard<'a, P>
+where
+    P: ?Sized + Policy,
+{
+    policy: &'a mut P,
+    state: P::State,
+}
+
+impl<'a, P> LoopGuard<'a, P>
+where
+    P: ?Sized + Policy,
+{
+    /// Wraps a lifetime-scoped guard around a reference to the policy
+    /// checker object and initializes the iteration check state.
+    pub fn new(policy: &'a mut P) -> Self {
+        let state = policy.begin();
+        LoopGuard { policy, state }
+    }
+
+    /// Calls the [`yield_check`](Policy::yield_check) method on the wrapped
+    /// [`Policy`] reference with its internal state object.
+    pub fn yield_check(&mut self) -> bool {
+        self.policy.yield_check(&mut self.state)
+    }
+
+    /// Called immediately after [`yield_check`](Policy::yield_check)
+    /// has returned `true`, to call [`when_yielded`](Policy::when_yielded)
+    /// on the wrapped [`Policy`] reference with its internal state object.
+    /// The normal destructor of `LoopGuard` is then bypassed.
+    pub fn process_yield(mut self) {
+        self.policy.when_yielded(&mut self.state);
+        mem::forget(self);
+    }
+}
+
+impl<P> Drop for LoopGuard<'_, P>
+where
+    P: ?Sized + Policy,
+{
+    /// Calls [`when_ended_early`](Policy::when_ended_early)
+    /// on the wrapped [`Policy`] reference with its internal state object.
+    fn drop(&mut self) {
+        self.policy.when_ended_early(&mut self.state);
+    }
+}
+
+/// An unlimited iteration policy.
+///
+/// The [`Policy`] implementation for a value of this token type bypasses
+/// any checking on iterations of a polling loop, allowing it to continue
+/// indefinitely until ended by logic in the loop body (normally when
+/// an asyncrhonous source is pending or the poll resolves with a return
+/// value).
 #[derive(Debug)]
 pub struct Unlimited {}
 
 impl Policy for Unlimited {
-    type Guard = ();
+    type State = ();
 
     #[inline]
     fn begin(&mut self) {}
@@ -25,10 +130,16 @@ impl Policy for Unlimited {
     }
 }
 
+/// An iteration policy with a limit on the number of consecutive iterations.
+///
+/// The [`Policy`] implementation of this type runs a counter on the number
+/// of iterations and, when the given limit is reached, instructs the
+/// [`yield_check`](Policy::yield_check) caller to yield.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Limit(NonZeroU32);
 
 impl Limit {
+    /// Creates a policy checker instance with the given limit.
     #[inline]
     pub const fn new(value: NonZeroU32) -> Self {
         Limit(value)
@@ -36,7 +147,7 @@ impl Limit {
 }
 
 impl Policy for Limit {
-    type Guard = u32;
+    type State = u32;
 
     #[inline]
     fn begin(&mut self) -> u32 {
@@ -47,30 +158,5 @@ impl Policy for Limit {
     fn yield_check(&self, counter: &mut u32) -> bool {
         *counter -= 1;
         *counter == 0
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    struct StatefulPolicy {
-        limit: Option<u32>,
-    }
-
-    impl Policy for StatefulPolicy {
-        type Guard = u32;
-
-        fn begin(&mut self) -> u32 {
-            0
-        }
-
-        fn yield_check(&self, guard: &mut u32) -> bool {
-            *guard = guard.wrapping_add(1);
-            match self.limit {
-                None => false,
-                Some(limit) => *guard >= limit,
-            }
-        }
     }
 }

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -1,0 +1,82 @@
+//! Helpers for cooperative polling behavior.
+
+use core::num::NonZeroU32;
+
+pub trait Policy {
+    type Guard;
+
+    fn begin(&mut self) -> Self::Guard;
+
+    fn yield_check(&self, guard: &mut Self::Guard) -> bool;
+}
+
+#[derive(Debug)]
+pub struct Unlimited {}
+
+impl Policy for Unlimited {
+    type Guard = ();
+
+    #[inline]
+    fn begin(&mut self) {}
+
+    #[inline]
+    fn yield_check(&self, _: &mut ()) -> bool {
+        false
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Limit(NonZeroU32);
+
+impl Limit {
+    #[inline]
+    pub const fn new(value: NonZeroU32) -> Self {
+        Limit(value)
+    }
+}
+
+impl Policy for Limit {
+    type Guard = u32;
+
+    #[inline]
+    fn begin(&mut self) -> u32 {
+        self.0.into()
+    }
+
+    #[inline]
+    fn yield_check(&self, counter: &mut u32) -> bool {
+        match counter.checked_sub(1) {
+            Some(v) => {
+                *counter = v;
+                false
+            }
+            #[cold]
+            None => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StatefulPolicy {
+        limit: Option<u32>,
+    }
+
+    impl Policy for StatefulPolicy {
+        type Guard = u32;
+
+        fn begin(&mut self) -> u32 {
+            0
+        }
+
+        fn yield_check(&self, guard: &mut u32) -> bool {
+            *guard = guard.wrapping_add(1);
+            match self.limit {
+                None => false,
+                Some(limit) => *guard >= limit,
+            }
+        }
+    }
+}

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -4,10 +4,12 @@
 //! be used to tune behavior of eager polling loops in a polymorphic way.
 //!
 //! An object implementing `Policy` is used by the [`poll_loop!`] macro,
-//! normally as a member of a future, stream, or sink object that runs a
-//! loop in its polling function that can potentially be saturated
-//! by asynchronous sources readily providing data for
-//! many consecutive iterations.
+//! normally as a member of a structure implementing an asynchronous
+//! API such as [`Future`] where a polling function runs a loop that
+//! can potentially be saturated by asynchronous sources readily yielding data
+//! for many consecutive iterations.
+//!
+//! [`Future`]: core::future::Future
 
 use core::mem;
 use core::num::NonZeroU32;

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -1,15 +1,4 @@
-//! Utilities to implement iterative polling in a cooperative way.
-//!
-//! This module provides trait [`Policy`] and its implementations that can
-//! be used to tune behavior of eager polling loops in a polymorphic way.
-//!
-//! An object implementing `Policy` is used by the [`poll_loop!`] macro,
-//! normally as a member of a structure implementing an asynchronous
-//! API such as [`Future`] where a polling function runs a loop that
-//! can potentially be saturated by asynchronous sources readily yielding data
-//! for many consecutive iterations.
-//!
-//! [`Future`]: core::future::Future
+//! Utilities for implementing iterative polling in a cooperative way.
 
 use core::mem;
 use core::num::NonZeroU32;

--- a/futures-core/src/iteration.rs
+++ b/futures-core/src/iteration.rs
@@ -45,14 +45,8 @@ impl Policy for Limit {
 
     #[inline]
     fn yield_check(&self, counter: &mut u32) -> bool {
-        match counter.checked_sub(1) {
-            Some(v) => {
-                *counter = v;
-                false
-            }
-            #[cold]
-            None => true,
-        }
+        *counter -= 1;
+        *counter == 0
     }
 }
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -28,6 +28,8 @@ pub mod stream;
 #[macro_use]
 pub mod task;
 
+pub mod iteration;
+
 // Not public API.
 #[doc(hidden)]
 pub mod core_reexport {

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -7,4 +7,3 @@ mod poll;
 pub mod __internal;
 
 pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
-pub use poll::ToYield;

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -7,3 +7,4 @@ mod poll;
 pub mod __internal;
 
 pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use poll::ToYield;

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -9,3 +9,40 @@ macro_rules! ready {
             return $crate::core_reexport::task::Poll::Pending,
     })
 }
+
+/// An eager polling loop with a limit on repetitions.
+///
+/// This macro helps implement eager polling loops in a way that prevents
+/// uncooperative polling behavior. It's typical for such a loop to occur
+/// a [`Future`](core::future::Future) implementation that repeatedly polls
+/// asynchronous event sources, most often a [`Stream`](crate::Stream), to
+/// perform some internal work without resolving the future and resume polling
+/// in the next loop iteration. If the source polls return `Ready` for many
+/// consecutive iterations, such a loop will not break for the whole duration,
+/// potentially starving other asynchronous operations in the same task
+/// from being polled.
+///
+/// To prevent this, `poll_loop!` runs a counter on the number of iterations
+/// to perform before yielding to the task by returning `Pending`, initialized
+/// from the first parameter of the macro. The second parameter receives the
+/// reference to the [`Context`](core::task::Context) passed to the poll
+/// function, and the third parameter is given the body of a loop iteration.
+#[macro_export]
+macro_rules! poll_loop {
+    {$yield_after:expr, $cx:expr, $body:expr} => {
+        {
+            let range = 0..$yield_after;
+            debug_assert!(
+                range.end != 0,
+                "0 used as the repetition limit in a poll loop",
+            );
+            for _ in range {
+                $body
+            }
+
+            #[cold]
+            $crate::core_reexport::task::Context::waker($cx).wake_by_ref();
+            return $crate::core_reexport::task::Poll::Pending;
+        }
+    }
+}

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -31,10 +31,10 @@ macro_rules! ready {
 macro_rules! poll_loop {
     {$yield_after:expr, $cx:expr, $body:expr} => {
         {
-            let mut range = 0u32..(::core::convert::Into::into($yield_after));
+            let mut range = 0u32..$crate::core_reexport::convert::Into::into($yield_after);
             debug_assert!(
                 range.end != 0,
-                "0 used as the repetition limit in a poll loop",
+                "0 used as the iteration limit in a poll loop",
             );
             let _ = loop {
                 if range.next().is_none() {

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -22,36 +22,33 @@ macro_rules! ready {
 /// potentially starving other asynchronous operations in the same task
 /// from being polled.
 ///
-/// To prevent this, `poll_loop!` uses a [`Policy`](crate::iteration::Policy)
-/// guard to check at the beginning of each iteration whether to yield
-/// to the task by returning `Pending`. The first parameter of the macro
-/// receives a mutable reference to the iteration policy checker.
+/// To prevent this, `poll_loop!` uses the [`Policy`](crate::iteration::Policy)
+/// protocol to check at the end of each iteration whether to yield
+/// to the task by returning [`Pending`](core::task::poll::Poll::Pending).
+/// The first parameter of the macro receives a mutable pointer to the
+/// iteration policy checker implementing `Policy`.
 /// The second parameter receives the reference to the
 /// [`Context`](core::task::Context) passed to the poll function.
-/// The third parameter is given the body of a loop iteration.
+/// The body of a loop iteration is given in the third parameter.
+///
+/// Note that a `continue` expression in the loop body has the effect of
+/// bypassing the iteration policy check, so it should be used with caution.
+/// `break` can be used as in the body of an unlabeled `loop`, also for
+/// producing the value of the macro invocation used as an expression.
+/// The loop is immediately terminated by `break` with no hidden effects.
 #[macro_export]
 macro_rules! poll_loop {
     {$policy:expr, $cx:expr, $body:expr} => {
         #[allow(clippy::deref_addrof)]
         {
             let mut guard = $crate::iteration::Policy::begin(&mut *$policy);
-            let _ = loop {
+            loop {
+                { $body }
                 if $crate::iteration::Policy::yield_check(&*$policy, &mut guard) {
-                    break $crate::task::ToYield;
+                    $crate::core_reexport::task::Context::waker($cx).wake_by_ref();
+                    return $crate::core_reexport::task::Poll::Pending;
                 }
-                $body
-            };
-
-            $crate::core_reexport::task::Context::waker($cx).wake_by_ref();
-            return $crate::core_reexport::task::Poll::Pending;
+            }
         }
     }
 }
-
-/// A token type used inside the [`poll_loop!`] macro.
-///
-/// `ToYield` can be used as a value of a `break` expression within an
-/// iteration body given to the `poll_loop!` macro to break out of the loop.
-/// The effect is to yield to the polling task, hence `break ToYield`.
-#[derive(Debug)]
-pub struct ToYield;

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -31,7 +31,7 @@ macro_rules! ready {
 macro_rules! poll_loop {
     {$yield_after:expr, $cx:expr, $body:expr} => {
         {
-            let mut range = 0..$yield_after;
+            let mut range = 0u32..(::core::convert::Into::into($yield_after));
             debug_assert!(
                 range.end != 0,
                 "0 used as the repetition limit in a poll loop",

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -14,37 +14,49 @@ macro_rules! ready {
 ///
 /// This macro helps implement eager polling loops in a way that prevents
 /// uncooperative polling behavior. It's typical for such a loop to occur in
-/// a [`Future`](core::future::Future) implementation that repeatedly polls
-/// asynchronous event sources, most often a [`Stream`](crate::Stream), to
-/// perform some internal work without resolving the future and resume polling
-/// in the next loop iteration. If the source polls return `Ready` for many
-/// consecutive iterations, such a loop will not break for the whole duration,
+/// a [`Future`] implementation that repeatedly polls asynchronous event
+/// sources, most often a [`Stream`], to perform some internal work without
+/// resolving the future and resume polling in the next loop iteration.
+/// If the source polls return [`Ready`] for many consecutive iterations,
+/// such a loop will not break for the whole duration,
 /// potentially starving other asynchronous operations in the same task
 /// from being polled.
 ///
-/// To prevent this, `poll_loop!` uses the [`Policy`](crate::iteration::Policy)
-/// protocol to check at the end of each iteration whether to yield
-/// to the task by returning [`Pending`](core::task::poll::Poll::Pending).
+/// To prevent this, `poll_loop!` uses the [`Policy`] protocol to check
+/// at the end of each iteration whether to yield to the task by returning
+/// [`Pending`].
 /// The first parameter of the macro receives a mutable pointer to the
 /// iteration policy checker implementing `Policy`.
 /// The second parameter receives the reference to the
-/// [`Context`](core::task::Context) passed to the poll function.
+/// [`Context`] passed to the poll function.
 /// The body of a loop iteration is given in the third parameter.
 ///
 /// Note that a `continue` expression in the loop body has the effect of
 /// bypassing the iteration policy check, so it should be used with caution.
 /// `break` can be used as in the body of an unlabeled `loop`, also for
 /// producing the value of the macro invocation used as an expression.
-/// The loop is immediately terminated by `break` with no hidden effects.
+/// The loop is immediately terminated by `break`, and a scoped [`LoopGuard`]
+/// around the `Policy` object is dropped, resulting in a [`when_ended_early`]
+/// method call on the latter.
+///
+/// [`Future`]: core::future::Future
+/// [`Stream`]: stream::Stream
+/// [`Context`]: core::task::Context
+/// [`Pending`]: core::task::Poll::Pending
+/// [`Ready`]: core::task::Poll::Ready
+/// [`LoopGuard`]: iteration::LoopGuard
+/// [`Policy`]: iteration::Policy
+/// [`when_ended_early`]: iteration::Policy::when_ended_early
 #[macro_export]
 macro_rules! poll_loop {
     {$policy:expr, $cx:expr, $body:expr} => {
         #[allow(clippy::deref_addrof)]
         {
-            let mut guard = $crate::iteration::Policy::begin(&mut *$policy);
+            let mut guard = $crate::iteration::LoopGuard::new(&mut *$policy);
             loop {
                 { $body }
-                if $crate::iteration::Policy::yield_check(&*$policy, &mut guard) {
+                if guard.yield_check() {
+                    guard.process_yield();
                     $crate::core_reexport::task::Context::waker($cx).wake_by_ref();
                     return $crate::core_reexport::task::Poll::Pending;
                 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -48,10 +48,6 @@ pub use self::async_await::*;
 #[doc(hidden)]
 pub use futures_core::core_reexport;
 
-// Default for repetition limits on eager polling loops, to prevent
-// stream-consuming combinators like ForEach from starving other tasks.
-const DEFAULT_YIELD_AFTER_LIMIT: u32 = 100;
-
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(
         #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
@@ -121,3 +117,9 @@ cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]
     pub mod lock;
 }
+
+use core::num::NonZeroU32;
+
+// Default for repetition limits on eager polling loops, to prevent
+// stream-consuming combinators like ForEach from starving other tasks.
+const DEFAULT_YIELD_AFTER_LIMIT: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(100) };

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -48,6 +48,11 @@ pub use self::async_await::*;
 #[doc(hidden)]
 pub use futures_core::core_reexport;
 
+#[macro_use]
+mod yield_after;
+
+use yield_after::DEFAULT_YIELD_AFTER_LIMIT;
+
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(
         #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
@@ -117,9 +122,3 @@ cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]
     pub mod lock;
 }
-
-use core::num::NonZeroU32;
-
-// Default for repetition limits on eager polling loops, to prevent
-// stream-consuming combinators like ForEach from starving other tasks.
-const DEFAULT_YIELD_AFTER_LIMIT: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(100) };

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -26,7 +26,7 @@ compile_error!("The `read-initializer` feature requires the `unstable` feature a
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-#[macro_use(ready)]
+#[macro_use(ready, poll_loop)]
 extern crate futures_core;
 
 // Macro re-exports
@@ -47,6 +47,10 @@ pub use self::async_await::*;
 // Not public API.
 #[doc(hidden)]
 pub use futures_core::core_reexport;
+
+// Default for repetition limits on eager polling loops, to prevent
+// stream-consuming combinators like ForEach from starving other tasks.
+const DEFAULT_YIELD_AFTER_LIMIT: u32 = 100;
 
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -50,8 +50,8 @@ where
     St: TryStream<Ok = Ok, Error = Error> + Stream + Unpin + ?Sized,
 {
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and the sink"]
-        #[doc = "the stream consecutively yields items that the sink
+        #[pollee = "the underlying stream and the sink"]
+        #[why_busy = "the stream consecutively yields items that the sink
             is ready to accept,"]
     }
 

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -49,6 +49,12 @@ where
     Si: Sink<Ok, Error = Error> + Unpin + ?Sized,
     St: TryStream<Ok = Ok, Error = Error> + Stream + Unpin + ?Sized,
 {
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and the sink"]
+        #[doc = "the stream consecutively yields items that the sink
+            is ready to accept,"]
+    }
+
     pub(super) fn new(
         sink: &'a mut Si,
         stream: &'a mut St,

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -26,6 +26,8 @@ impl<St: Stream, C: Default> Collect<St, C> {
         mem::replace(self.as_mut().collection(), Default::default())
     }
 
+    future_method_yield_after_every!();
+
     pub(super) fn new(stream: St) -> Collect<St, C> {
         Collect {
             stream,

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -1,7 +1,7 @@
 use core::mem;
-use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
+use futures_core::iteration;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -12,7 +12,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 pub struct Collect<St, C> {
     stream: St,
     collection: C,
-    yield_after: NonZeroU32,
+    yield_after: iteration::Limit,
 }
 
 impl<St: Unpin, C> Unpin for Collect<St, C> {}
@@ -20,7 +20,7 @@ impl<St: Unpin, C> Unpin for Collect<St, C> {}
 impl<St: Stream, C: Default> Collect<St, C> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(collection: C);
-    unsafe_unpinned!(yield_after: NonZeroU32);
+    unsafe_unpinned!(yield_after: iteration::Limit);
 
     fn finish(mut self: Pin<&mut Self>) -> C {
         mem::replace(self.as_mut().collection(), Default::default())
@@ -53,7 +53,7 @@ where St: Stream,
     type Output = C;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<C> {
-        poll_loop! { self.yield_after, cx,
+        poll_loop! { self.as_mut().yield_after(), cx,
             match ready!(self.as_mut().stream().poll_next(cx)) {
                 Some(e) => self.as_mut().collection().extend(Some(e)),
                 None => return Poll::Ready(self.as_mut().finish()),

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -1,4 +1,5 @@
 use core::mem;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
@@ -11,7 +12,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 pub struct Collect<St, C> {
     stream: St,
     collection: C,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin, C> Unpin for Collect<St, C> {}
@@ -19,7 +20,7 @@ impl<St: Unpin, C> Unpin for Collect<St, C> {}
 impl<St: Stream, C: Default> Collect<St, C> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(collection: C);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     fn finish(mut self: Pin<&mut Self>) -> C {
         mem::replace(self.as_mut().collection(), Default::default())

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{Future, FusedFuture};
 use futures_core::stream::{Stream, FusedStream};
@@ -10,7 +11,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 pub struct Concat<St: Stream> {
     stream: St,
     accum: Option<St::Item>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Stream + Unpin> Unpin for Concat<St> {}
@@ -22,7 +23,7 @@ where St: Stream,
 {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(accum: Option<St::Item>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St) -> Concat<St> {
         Concat {

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -25,6 +25,8 @@ where St: Stream,
     unsafe_unpinned!(accum: Option<St::Item>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every!();
+
     pub(super) fn new(stream: St) -> Concat<St> {
         Concat {
             stream,

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -53,6 +53,27 @@ where St: Stream,
     unsafe_unpinned!(pending_item: Option<St::Item>);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
+    fn split_borrows(
+        self: Pin<&mut Self>,
+    ) -> (
+        Pin<&mut St>,
+        &mut F,
+        Pin<&mut Option<Fut>>,
+        &mut Option<St::Item>,
+        &mut iteration::Limit,
+    ) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.f,
+                Pin::new_unchecked(&mut this.pending_fut),
+                &mut this.pending_item,
+                &mut this.yield_after,
+            )
+        }
+    }
+
     pub(super) fn new(stream: St, f: F) -> Filter<St, Fut, F> {
         Filter {
             stream,
@@ -120,24 +141,22 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
 {
     type Item = St::Item;
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<St::Item>> {
-        poll_loop! { self.as_mut().yield_after(), cx, {
-            if self.pending_fut.is_none() {
-                let item = match ready!(self.as_mut().stream().poll_next(cx)) {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
+        let (mut stream, op, mut pending_fut, pending_item, yield_after) = self.split_borrows();
+        poll_loop! { yield_after, cx, {
+            if pending_fut.as_ref().is_none() {
+                let item = match ready!(stream.as_mut().poll_next(cx)) {
                     Some(e) => e,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(&item);
-                self.as_mut().pending_fut().set(Some(fut));
-                *self.as_mut().pending_item() = Some(item);
+                let fut = op(&item);
+                pending_fut.set(Some(fut));
+                *pending_item = Some(item);
             }
 
-            let yield_item = ready!(self.as_mut().pending_fut().as_pin_mut().unwrap().poll(cx));
-            self.as_mut().pending_fut().set(None);
-            let item = self.as_mut().pending_item().take().unwrap();
+            let yield_item = ready!(pending_fut.as_mut().as_pin_mut().unwrap().poll(cx));
+            pending_fut.set(None);
+            let item = pending_item.take().unwrap();
 
             if yield_item {
                 return Poll::Ready(Some(item));

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -16,7 +17,7 @@ pub struct Filter<St, Fut, F>
     f: F,
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for Filter<St, Fut, F>
@@ -50,7 +51,7 @@ where St: Stream,
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Item>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> Filter<St, Fut, F> {
         Filter {

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -94,6 +94,13 @@ where St: Stream,
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by
+            the predicate closure,"]
+        #[doc = "items are consecutively yielded by the stream,
+            but get immediately filtered out,"]
+    }
 }
 
 impl<St, Fut, F> FusedStream for Filter<St, Fut, F>

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -119,9 +119,9 @@ where St: Stream,
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by
-            the predicate closure,"]
-        #[doc = "items are consecutively yielded by the stream,
+        #[pollee = "the underlying stream and, when pending,
+            a future returned by the predicate closure,"]
+        #[why_busy = "items are consecutively yielded by the stream,
             but get immediately filtered out,"]
     }
 }

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -16,6 +16,7 @@ pub struct Filter<St, Fut, F>
     f: F,
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
+    yield_after: u32,
 }
 
 impl<St, Fut, F> Unpin for Filter<St, Fut, F>
@@ -35,6 +36,7 @@ where
             .field("stream", &self.stream)
             .field("pending_fut", &self.pending_fut)
             .field("pending_item", &self.pending_item)
+            .field("yield_after", &self.yield_after)
             .finish()
     }
 }
@@ -48,6 +50,7 @@ where St: Stream,
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Item>);
+    unsafe_unpinned!(yield_after: u32);
 
     pub(super) fn new(stream: St, f: F) -> Filter<St, Fut, F> {
         Filter {
@@ -55,6 +58,7 @@ where St: Stream,
             f,
             pending_fut: None,
             pending_item: None,
+            yield_after: crate::DEFAULT_YIELD_AFTER_LIMIT,
         }
     }
 
@@ -112,7 +116,7 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        loop {
+        poll_loop! { self.yield_after, cx, {
             if self.pending_fut.is_none() {
                 let item = match ready!(self.as_mut().stream().poll_next(cx)) {
                     Some(e) => e,
@@ -130,7 +134,7 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
             if yield_item {
                 return Poll::Ready(Some(item));
             }
-        }
+        }}
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -13,7 +14,7 @@ pub struct FilterMap<St, Fut, F> {
     stream: St,
     f: F,
     pending: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for FilterMap<St, Fut, F>
@@ -44,7 +45,7 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> FilterMap<St, Fut, F> {
         FilterMap {

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -108,8 +108,9 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by the map closure,"]
-        #[doc = "items are consecutively yielded by the stream, but get immediately filtered out,"]
+        #[pollee = "the underlying stream and, when pending, a future returned by the map closure,"]
+        #[why_busy = "items are consecutively yielded by the stream,
+            but get immediately filtered out,"]
     }
 }
 

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -87,6 +87,11 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by the map closure,"]
+        #[doc = "items are consecutively yielded by the stream, but get immediately filtered out,"]
+    }
 }
 
 impl<St, Fut, F, T> FusedStream for FilterMap<St, Fut, F>

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -97,8 +97,8 @@ where
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream or a yet unconsumed stream yielded by it"]
-        #[doc = "the underlying stream keeps yielding streams that immediately poll empty,"]
+        #[pollee = "the underlying stream or a yet unconsumed stream yielded by it"]
+        #[why_busy = "the underlying stream keeps yielding streams that immediately poll empty,"]
     }
 }
 

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -14,7 +15,7 @@ where
 {
     stream: St,
     next: Option<St::Item>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St> Unpin for Flatten<St>
@@ -30,7 +31,7 @@ where
 {
     unsafe_pinned!(stream: St);
     unsafe_pinned!(next: Option<St::Item>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 }
 
 impl<St> Flatten<St>

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -78,6 +78,11 @@ where
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream or a yet unconsumed stream yielded by it"]
+        #[doc = "the underlying stream keeps yielding streams that immediately poll empty,"]
+    }
 }
 
 impl<St> FusedStream for Flatten<St>

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_utils::unsafe_pinned;
+use pin_utils::{unsafe_pinned, unsafe_unpinned};
 
 /// Stream for the [`flatten`](super::StreamExt::flatten) method.
 #[derive(Debug)]
@@ -14,6 +14,7 @@ where
 {
     stream: St,
     next: Option<St::Item>,
+    yield_after: u32,
 }
 
 impl<St> Unpin for Flatten<St>
@@ -29,6 +30,7 @@ where
 {
     unsafe_pinned!(stream: St);
     unsafe_pinned!(next: Option<St::Item>);
+    unsafe_unpinned!(yield_after: u32);
 }
 
 impl<St> Flatten<St>
@@ -37,7 +39,11 @@ where
     St::Item: Stream,
 {
     pub(super) fn new(stream: St) -> Self {
-        Self { stream, next: None }
+        Self {
+            stream,
+            next: None,
+            yield_after: crate::DEFAULT_YIELD_AFTER_LIMIT,
+        }
     }
 
     /// Acquires a reference to the underlying stream that this combinator is
@@ -91,7 +97,7 @@ where
     type Item = <St::Item as Stream>::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        loop {
+        poll_loop! { self.yield_after, cx, {
             if self.next.is_none() {
                 match ready!(self.as_mut().stream().poll_next(cx)) {
                     Some(e) => self.as_mut().next().set(Some(e)),
@@ -104,7 +110,7 @@ where
             } else {
                 self.as_mut().next().set(None);
             }
-        }
+        }}
     }
 }
 

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
@@ -12,7 +13,7 @@ pub struct Fold<St, Fut, T, F> {
     f: F,
     accum: Option<T>,
     future: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin, Fut: Unpin, T, F> Unpin for Fold<St, Fut, T, F> {}
@@ -42,7 +43,7 @@ where St: Stream,
     unsafe_unpinned!(f: F);
     unsafe_unpinned!(accum: Option<T>);
     unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F, t: T) -> Fold<St, Fut, T, F> {
         Fold {

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -67,9 +67,9 @@ where St: Stream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and, if pending, a future returned by
+        #[pollee = "the underlying stream and, if pending, a future returned by
             the accumulation closure,"]
-        #[doc = "the underlying stream consecutively yields items and
+        #[why_busy = "the underlying stream consecutively yields items and
             the accumulation futures immediately resolve as ready,"]
     }
 

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -45,6 +45,13 @@ where St: Stream,
     unsafe_pinned!(future: Option<Fut>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and, if pending, a future returned by
+            the accumulation closure,"]
+        #[doc = "the underlying stream consecutively yields items and
+            the accumulation futures immediately resolve as ready,"]
+    }
+
     pub(super) fn new(stream: St, f: F, t: T) -> Fold<St, Fut, T, F> {
         Fold {
             stream,

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
@@ -11,7 +12,7 @@ pub struct ForEach<St, Fut, F> {
     stream: St,
     f: F,
     future: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for ForEach<St, Fut, F>
@@ -42,7 +43,7 @@ where St: Stream,
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> ForEach<St, Fut, F> {
         ForEach {

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -45,6 +45,13 @@ where St: Stream,
     unsafe_pinned!(future: Option<Fut>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and, if pending, a future returned by
+            the processing closure,"]
+        #[doc = "the underlying stream consecutively yields items and
+            the processing futures immediately resolve as ready,"]
+    }
+
     pub(super) fn new(stream: St, f: F) -> ForEach<St, Fut, F> {
         ForEach {
             stream,

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -65,9 +65,9 @@ where St: Stream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and, if pending, a future returned by
+        #[pollee = "the underlying stream and, if pending, a future returned by
             the processing closure,"]
-        #[doc = "the underlying stream consecutively yields items and
+        #[why_busy = "the underlying stream consecutively yields items and
             the processing futures immediately resolve as ready,"]
     }
 

--- a/futures-util/src/stream/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/stream/for_each_concurrent.rs
@@ -49,6 +49,13 @@ where St: Stream,
     unsafe_unpinned!(limit: Option<NonZeroUsize>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and a pool of pending futures returned by
+            the processing closure,"]
+        #[doc = "the underlying stream consecutively yields items and some of
+            the processing futures turn out ready,"]
+    }
+
     pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> ForEachConcurrent<St, Fut, F> {
         ForEachConcurrent {
             stream: Some(stream),

--- a/futures-util/src/stream/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/stream/for_each_concurrent.rs
@@ -70,9 +70,9 @@ where St: Stream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and a pool of pending futures returned by
+        #[pollee = "the underlying stream and a pool of pending futures returned by
             the processing closure,"]
-        #[doc = "the underlying stream consecutively yields items and some of
+        #[why_busy = "the underlying stream consecutively yields items and some of
             the processing futures turn out ready,"]
     }
 

--- a/futures-util/src/stream/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/stream/for_each_concurrent.rs
@@ -1,7 +1,7 @@
 use crate::stream::{FuturesUnordered, StreamExt};
 use core::fmt;
+use core::num::{NonZeroU32, NonZeroUsize};
 use core::pin::Pin;
-use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
@@ -15,7 +15,7 @@ pub struct ForEachConcurrent<St, Fut, F> {
     f: F,
     futures: FuturesUnordered<Fut>,
     limit: Option<NonZeroUsize>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for ForEachConcurrent<St, Fut, F>
@@ -47,7 +47,7 @@ where St: Stream,
     unsafe_unpinned!(f: F);
     unsafe_unpinned!(futures: FuturesUnordered<Fut>);
     unsafe_unpinned!(limit: Option<NonZeroUsize>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> ForEachConcurrent<St, Fut, F> {
         ForEachConcurrent {

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -51,8 +51,8 @@ where
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and the sink"]
-        #[doc = "the stream consecutively yields items that the sink
+        #[pollee = "the underlying stream and the sink"]
+        #[why_busy = "the stream consecutively yields items that the sink
             is ready to accept,"]
     }
 

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -31,6 +31,12 @@ where
     unsafe_unpinned!(buffered_item: Option<St::Ok>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and the sink"]
+        #[doc = "the stream consecutively yields items that the sink
+            is ready to accept,"]
+    }
+
     pub(super) fn new(stream: St, sink: Si) -> Self {
         Forward {
             sink: Some(sink),

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -1,4 +1,5 @@
 use crate::stream::{StreamExt, Fuse};
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{Stream, TryStream};
@@ -15,7 +16,7 @@ pub struct Forward<St: TryStream, Si> {
     sink: Option<Si>,
     stream: Fuse<St>,
     buffered_item: Option<St::Ok>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: TryStream + Unpin, Si: Unpin> Unpin for Forward<St, Si> {}
@@ -28,7 +29,7 @@ where
     unsafe_pinned!(sink: Option<Si>);
     unsafe_pinned!(stream: Fuse<St>);
     unsafe_unpinned!(buffered_item: Option<St::Ok>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, sink: Si) -> Self {
         Forward {

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -1,7 +1,7 @@
 use core::fmt;
-use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
+use futures_core::iteration;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
@@ -16,7 +16,7 @@ pub struct SkipWhile<St, Fut, F> where St: Stream {
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
     done_skipping: bool,
-    yield_after: NonZeroU32,
+    yield_after: iteration::Limit,
 }
 
 impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for SkipWhile<St, Fut, F> {}
@@ -48,7 +48,7 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Item>);
     unsafe_unpinned!(done_skipping: bool);
-    unsafe_unpinned!(yield_after: NonZeroU32);
+    unsafe_unpinned!(yield_after: iteration::Limit);
 
     pub(super) fn new(stream: St, f: F) -> SkipWhile<St, Fut, F> {
         SkipWhile {
@@ -126,7 +126,7 @@ impl<St, Fut, F> Stream for SkipWhile<St, Fut, F>
             return self.as_mut().stream().poll_next(cx);
         }
 
-        poll_loop! { self.yield_after, cx, {
+        poll_loop! { self.as_mut().yield_after(), cx, {
             if self.pending_item.is_none() {
                 let item = match ready!(self.as_mut().stream().poll_next(cx)) {
                     Some(e) => e,

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
@@ -15,7 +16,7 @@ pub struct SkipWhile<St, Fut, F> where St: Stream {
     pending_fut: Option<Fut>,
     pending_item: Option<St::Item>,
     done_skipping: bool,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin + Stream, Fut: Unpin, F> Unpin for SkipWhile<St, Fut, F> {}
@@ -47,7 +48,7 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Item>);
     unsafe_unpinned!(done_skipping: bool);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> SkipWhile<St, Fut, F> {
         SkipWhile {

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -117,9 +117,9 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by
+        #[pollee = "the underlying stream and, when pending, a future returned by
             the predicate closure,"]
-        #[doc = "items are consecutively yielded by the stream,
+        #[why_busy = "items are consecutively yielded by the stream,
             but the predicate immediately resolves to skip them,"]
     }
 }

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -92,6 +92,13 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by
+            the predicate closure,"]
+        #[doc = "items are consecutively yielded by the stream,
+            but the predicate immediately resolves to skip them,"]
+    }
 }
 
 impl<St, Fut, F> FusedStream for SkipWhile<St, Fut, F>

--- a/futures-util/src/stream/stream/split.rs
+++ b/futures-util/src/stream/stream/split.rs
@@ -82,6 +82,7 @@ impl<S: Sink<Item>, Item> Sink<Item> for SplitSink<S, Item> {
     type Error = S::Error;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        // No busy looping: this loop ends in at most two iterations.
         loop {
             if self.slot.is_none() {
                 return Poll::Ready(Ok(()));

--- a/futures-util/src/stream/try_stream/into_async_read.rs
+++ b/futures-util/src/stream/try_stream/into_async_read.rs
@@ -55,6 +55,9 @@ where
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<Result<usize>> {
+        // This will only busy-loop if the stream keeps producing empty chunks.
+        // It probably does not make sense for any stream that needs to be
+        // consumed as AsyncRead to do so.
         loop {
             match &mut self.state {
                 ReadState::Ready { chunk, chunk_start } => {

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -20,6 +20,8 @@ impl<St: TryStream, C: Default> TryCollect<St, C> {
     unsafe_unpinned!(items: C);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    try_future_method_yield_after_every!();
+
     pub(super) fn new(s: St) -> TryCollect<St, C> {
         TryCollect {
             stream: s,

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -1,4 +1,5 @@
 use core::mem;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, TryStream};
@@ -11,13 +12,13 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 pub struct TryCollect<St, C> {
     stream: St,
     items: C,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: TryStream, C: Default> TryCollect<St, C> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(items: C);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(s: St) -> TryCollect<St, C> {
         TryCollect {

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -25,6 +25,8 @@ where
     unsafe_unpinned!(accum: Option<St::Ok>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    try_future_method_yield_after_every!();
+
     pub(super) fn new(stream: St) -> TryConcat<St> {
         TryConcat {
             stream,

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::TryStream;
@@ -10,7 +11,7 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 pub struct TryConcat<St: TryStream> {
     stream: St,
     accum: Option<St::Ok>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: TryStream + Unpin> Unpin for TryConcat<St> {}
@@ -22,7 +23,7 @@ where
 {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(accum: Option<St::Ok>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St) -> TryConcat<St> {
         TryConcat {

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -21,6 +21,16 @@ pub struct TryFilter<St, Fut, F>
     yield_after: iteration::Limit,
 }
 
+struct Borrows<'a, St, Fut, F>
+    where St: TryStream
+{
+    stream: Pin<&'a mut St>,
+    f: &'a mut F,
+    pending_fut: Pin<&'a mut Option<Fut>>,
+    pending_item: &'a mut Option<St::Ok>,
+    yield_after: &'a mut iteration::Limit,
+}
+
 impl<St, Fut, F> Unpin for TryFilter<St, Fut, F>
     where St: TryStream + Unpin, Fut: Unpin,
 {}
@@ -50,24 +60,16 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     unsafe_unpinned!(pending_item: Option<St::Ok>);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
-    fn split_borrows(
-        self: Pin<&mut Self>,
-    ) -> (
-        Pin<&mut St>,
-        &mut F,
-        Pin<&mut Option<Fut>>,
-        &mut Option<St::Ok>,
-        &mut iteration::Limit,
-    ) {
+    fn split_borrows(self: Pin<&mut Self>) -> Borrows<'_, St, Fut, F> {
         unsafe {
             let this = self.get_unchecked_mut();
-            (
-                Pin::new_unchecked(&mut this.stream),
-                &mut this.f,
-                Pin::new_unchecked(&mut this.pending_fut),
-                &mut this.pending_item,
-                &mut this.yield_after,
-            )
+            Borrows {
+                stream: Pin::new_unchecked(&mut this.stream),
+                f: &mut this.f,
+                pending_fut: Pin::new_unchecked(&mut this.pending_fut),
+                pending_item: &mut this.pending_item,
+                yield_after: &mut this.yield_after,
+            }
         }
     }
 
@@ -142,14 +144,20 @@ impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<St::Ok, St::Error>>> {
-        let (mut stream, op, mut pending_fut, pending_item, yield_after) = self.split_borrows();
+        let Borrows {
+            mut stream,
+            f,
+            mut pending_fut,
+            pending_item,
+            yield_after,
+        } = self.split_borrows();
         poll_loop! { yield_after, cx, {
             if pending_fut.as_ref().is_none() {
                 let item = match ready!(stream.as_mut().try_poll_next(cx)?) {
                     Some(x) => x,
                     None => return Poll::Ready(None),
                 };
-                let fut = op(&item);
+                let fut = f(&item);
                 pending_fut.as_mut().set(Some(fut));
                 *pending_item = Some(item);
             }

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{Stream, TryStream, FusedStream};
@@ -17,7 +18,7 @@ pub struct TryFilter<St, Fut, F>
     f: F,
     pending_fut: Option<Fut>,
     pending_item: Option<St::Ok>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for TryFilter<St, Fut, F>
@@ -47,7 +48,7 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Ok>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilter {

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -74,9 +74,9 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by
+        #[pollee = "the underlying stream and, when pending, a future returned by
             the predicate closure,"]
-        #[doc = "`Ok` items are consecutively yielded by the stream,
+        #[why_busy = "`Ok` items are consecutively yielded by the stream,
             but get immediately filtered out,"]
     }
 

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -50,6 +50,13 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     unsafe_unpinned!(pending_item: Option<St::Ok>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by
+            the predicate closure,"]
+        #[doc = "`Ok` items are consecutively yielded by the stream,
+            but get immediately filtered out,"]
+    }
+
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilter {
             stream,

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -42,6 +42,25 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     unsafe_pinned!(pending: Option<Fut>);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
+    fn split_borrows(
+        self: Pin<&mut Self>,
+    ) -> (
+        Pin<&mut St>,
+        &mut F,
+        Pin<&mut Option<Fut>>,
+        &mut iteration::Limit,
+    ) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.f,
+                Pin::new_unchecked(&mut this.pending),
+                &mut this.yield_after,
+            )
+        }
+    }
+
     stream_method_yield_after_every! {
         #[doc = "the underlying stream and, when pending, a future returned by the map closure,"]
         #[doc = "`Ok` items are consecutively yielded by the stream,
@@ -107,22 +126,20 @@ impl<St, Fut, F, T> Stream for TryFilterMap<St, Fut, F>
 {
     type Item = Result<T, St::Error>;
 
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<T, St::Error>>> {
-        poll_loop! { self.as_mut().yield_after(), cx, {
-            if self.pending.is_none() {
-                let item = match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<T, St::Error>>> {
+        let (mut stream, op, mut pending, yield_after) = self.split_borrows();
+        poll_loop! { yield_after, cx, {
+            if pending.as_ref().is_none() {
+                let item = match ready!(stream.as_mut().try_poll_next(cx)?) {
                     Some(x) => x,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(item);
-                self.as_mut().pending().set(Some(fut));
+                let fut = op(item);
+                pending.as_mut().set(Some(fut));
             }
 
-            let result = ready!(self.as_mut().pending().as_pin_mut().unwrap().try_poll(cx));
-            self.as_mut().pending().set(None);
+            let result = ready!(pending.as_mut().as_pin_mut().unwrap().try_poll(cx));
+            pending.set(None);
             if let Some(x) = result? {
                 return Poll::Ready(Some(Ok(x)));
             }

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -42,6 +42,12 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     unsafe_pinned!(pending: Option<Fut>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by the map closure,"]
+        #[doc = "`Ok` items are consecutively yielded by the stream,
+            but get immediately filtered out,"]
+    }
+
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilterMap {
             stream,

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -62,8 +62,8 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by the map closure,"]
-        #[doc = "`Ok` items are consecutively yielded by the stream,
+        #[pollee = "the underlying stream and, when pending, a future returned by the map closure,"]
+        #[why_busy = "`Ok` items are consecutively yielded by the stream,
             but get immediately filtered out,"]
     }
 

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{TryFuture};
 use futures_core::stream::{Stream, TryStream, FusedStream};
@@ -14,7 +15,7 @@ pub struct TryFilterMap<St, Fut, F> {
     stream: St,
     f: F,
     pending: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for TryFilterMap<St, Fut, F>
@@ -39,7 +40,7 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(pending: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> Self {
         TryFilterMap {

--- a/futures-util/src/stream/try_stream/try_flatten.rs
+++ b/futures-util/src/stream/try_stream/try_flatten.rs
@@ -79,6 +79,11 @@ where
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream or a yet unconsumed stream yielded by it"]
+        #[doc = "the underlying stream keeps yielding streams that immediately poll empty,"]
+    }
 }
 
 impl<St> FusedStream for TryFlatten<St>

--- a/futures-util/src/stream/try_stream/try_flatten.rs
+++ b/futures-util/src/stream/try_stream/try_flatten.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
@@ -14,7 +15,7 @@ where
 {
     stream: St,
     next: Option<St::Ok>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St> Unpin for TryFlatten<St>
@@ -30,7 +31,7 @@ where
 {
     unsafe_pinned!(stream: St);
     unsafe_pinned!(next: Option<St::Ok>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 }
 
 impl<St> TryFlatten<St>

--- a/futures-util/src/stream/try_stream/try_flatten.rs
+++ b/futures-util/src/stream/try_stream/try_flatten.rs
@@ -98,8 +98,8 @@ where
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream or a yet unconsumed stream yielded by it"]
-        #[doc = "the underlying stream keeps yielding streams that immediately poll empty,"]
+        #[pollee = "the underlying stream or a yet unconsumed stream yielded by it"]
+        #[why_busy = "the underlying stream keeps yielding streams that immediately poll empty,"]
     }
 }
 

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -1,7 +1,7 @@
 use core::fmt;
-use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::iteration;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
@@ -13,7 +13,7 @@ pub struct TryFold<St, Fut, T, F> {
     f: F,
     accum: Option<T>,
     future: Option<Fut>,
-    yield_after: NonZeroU32,
+    yield_after: iteration::Limit,
 }
 
 impl<St: Unpin, Fut: Unpin, T, F> Unpin for TryFold<St, Fut, T, F> {}
@@ -43,7 +43,7 @@ where St: TryStream,
     unsafe_unpinned!(f: F);
     unsafe_unpinned!(accum: Option<T>);
     unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(yield_after: NonZeroU32);
+    unsafe_unpinned!(yield_after: iteration::Limit);
 
     future_method_yield_after_every! {
         #[doc = "the underlying stream and, if pending, a future returned by
@@ -81,7 +81,7 @@ impl<St, Fut, T, F> Future for TryFold<St, Fut, T, F>
     type Output = Result<T, St::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        poll_loop! { self.yield_after, cx, {
+        poll_loop! { self.as_mut().yield_after(), cx, {
             // we're currently processing a future to produce a new accum value
             if self.accum.is_none() {
                 let accum = match ready!(

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::stream::TryStream;
@@ -12,7 +13,7 @@ pub struct TryFold<St, Fut, T, F> {
     f: F,
     accum: Option<T>,
     future: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin, Fut: Unpin, T, F> Unpin for TryFold<St, Fut, T, F> {}
@@ -42,7 +43,7 @@ where St: TryStream,
     unsafe_unpinned!(f: F);
     unsafe_unpinned!(accum: Option<T>);
     unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F, t: T) -> TryFold<St, Fut, T, F> {
         TryFold {

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -67,9 +67,9 @@ where St: TryStream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and, if pending, a future returned by
+        #[pollee = "the underlying stream and, if pending, a future returned by
             the accumulation closure,"]
-        #[doc = "the underlying stream consecutively yields `Ok` items and
+        #[why_busy = "the underlying stream consecutively yields `Ok` items and
             the accumulation futures immediately resolve with `Ok`,"]
     }
 

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -45,6 +45,13 @@ where St: TryStream,
     unsafe_pinned!(future: Option<Fut>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and, if pending, a future returned by
+            the accumulation closure,"]
+        #[doc = "the underlying stream consecutively yields `Ok` items and
+            the accumulation futures immediately resolve with `Ok`,"]
+    }
+
     pub(super) fn new(stream: St, f: F, t: T) -> TryFold<St, Fut, T, F> {
         TryFold {
             stream,

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -41,6 +41,25 @@ where St: TryStream,
     unsafe_pinned!(future: Option<Fut>);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
+    fn split_borrows(
+        self: Pin<&mut Self>,
+    ) -> (
+        Pin<&mut St>,
+        &mut F,
+        Pin<&mut Option<Fut>>,
+        &mut iteration::Limit,
+    ) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.f,
+                Pin::new_unchecked(&mut this.future),
+                &mut this.yield_after,
+            )
+        }
+    }
+
     future_method_yield_after_every! {
         #[doc = "the underlying stream and, if pending, a future returned by
             the processing closure,"]
@@ -65,17 +84,18 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
 {
     type Output = Result<(), St::Error>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        poll_loop! { self.as_mut().yield_after(), cx, {
-            if let Some(future) = self.as_mut().future().as_pin_mut() {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let (mut stream, op, mut future, yield_after) = self.split_borrows();
+        poll_loop! { yield_after, cx, {
+            if let Some(future) = future.as_mut().as_pin_mut() {
                 ready!(future.try_poll(cx))?;
             }
-            self.as_mut().future().set(None);
+            future.as_mut().set(None);
 
-            match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+            match ready!(stream.as_mut().try_poll_next(cx)?) {
                 Some(e) => {
-                    let future = (self.as_mut().f())(e);
-                    self.as_mut().future().set(Some(future));
+                    let fut = op(e);
+                    future.as_mut().set(Some(fut));
                 }
                 None => return Poll::Ready(Ok(())),
             }

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -11,6 +11,7 @@ pub struct TryForEach<St, Fut, F> {
     stream: St,
     f: F,
     future: Option<Fut>,
+    yield_after: u32,
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for TryForEach<St, Fut, F> {}
@@ -24,6 +25,7 @@ where
         f.debug_struct("TryForEach")
             .field("stream", &self.stream)
             .field("future", &self.future)
+            .field("yield_after", &self.yield_after)
             .finish()
     }
 }
@@ -36,12 +38,14 @@ where St: TryStream,
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(future: Option<Fut>);
+    unsafe_unpinned!(yield_after: u32);
 
     pub(super) fn new(stream: St, f: F) -> TryForEach<St, Fut, F> {
         TryForEach {
             stream,
             f,
             future: None,
+            yield_after: crate::DEFAULT_YIELD_AFTER_LIMIT,
         }
     }
 }
@@ -54,7 +58,7 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
     type Output = Result<(), St::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        loop {
+        poll_loop! { self.yield_after, cx, {
             if let Some(future) = self.as_mut().future().as_pin_mut() {
                 ready!(future.try_poll(cx))?;
             }
@@ -67,6 +71,6 @@ impl<St, Fut, F> Future for TryForEach<St, Fut, F>
                 }
                 None => return Poll::Ready(Ok(())),
             }
-        }
+        }}
     }
 }

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::stream::TryStream;
@@ -11,7 +12,7 @@ pub struct TryForEach<St, Fut, F> {
     stream: St,
     f: F,
     future: Option<Fut>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin, Fut: Unpin, F> Unpin for TryForEach<St, Fut, F> {}
@@ -38,7 +39,7 @@ where St: TryStream,
     unsafe_pinned!(stream: St);
     unsafe_unpinned!(f: F);
     unsafe_pinned!(future: Option<Fut>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> TryForEach<St, Fut, F> {
         TryForEach {

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -41,6 +41,13 @@ where St: TryStream,
     unsafe_pinned!(future: Option<Fut>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and, if pending, a future returned by
+            the processing closure,"]
+        #[doc = "the underlying stream consecutively yields `Ok` items and
+            the processing futures immediately resolve with `Ok`,"]
+    }
+
     pub(super) fn new(stream: St, f: F) -> TryForEach<St, Fut, F> {
         TryForEach {
             stream,

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -61,9 +61,9 @@ where St: TryStream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and, if pending, a future returned by
+        #[pollee = "the underlying stream and, if pending, a future returned by
             the processing closure,"]
-        #[doc = "the underlying stream consecutively yields `Ok` items and
+        #[why_busy = "the underlying stream consecutively yields `Ok` items and
             the processing futures immediately resolve with `Ok`,"]
     }
 

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -1,8 +1,8 @@
 use crate::stream::{FuturesUnordered, StreamExt};
 use core::fmt;
 use core::mem;
+use core::num::{NonZeroU32, NonZeroUsize};
 use core::pin::Pin;
-use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
@@ -17,7 +17,7 @@ pub struct TryForEachConcurrent<St, Fut, F> {
     f: F,
     futures: FuturesUnordered<Fut>,
     limit: Option<NonZeroUsize>,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St, Fut, F> Unpin for TryForEachConcurrent<St, Fut, F>
@@ -59,7 +59,7 @@ where St: TryStream,
     unsafe_unpinned!(f: F);
     unsafe_unpinned!(futures: FuturesUnordered<Fut>);
     unsafe_unpinned!(limit: Option<NonZeroUsize>);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> TryForEachConcurrent<St, Fut, F> {
         TryForEachConcurrent {

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -62,6 +62,25 @@ where St: TryStream,
     unsafe_unpinned!(limit: Option<NonZeroUsize>);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
+    fn split_borrows(
+        self: Pin<&mut Self>,
+    ) -> (
+        Pin<&mut Option<St>>,
+        &mut F,
+        &mut FuturesUnordered<Fut>,
+        &mut iteration::Limit,
+    ) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.f,
+                &mut this.futures,
+                &mut this.yield_after,
+            )
+        }
+    }
+
     future_method_yield_after_every! {
         #[doc = "the underlying stream and a pool of pending futures returned by
             the processing closure,"]
@@ -88,15 +107,17 @@ impl<St, Fut, F> Future for TryForEachConcurrent<St, Fut, F>
 {
     type Output = Result<(), St::Error>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        poll_loop! { self.as_mut().yield_after(), cx, {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let limit = self.limit;
+        let (mut stream, op, futures, yield_after) = self.split_borrows();
+        poll_loop! { yield_after, cx, {
             let mut made_progress_this_iter = false;
 
             // Try and pull an item from the stream
-            let current_len = self.futures.len();
+            let current_len = futures.len();
             // Check if we've already created a number of futures greater than `limit`
-            if self.limit.map(|limit| limit.get() > current_len).unwrap_or(true) {
-                let poll_res = match self.as_mut().stream().as_pin_mut() {
+            if limit.map(|limit| limit.get() > current_len).unwrap_or(true) {
+                let poll_res = match stream.as_mut().as_pin_mut() {
                     Some(stream) => stream.try_poll_next(cx),
                     None => Poll::Ready(None),
                 };
@@ -107,29 +128,29 @@ impl<St, Fut, F> Future for TryForEachConcurrent<St, Fut, F>
                         Some(elem)
                     },
                     Poll::Ready(None) => {
-                        self.as_mut().stream().set(None);
+                        stream.set(None);
                         None
                     }
                     Poll::Pending => None,
                     Poll::Ready(Some(Err(e))) => {
                         // Empty the stream and futures so that we know
                         // the future has completed.
-                        self.as_mut().stream().set(None);
-                        drop(mem::replace(self.as_mut().futures(), FuturesUnordered::new()));
+                        stream.set(None);
+                        drop(mem::replace(futures, FuturesUnordered::new()));
                         return Poll::Ready(Err(e));
                     }
                 };
 
                 if let Some(elem) = elem {
-                    let next_future = (self.as_mut().f())(elem);
-                    self.as_mut().futures().push(next_future);
+                    let next_future = op(elem);
+                    futures.push(next_future);
                 }
             }
 
-            match self.as_mut().futures().poll_next_unpin(cx) {
+            match futures.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(()))) => made_progress_this_iter = true,
                 Poll::Ready(None) => {
-                    if self.stream.is_none() {
+                    if stream.as_ref().is_none() {
                         return Poll::Ready(Ok(()))
                     }
                 },
@@ -137,8 +158,8 @@ impl<St, Fut, F> Future for TryForEachConcurrent<St, Fut, F>
                 Poll::Ready(Some(Err(e))) => {
                     // Empty the stream and futures so that we know
                     // the future has completed.
-                    self.as_mut().stream().set(None);
-                    drop(mem::replace(self.as_mut().futures(), FuturesUnordered::new()));
+                    stream.as_mut().set(None);
+                    drop(mem::replace(futures, FuturesUnordered::new()));
                     return Poll::Ready(Err(e));
                 }
             }

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -82,9 +82,9 @@ where St: TryStream,
     }
 
     future_method_yield_after_every! {
-        #[doc = "the underlying stream and a pool of pending futures returned by
+        #[pollee = "the underlying stream and a pool of pending futures returned by
             the processing closure,"]
-        #[doc = "the underlying stream consecutively yields `Ok` items and some of
+        #[why_busy = "the underlying stream consecutively yields `Ok` items and some of
             the processing futures resolve, all of them with `Ok`,"]
     }
 

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -61,6 +61,13 @@ where St: TryStream,
     unsafe_unpinned!(limit: Option<NonZeroUsize>);
     unsafe_unpinned!(yield_after: NonZeroU32);
 
+    future_method_yield_after_every! {
+        #[doc = "the underlying stream and a pool of pending futures returned by
+            the processing closure,"]
+        #[doc = "the underlying stream consecutively yields `Ok` items and some of
+            the processing futures resolve, all of them with `Ok`,"]
+    }
+
     pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> TryForEachConcurrent<St, Fut, F> {
         TryForEachConcurrent {
             stream: Some(stream),

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -56,6 +56,29 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     unsafe_unpinned!(done_skipping: bool);
     unsafe_unpinned!(yield_after: iteration::Limit);
 
+    fn split_borrows(
+        self: Pin<&mut Self>,
+    ) -> (
+        Pin<&mut St>,
+        &mut F,
+        Pin<&mut Option<Fut>>,
+        &mut Option<St::Ok>,
+        &mut bool,
+        &mut iteration::Limit,
+    ) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.f,
+                Pin::new_unchecked(&mut this.pending_fut),
+                &mut this.pending_item,
+                &mut this.done_skipping,
+                &mut this.yield_after,
+            )
+        }
+    }
+
     pub(super) fn new(stream: St, f: F) -> TrySkipWhile<St, Fut, F> {
         TrySkipWhile {
             stream,
@@ -122,23 +145,25 @@ impl<St, Fut, F> Stream for TrySkipWhile<St, Fut, F>
             return self.as_mut().stream().try_poll_next(cx);
         }
 
-        poll_loop! { self.as_mut().yield_after(), cx, {
-            if self.pending_item.is_none() {
-                let item = match ready!(self.as_mut().stream().try_poll_next(cx)?) {
+        let (mut stream, predicate, mut pending_fut, pending_item, done_skipping, yield_after) =
+            self.split_borrows();
+        poll_loop! { yield_after, cx, {
+            if pending_item.is_none() {
+                let item = match ready!(stream.as_mut().try_poll_next(cx)?) {
                     Some(e) => e,
                     None => return Poll::Ready(None),
                 };
-                let fut = (self.as_mut().f())(&item);
-                self.as_mut().pending_fut().set(Some(fut));
-                *self.as_mut().pending_item() = Some(item);
+                let fut = predicate(&item);
+                pending_fut.as_mut().set(Some(fut));
+                *pending_item = Some(item);
             }
 
-            let skipped = ready!(self.as_mut().pending_fut().as_pin_mut().unwrap().try_poll(cx)?);
-            let item = self.as_mut().pending_item().take().unwrap();
-            self.as_mut().pending_fut().set(None);
+            let skipped = ready!(pending_fut.as_mut().as_pin_mut().unwrap().try_poll(cx)?);
+            let item = pending_item.take().unwrap();
+            pending_fut.as_mut().set(None);
 
             if !skipped {
-                *self.as_mut().done_skipping() = true;
+                *done_skipping = true;
                 return Poll::Ready(Some(Ok(item)))
             }
         }}

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -123,9 +123,9 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     }
 
     stream_method_yield_after_every! {
-        #[doc = "the underlying stream and, when pending, a future returned by
+        #[pollee = "the underlying stream and, when pending, a future returned by
             the predicate closure,"]
-        #[doc = "`Ok` items are consecutively yielded by the stream,
+        #[why_busy = "`Ok` items are consecutively yielded by the stream,
             but the predicate immediately resolves to skip them,"]
     }
 }

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use core::num::NonZeroU32;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::stream::{Stream, TryStream, FusedStream};
@@ -16,7 +17,7 @@ pub struct TrySkipWhile<St, Fut, F> where St: TryStream {
     pending_fut: Option<Fut>,
     pending_item: Option<St::Ok>,
     done_skipping: bool,
-    yield_after: u32,
+    yield_after: NonZeroU32,
 }
 
 impl<St: Unpin + TryStream, Fut: Unpin, F> Unpin for TrySkipWhile<St, Fut, F> {}
@@ -53,7 +54,7 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     unsafe_pinned!(pending_fut: Option<Fut>);
     unsafe_unpinned!(pending_item: Option<St::Ok>);
     unsafe_unpinned!(done_skipping: bool);
-    unsafe_unpinned!(yield_after: u32);
+    unsafe_unpinned!(yield_after: NonZeroU32);
 
     pub(super) fn new(stream: St, f: F) -> TrySkipWhile<St, Fut, F> {
         TrySkipWhile {

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -98,6 +98,13 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
     pub fn into_inner(self) -> St {
         self.stream
     }
+
+    stream_method_yield_after_every! {
+        #[doc = "the underlying stream and, when pending, a future returned by
+            the predicate closure,"]
+        #[doc = "`Ok` items are consecutively yielded by the stream,
+            but the predicate immediately resolves to skip them,"]
+    }
 }
 
 impl<St, Fut, F> Stream for TrySkipWhile<St, Fut, F>

--- a/futures-util/src/yield_after.rs
+++ b/futures-util/src/yield_after.rs
@@ -1,8 +1,23 @@
 use core::num::NonZeroU32;
+use futures_core::iteration::Limit;
 
 // Default for repetition limits on eager polling loops, to prevent
 // stream-consuming combinators like ForEach from starving other tasks.
-pub(crate) const DEFAULT_YIELD_AFTER_LIMIT: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(100) };
+pub(crate) const DEFAULT_YIELD_AFTER_LIMIT: Limit = Limit::new(
+    unsafe { NonZeroU32::new_unchecked(100) }
+);
+
+macro_rules! method_yield_after_every {
+    ($(#[$doc:meta])*) => {
+        $(#[$doc])*
+        pub fn yield_after_every(mut self, iterations: u32) -> Self {
+            let v = core::num::NonZeroU32::new(iterations)
+                .expect("iteration limit can't be 0");
+            self.yield_after = futures_core::iteration::Limit::new(v);
+            self
+        }
+    }
+}
 
 macro_rules! future_method_yield_after_every {
     () => {
@@ -12,29 +27,25 @@ macro_rules! future_method_yield_after_every {
         }
     };
     (#[$pollee:meta] #[$why_busy:meta]) => {
-        /// Changes the maximum number of iterations before `poll` yields.
-        ///
-        /// The implementation of [`poll`] on this future
-        /** polls */#[$pollee]/** in a loop. */
-        /// To prevent blocking in the call to `poll` for too long while
-        #[$why_busy]
-        /// the number of iterations is capped to an internal limit,
-        /// after which the `poll` function wakes up the task
-        /// and returns [`Pending`]. The `yield_after_every` combinator
-        /// can be used to tune the iteration limit, returning a future
-        /// with the limit updated to the provided value.
-        ///
-        /// [`poll`]: core::future::Future::poll
-        /// [`Pending`]: core::task::poll::Poll::Pending
-        ///
-        /// # Panics
-        ///
-        /// If called with 0 as the number of iterations, this method panics.
-        ///
-        pub fn yield_after_every(mut self, iterations: u32) -> Self {
-            self.yield_after = $crate::core_reexport::num::NonZeroU32::new(iterations)
-                .expect("iteration limit can't be 0");
-            self
+        method_yield_after_every! {
+            /// Changes the maximum number of iterations before `poll` yields.
+            ///
+            /// The implementation of [`poll`] on this future
+            /** polls */#[$pollee]/** in a loop. */
+            /// To prevent blocking in the call to `poll` for too long while
+            #[$why_busy]
+            /// the number of iterations is capped to an internal limit,
+            /// after which the `poll` function wakes up the task
+            /// and returns [`Pending`]. The `yield_after_every` combinator
+            /// can be used to tune the iteration limit, returning a future
+            /// with the limit updated to the provided value.
+            ///
+            /// [`poll`]: core::future::Future::poll
+            /// [`Pending`]: core::task::poll::Poll::Pending
+            ///
+            /// # Panics
+            ///
+            /// If called with 0 as the number of iterations, this method panics.
         }
     };
 }
@@ -56,29 +67,25 @@ macro_rules! stream_method_yield_after_every {
         }
     };
     (#[$pollee:meta] #[$why_busy:meta]) => {
-        /// Changes the maximum number of iterations before `poll_next` yields.
-        ///
-        /// The implementation of [`poll_next`] on this stream
-        /** polls */#[$pollee]/** in a loop. */
-        /// To prevent blocking in the call to `poll_next` for too long while
-        #[$why_busy]
-        /// the number of iterations is capped to an internal limit,
-        /// after which the `poll_next` function wakes up the task
-        /// and returns [`Pending`]. The `yield_after_every` combinator
-        /// can be used to tune the iteration limit, returning a stream
-        /// with the limit updated to the provided value.
-        ///
-        /// [`poll_next`]: crate::stream::Stream::poll_next
-        /// [`Pending`]: core::task::poll::Poll::Pending
-        ///
-        /// # Panics
-        ///
-        /// If called with 0 as the number of iterations, this method panics.
-        ///
-        pub fn yield_after_every(mut self, iterations: u32) -> Self {
-            self.yield_after = $crate::core_reexport::num::NonZeroU32::new(iterations)
-                .expect("iteration limit can't be 0");
-            self
+        method_yield_after_every! {
+            /// Changes the maximum number of iterations before `poll_next` yields.
+            ///
+            /// The implementation of [`poll_next`] on this stream
+            /** polls */#[$pollee]/** in a loop. */
+            /// To prevent blocking in the call to `poll_next` for too long while
+            #[$why_busy]
+            /// the number of iterations is capped to an internal limit,
+            /// after which the `poll_next` function wakes up the task
+            /// and returns [`Pending`]. The `yield_after_every` combinator
+            /// can be used to tune the iteration limit, returning a stream
+            /// with the limit updated to the provided value.
+            ///
+            /// [`poll_next`]: crate::stream::Stream::poll_next
+            /// [`Pending`]: core::task::poll::Poll::Pending
+            ///
+            /// # Panics
+            ///
+            /// If called with 0 as the number of iterations, this method panics.
         }
     };
 }

--- a/futures-util/src/yield_after.rs
+++ b/futures-util/src/yield_after.rs
@@ -1,10 +1,10 @@
 use core::num::NonZeroU32;
 use futures_core::iteration::Limit;
 
-// Default for repetition limits on eager polling loops, to prevent
+// Default for iteration limits on eager polling loops, to prevent
 // stream-consuming combinators like ForEach from starving other tasks.
 pub(crate) const DEFAULT_YIELD_AFTER_LIMIT: Limit = Limit::new(
-    unsafe { NonZeroU32::new_unchecked(100) }
+    unsafe { NonZeroU32::new_unchecked(64) }
 );
 
 macro_rules! method_yield_after_every {

--- a/futures-util/src/yield_after.rs
+++ b/futures-util/src/yield_after.rs
@@ -25,19 +25,19 @@ macro_rules! method_yield_after_every {
 macro_rules! future_method_yield_after_every {
     ($(self$(.$field:ident)+)?) => {
         future_method_yield_after_every! {
-            #[doc = "the underlying stream"]
-            #[doc = "the stream consecutively yields items,"]
+            #[pollee = "the underlying stream"]
+            #[why_busy = "the stream consecutively yields items,"]
             $(self$(.$field)+)?
         }
     };
-    (#[$pollee:meta] #[$why_busy:meta] $(self$(.$field:ident)+)?) => {
+    (#[pollee = $pollee:literal] #[why_busy = $why_busy:literal] $(self$(.$field:ident)+)?) => {
         method_yield_after_every! {
             /// Changes the maximum number of iterations before `poll` yields.
             ///
             /// The implementation of [`poll`] on this future
-            /** polls */#[$pollee]/** in a loop. */
+            /** polls */#[doc = $pollee]/** in a loop. */
             /// To prevent blocking in the call to `poll` for too long while
-            #[$why_busy]
+            #[doc = $why_busy]
             /// the number of iterations is capped to an internal limit,
             /// after which the `poll` function wakes up the task
             /// and returns [`Pending`]. The `yield_after_every` combinator
@@ -58,8 +58,8 @@ macro_rules! future_method_yield_after_every {
 macro_rules! try_future_method_yield_after_every {
     ($(self$(.$field:ident)+)?) => {
         future_method_yield_after_every! {
-            #[doc = "the underlying stream"]
-            #[doc = "the stream consecutively yields `Ok` items,"]
+            #[pollee = "the underlying stream"]
+            #[why_busy = "the stream consecutively yields `Ok` items,"]
             $(self$(.$field)+)?
         }
     }
@@ -68,19 +68,19 @@ macro_rules! try_future_method_yield_after_every {
 macro_rules! stream_method_yield_after_every {
     ($(self$(.$field:ident)+)?) => {
         stream_method_yield_after_every! {
-            #[doc = "the underlying stream"]
-            #[doc = "the stream consecutively yields items,"]
+            #[pollee = "the underlying stream"]
+            #[why_busy = "the stream consecutively yields items,"]
             $(self$(.$field)+)?
         }
     };
-    (#[$pollee:meta] #[$why_busy:meta] $(self$(.$field:ident)+)?) => {
+    (#[pollee = $pollee:literal] #[why_busy = $why_busy:literal] $(self$(.$field:ident)+)?) => {
         method_yield_after_every! {
             /// Changes the maximum number of iterations before `poll_next` yields.
             ///
             /// The implementation of [`poll_next`] on this stream
-            /** polls */#[$pollee]/** in a loop. */
+            /** polls */#[doc = $pollee]/** in a loop. */
             /// To prevent blocking in the call to `poll_next` for too long while
-            #[$why_busy]
+            #[doc = $why_busy]
             /// the number of iterations is capped to an internal limit,
             /// after which the `poll_next` function wakes up the task
             /// and returns [`Pending`]. The `yield_after_every` combinator

--- a/futures-util/src/yield_after.rs
+++ b/futures-util/src/yield_after.rs
@@ -9,24 +9,28 @@ pub(crate) const DEFAULT_YIELD_AFTER_LIMIT: Limit = Limit::new(
 
 macro_rules! method_yield_after_every {
     ($(#[$doc:meta])*) => {
+        method_yield_after_every!($(#[$doc])* self.yield_after);
+    };
+    ($(#[$doc:meta])* self$(.$field:ident)+) => {
         $(#[$doc])*
         pub fn yield_after_every(mut self, iterations: u32) -> Self {
             let v = core::num::NonZeroU32::new(iterations)
                 .expect("iteration limit can't be 0");
-            self.yield_after = futures_core::iteration::Limit::new(v);
+            self$(.$field)+ = futures_core::iteration::Limit::new(v);
             self
         }
     }
 }
 
 macro_rules! future_method_yield_after_every {
-    () => {
+    ($(self$(.$field:ident)+)?) => {
         future_method_yield_after_every! {
             #[doc = "the underlying stream"]
             #[doc = "the stream consecutively yields items,"]
+            $(self$(.$field)+)?
         }
     };
-    (#[$pollee:meta] #[$why_busy:meta]) => {
+    (#[$pollee:meta] #[$why_busy:meta] $(self$(.$field:ident)+)?) => {
         method_yield_after_every! {
             /// Changes the maximum number of iterations before `poll` yields.
             ///
@@ -46,27 +50,30 @@ macro_rules! future_method_yield_after_every {
             /// # Panics
             ///
             /// If called with 0 as the number of iterations, this method panics.
+            $(self$(.$field)+)?
         }
     };
 }
 
 macro_rules! try_future_method_yield_after_every {
-    () => {
+    ($(self$(.$field:ident)+)?) => {
         future_method_yield_after_every! {
             #[doc = "the underlying stream"]
             #[doc = "the stream consecutively yields `Ok` items,"]
-        }    
+            $(self$(.$field)+)?
+        }
     }
 }
 
 macro_rules! stream_method_yield_after_every {
-    () => {
+    ($(self$(.$field:ident)+)?) => {
         stream_method_yield_after_every! {
             #[doc = "the underlying stream"]
             #[doc = "the stream consecutively yields items,"]
+            $(self$(.$field)+)?
         }
     };
-    (#[$pollee:meta] #[$why_busy:meta]) => {
+    (#[$pollee:meta] #[$why_busy:meta] $(self$(.$field:ident)+)?) => {
         method_yield_after_every! {
             /// Changes the maximum number of iterations before `poll_next` yields.
             ///
@@ -86,6 +93,7 @@ macro_rules! stream_method_yield_after_every {
             /// # Panics
             ///
             /// If called with 0 as the number of iterations, this method panics.
+            $(self$(.$field)+)?
         }
     };
 }

--- a/futures-util/src/yield_after.rs
+++ b/futures-util/src/yield_after.rs
@@ -1,0 +1,84 @@
+use core::num::NonZeroU32;
+
+// Default for repetition limits on eager polling loops, to prevent
+// stream-consuming combinators like ForEach from starving other tasks.
+pub(crate) const DEFAULT_YIELD_AFTER_LIMIT: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(100) };
+
+macro_rules! future_method_yield_after_every {
+    () => {
+        future_method_yield_after_every! {
+            #[doc = "the underlying stream"]
+            #[doc = "the stream consecutively yields items,"]
+        }
+    };
+    (#[$pollee:meta] #[$why_busy:meta]) => {
+        /// Changes the maximum number of iterations before `poll` yields.
+        ///
+        /// The implementation of [`poll`] on this future
+        /** polls */#[$pollee]/** in a loop. */
+        /// To prevent blocking in the call to `poll` for too long while
+        #[$why_busy]
+        /// the number of iterations is capped to an internal limit,
+        /// after which the `poll` function wakes up the task
+        /// and returns [`Pending`]. The `yield_after_every` combinator
+        /// can be used to tune the iteration limit, returning a future
+        /// with the limit updated to the provided value.
+        ///
+        /// [`poll`]: core::future::Future::poll
+        /// [`Pending`]: core::task::poll::Poll::Pending
+        ///
+        /// # Panics
+        ///
+        /// If called with 0 as the number of iterations, this method panics.
+        ///
+        pub fn yield_after_every(mut self, iterations: u32) -> Self {
+            self.yield_after = $crate::core_reexport::num::NonZeroU32::new(iterations)
+                .expect("iteration limit can't be 0");
+            self
+        }
+    };
+}
+
+macro_rules! try_future_method_yield_after_every {
+    () => {
+        future_method_yield_after_every! {
+            #[doc = "the underlying stream"]
+            #[doc = "the stream consecutively yields `Ok` items,"]
+        }    
+    }
+}
+
+macro_rules! stream_method_yield_after_every {
+    () => {
+        stream_method_yield_after_every! {
+            #[doc = "the underlying stream"]
+            #[doc = "the stream consecutively yields items,"]
+        }
+    };
+    (#[$pollee:meta] #[$why_busy:meta]) => {
+        /// Changes the maximum number of iterations before `poll_next` yields.
+        ///
+        /// The implementation of [`poll_next`] on this stream
+        /** polls */#[$pollee]/** in a loop. */
+        /// To prevent blocking in the call to `poll_next` for too long while
+        #[$why_busy]
+        /// the number of iterations is capped to an internal limit,
+        /// after which the `poll_next` function wakes up the task
+        /// and returns [`Pending`]. The `yield_after_every` combinator
+        /// can be used to tune the iteration limit, returning a stream
+        /// with the limit updated to the provided value.
+        ///
+        /// [`poll_next`]: crate::stream::Stream::poll_next
+        /// [`Pending`]: core::task::poll::Poll::Pending
+        ///
+        /// # Panics
+        ///
+        /// If called with 0 as the number of iterations, this method panics.
+        ///
+        pub fn yield_after_every(mut self, iterations: u32) -> Self {
+            self.yield_after = $crate::core_reexport::num::NonZeroU32::new(iterations)
+                .expect("iteration limit can't be 0");
+            self
+        }
+    };
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -338,6 +338,24 @@ pub mod io {
     };
 }
 
+pub mod iteration {
+    //! Utilities for implementing iterative polling in a cooperative way.
+    //!
+    //! This module provides the [`Policy`] trait and its implementations
+    //! that can be used to tune behavior of eager polling loops in a
+    //! polymorphic way.
+    //!
+    //! An object implementing `Policy` is used by the [`poll_loop!`] macro,
+    //! normally as a member of a structure implementing an asynchronous polling
+    //! API such as [`Future`], where a poll function runs a loop that can
+    //! potentially be saturated by asynchronous sources readily yielding
+    //! data for many consecutive iterations.
+    //!
+    //! [`Future`]: core::future::Future
+
+    pub use futures_core::iteration::{Policy, LoopGuard, Limit, Unlimited};
+}
+
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]
 pub mod lock {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -505,7 +505,7 @@ pub mod task {
     //! The remaining types and traits in the module are used for implementing
     //! executors or dealing with synchronization issues around task wakeup.
 
-    pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+    pub use futures_core::task::{Context, Poll, ToYield, Waker, RawWaker, RawWakerVTable};
 
     pub use futures_task::{
         Spawn, LocalSpawn, SpawnError,

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -505,7 +505,7 @@ pub mod task {
     //! The remaining types and traits in the module are used for implementing
     //! executors or dealing with synchronization issues around task wakeup.
 
-    pub use futures_core::task::{Context, Poll, ToYield, Waker, RawWaker, RawWakerVTable};
+    pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
 
     pub use futures_task::{
         Spawn, LocalSpawn, SpawnError,

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -353,7 +353,7 @@ pub mod iteration {
     //!
     //! [`Future`]: core::future::Future
 
-    pub use futures_core::iteration::{Policy, LoopGuard, Limit, Unlimited};
+    pub use futures_core::iteration::{Policy, Limit, Unlimited};
 }
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -116,7 +116,8 @@ compile_error!("The `read-initializer` feature requires the `unstable` feature a
 #[doc(hidden)] pub use futures_util::{AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt};
 
 // Macro reexports
-pub use futures_core::ready; // Readiness propagation
+pub use futures_core::poll_loop; // Cooperative looping
+pub use futures_core::ready;     // Readiness propagation
 pub use futures_util::pin_mut;
 #[cfg(feature = "std")]
 #[cfg(feature = "async-await")]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -341,11 +341,11 @@ pub mod io {
 pub mod iteration {
     //! Utilities for implementing iterative polling in a cooperative way.
     //!
-    //! This module provides the [`Policy`] trait and its implementations
+    //! This module provides the [`LoopPolicy`] trait and its implementations
     //! that can be used to tune behavior of eager polling loops in a
     //! polymorphic way.
     //!
-    //! An object implementing `Policy` is used by the [`poll_loop!`] macro,
+    //! An object implementing `LoopPolicy` is used by the [`poll_loop!`] macro,
     //! normally as a member of a structure implementing an asynchronous polling
     //! API such as [`Future`], where a poll function runs a loop that can
     //! potentially be saturated by asynchronous sources readily yielding
@@ -353,7 +353,7 @@ pub mod iteration {
     //!
     //! [`Future`]: core::future::Future
 
-    pub use futures_core::iteration::{Policy, Limit, Unlimited};
+    pub use futures_core::iteration::{LoopPolicy, Limit, Unlimited};
 }
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]

--- a/futures/tests/poll_loop.rs
+++ b/futures/tests/poll_loop.rs
@@ -1,0 +1,192 @@
+use futures::iteration::{self, Limit, LoopPolicy, Unlimited};
+use futures::prelude::*;
+use futures_test::stream::StreamTestExt;
+use futures_test::task::{new_count_waker, panic_context};
+use std::marker::Unpin;
+use std::num::NonZeroU32;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::{pin_mut, poll_loop, ready};
+
+// A proof of concept for polling loop instrumentation using the LoopPolicy trait.
+#[derive(Debug)]
+struct PollOMeter<P> {
+    inner: P,
+    total_iterations: u64,
+    loop_entered: u64,
+    loop_yielded: u64,
+}
+
+impl<P> PollOMeter<P> {
+    fn new(inner: P) -> Self {
+        PollOMeter {
+            inner,
+            total_iterations: 0,
+            loop_entered: 0,
+            loop_yielded: 0,
+        }
+    }
+
+    fn average_iterations_per_loop(&self) -> Option<f64> {
+        if self.loop_entered != 0 {
+            let ratio = self.total_iterations as f64 / self.loop_entered as f64;
+            Some(ratio)
+        } else {
+            None
+        }
+    }
+}
+
+impl<P: LoopPolicy> LoopPolicy for PollOMeter<P> {
+    type State = P::State;
+
+    fn enter(&mut self) -> Self::State {
+        self.loop_entered += 1;
+        self.inner.enter()
+    }
+
+    fn yield_check(&mut self, state: &mut Self::State) -> bool {
+        self.total_iterations += 1;
+        if self.inner.yield_check(state) {
+            self.loop_yielded += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+struct Count<S, P = iteration::Limit> {
+    stream: S,
+    count: u64,
+    loop_policy: P,
+}
+
+impl<S: Unpin, P> Unpin for Count<S, P> {}
+
+impl<S> Count<S> {
+    fn new(stream: S) -> Self {
+        Count {
+            stream,
+            count: 0,
+            loop_policy: Limit::new(NonZeroU32::new(64).unwrap()),
+        }
+    }
+}
+
+impl<S, P> Count<S, P> {
+    fn with_loop_policy<Q>(self, loop_policy: Q) -> Count<S, Q> {
+        Count {
+            stream: self.stream,
+            count: self.count,
+            loop_policy,
+        }
+    }
+
+    fn loop_policy(&self) -> &P {
+        &self.loop_policy
+    }
+
+    fn split_borrows(self: Pin<&mut Self>) -> (Pin<&mut S>, &mut P, &mut u64) {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            (
+                Pin::new_unchecked(&mut this.stream),
+                &mut this.loop_policy,
+                &mut this.count,
+            )
+        }
+    }
+}
+
+impl<S: Stream, P: LoopPolicy> Future for Count<S, P> {
+    type Output = u64;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<u64> {
+        let (mut stream, loop_policy, count) = self.split_borrows();
+        poll_loop! { loop_policy, cx,
+            match ready!(stream.as_mut().poll_next(cx)) {
+                Some(_) => {
+                    *count += 1;
+                }
+                None => return Poll::Ready(*count),
+            }
+        }
+    }
+}
+
+#[test]
+fn unlimited_policy_never_yields() {
+    let future = Count::new(stream::repeat(()).take(100000))
+        .with_loop_policy(Unlimited);
+    pin_mut!(future);
+    let mut cx = panic_context();
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Ready(100000));
+}
+
+#[test]
+fn limit_policy_yields() {
+    let future = Count::new(stream::repeat(()).take(11))
+        .with_loop_policy(Limit::new(NonZeroU32::new(10).unwrap()));
+    pin_mut!(future);
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 1);
+    assert_eq!(future.count, 10);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Ready(11));
+    assert_eq!(wake_count, 1);
+}
+
+#[test]
+fn custom_mutable_policy_is_feasible() {
+    let stream = stream::iter([0, 10, 21].iter().map(|&n| stream::repeat(()).take(n)))
+        .interleave_pending()
+        .flatten();
+
+    let limit = Limit::new(NonZeroU32::new(20).unwrap());
+    let future = Count::new(stream).with_loop_policy(PollOMeter::new(limit));
+    pin_mut!(future);
+
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert!(future.loop_policy().average_iterations_per_loop().is_none());
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 1);
+    assert_eq!(future.count, 0);
+    assert_eq!(future.loop_policy.loop_entered, 1);
+    assert_eq!(future.loop_policy.loop_yielded, 0);
+    assert_eq!(future.loop_policy.total_iterations, 0);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 2);
+    assert_eq!(future.count, 0);
+    assert_eq!(future.loop_policy.loop_entered, 2);
+    assert_eq!(future.loop_policy.loop_yielded, 0);
+    assert_eq!(future.loop_policy.total_iterations, 0);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 3);
+    assert_eq!(future.count, 10);
+    assert_eq!(future.loop_policy.loop_entered, 3);
+    assert_eq!(future.loop_policy.loop_yielded, 0);
+    assert_eq!(future.loop_policy.total_iterations, 10);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 4);
+    assert_eq!(future.count, 30);
+    assert_eq!(future.loop_policy.loop_entered, 4);
+    assert_eq!(future.loop_policy.loop_yielded, 1);
+    assert_eq!(future.loop_policy.total_iterations, 30);
+    assert_eq!(future.loop_policy().average_iterations_per_loop(), Some(7.5));
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Pending);
+    assert_eq!(wake_count, 5);
+    assert_eq!(future.count, 31);
+    assert_eq!(future.loop_policy.loop_entered, 5);
+    assert_eq!(future.loop_policy.loop_yielded, 1);
+    assert_eq!(future.loop_policy.total_iterations, 31);
+    assert_eq!(future.as_mut().poll(&mut cx), Poll::Ready(31));
+    assert_eq!(wake_count, 5);
+    assert_eq!(future.loop_policy.loop_entered, 6);
+    assert_eq!(future.loop_policy.loop_yielded, 1);
+    assert_eq!(future.loop_policy.total_iterations, 31);
+}


### PR DESCRIPTION
Work to fix #1957 and provide a new macro for responsible polling.