### PR TITLE
Remove note about async-await feature not active by default

### DIFF
--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -14,7 +14,7 @@ macro_rules! document_join_macro {
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is
-        /// _not_ activated by default.
+        /// activated by default.
         ///
         /// # Examples
         ///
@@ -38,7 +38,7 @@ macro_rules! document_join_macro {
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is
-        /// _not_ activated by default.
+        /// activated by default.
         ///
         /// # Examples
         ///

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -11,7 +11,7 @@ use futures_core::task::{Context, Poll};
 ///
 /// This macro is only usable inside of async functions, closures, and blocks.
 /// It is also gated behind the `async-await` feature of this library, which is
-/// _not_ activated by default.
+/// activated by default.
 #[macro_export]
 macro_rules! pending {
     () => {

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -8,7 +8,7 @@ use futures_core::task::{Context, Poll};
 ///
 /// This macro is only usable inside of `async` functions, closures, and blocks.
 /// It is also gated behind the `async-await` feature of this library, which is
-/// _not_ activated by default.
+/// activated by default.
 #[macro_export]
 macro_rules! poll {
     ($x:expr $(,)?) => {

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -30,7 +30,7 @@ macro_rules! document_select_macro {
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is
-        /// _not_ activated by default.
+        /// activated by default.
         ///
         /// Note that `select!` relies on `proc-macro-hack`, and may require to set the
         /// compiler's recursion limit very high, e.g. `#![recursion_limit="1024"]`.
@@ -179,7 +179,7 @@ macro_rules! document_select_macro {
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is
-        /// _not_ activated by default.
+        /// activated by default.
         ///
         /// # Examples
         ///


### PR DESCRIPTION
The removed notes are no longer valid now that the `async-await` feature is enabled by default (https://github.com/rust-lang-nursery/futures-rs/pull/1953).