### PR TITLE
Add `IntoAsyncRead::into_inner()` method and test

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -45,7 +45,7 @@ pub use self::try_stream::{
 
 #[cfg(feature = "io")]
 #[cfg(feature = "std")]
-pub use self::try_stream::IntoAsyncRead;
+pub use self::try_stream::{IntoAsyncRead, IntoAsyncReadParts};
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]

--- a/futures-util/src/stream/try_stream/into_async_read.rs
+++ b/futures-util/src/stream/try_stream/into_async_read.rs
@@ -43,6 +43,20 @@ where
             state: ReadState::PendingChunk,
         }
     }
+
+    /// Return the underlying stream along with any stream elements that are currently buffered.
+    ///
+    /// Returns `(None, stream)` if no stream elements are currently buffered.
+    ///
+    /// Returns `(Some(element, offset), stream)` if an element is currently buffered, where
+    /// `offset` is the current offset into `element` that would have been read from next.
+    pub fn into_inner(self) -> (Option<(St::Ok, usize)>, St) {
+        match self.state {
+            ReadState::Ready { chunk, chunk_start } => (Some((chunk, chunk_start)), self.stream),
+            ReadState::PendingChunk => (None, self.stream),
+            ReadState::Eof => (None, self.stream),
+        }
+    }
 }
 
 impl<St> AsyncRead for IntoAsyncRead<St>

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -104,7 +104,7 @@ mod into_async_read;
 #[cfg(feature = "io")]
 #[cfg(feature = "std")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::into_async_read::IntoAsyncRead;
+pub use self::into_async_read::{IntoAsyncRead, IntoAsyncReadParts};
 
 impl<S: ?Sized + TryStream> TryStreamExt for S {}
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -488,7 +488,7 @@ pub mod stream {
     };
 
     #[cfg(feature = "std")]
-    pub use futures_util::stream::IntoAsyncRead;
+    pub use futures_util::stream::{IntoAsyncRead, IntoAsyncReadParts};
 }
 
 pub mod task {

--- a/futures/tests/stream_into_async_read.rs
+++ b/futures/tests/stream_into_async_read.rs
@@ -1,6 +1,7 @@
 use core::pin::Pin;
+use futures::future;
 use futures::io::{AsyncRead, AsyncBufRead};
-use futures::stream::{self, TryStreamExt};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::task::Poll;
 use futures_test::{task::noop_context, stream::StreamTestExt};
 
@@ -93,4 +94,53 @@ fn test_into_async_bufread() -> std::io::Result<()> {
     assert_fill_buf!(reader, &[][..]);
 
     Ok(())
+}
+
+#[test]
+fn test_into_async_read_into_inner() {
+    let stream = stream::iter((1..=3).flat_map(|_| vec![Ok(vec![]), Ok(vec![1, 2, 3, 4, 5])]));
+    let mut reader = stream.interleave_pending().into_async_read();
+    let mut buf = vec![0; 3];
+
+    assert_read!(reader, &mut buf, 3);
+    assert_eq!(&buf, &[1, 2, 3]);
+
+    // turn the reader into its inner parts, which we can inspect
+    let (first, rest) = reader.into_inner();
+    let (mut chunk, offset) = first.expect(".into_inner() called in the middle of a chunk");
+    assert_eq!(&chunk, &[1, 2, 3, 4, 5]);
+    assert_eq!(offset, 3);
+
+    // package the stream back up by splitting off the chunk according to the offset we got back
+    let stream = stream::once(future::ready(Ok(chunk.split_off(offset)))).chain(rest);
+    let mut reader = stream.into_async_read();
+
+    // resume reading as normal
+    assert_read!(reader, &mut buf, 2);
+    assert_eq!(&buf[..2], &[4, 5]);
+
+    assert_read!(reader, &mut buf, 3);
+    assert_eq!(&buf, &[1, 2, 3]);
+
+    assert_read!(reader, &mut buf, 2);
+    assert_eq!(&buf[..2], &[4, 5]);
+
+    // turn the reader into its inner parts again, this time on a chunk boundary
+    let (first, rest) = reader.into_inner();
+    assert!(first.is_none());
+
+    // package the stream back up and resume reading as normal
+    let mut reader = rest.into_async_read();
+
+    assert_read!(reader, &mut buf, 3);
+    assert_eq!(&buf, &[1, 2, 3]);
+
+    assert_read!(reader, &mut buf, 2);
+    assert_eq!(&buf[..2], &[4, 5]);
+
+    assert_read!(reader, &mut buf, 0);
+
+    // at the end of the stream, there should be no element buffered in the reader
+    let (first, _end) = reader.into_inner();
+    assert!(first.is_none());
 }


### PR DESCRIPTION
This is useful when you don't necessarily want to consume the entire stream as a reader, but still want to retain the stream for other uses.

~The nested tuple/`Option`/tuple is a bit awkward, but minimal. Do you think it'd be worth making a single-purpose enum to return here instead?~ For readability of code that calls this method, I added an enum.