### PR TITLE
Clarify dropping behavior of RemoteHandle

### DIFF
--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -20,7 +20,8 @@ use {
 };
 
 /// The handle to a remote future returned by
-/// [`remote_handle`](crate::future::FutureExt::remote_handle).
+/// [`remote_handle`](crate::future::FutureExt::remote_handle). If you drop this,
+/// the remote future will be dropped __when it next get's polled__.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct RemoteHandle<T> {


### PR DESCRIPTION
It's quite surprising if you expect it to be dropped immediately, especially because it might just be Pending on something that no longer generates wakeups. I have had to select on a oneshot to avoid this problem.