### PR TITLE
Make AtomicWaker::new() a const fn

### DIFF
--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -197,7 +197,7 @@ const WAKING: usize = 0b10;
 
 impl AtomicWaker {
     /// Create an `AtomicWaker`.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         // Make sure that task is Sync
         trait AssertSync: Sync {}
         impl AssertSync for Waker {}


### PR DESCRIPTION
Allows doing `static FOO: AtomicWaker = AtomicWaker::new();`.