### PR TITLE
`Peek` future for `Peekable` stream

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -14,8 +14,8 @@ pub use futures_core::stream::{FusedStream, Stream, TryStream};
 mod stream;
 pub use self::stream::{
     Chain, Collect, Concat, Enumerate, Filter, FilterMap, Flatten, Fold, ForEach, Fuse, Inspect,
-    Map, Next, Peekable, SelectNextSome, Skip, SkipWhile, StreamExt, StreamFuture, Take, TakeWhile,
-    Then, Zip,
+    Map, Next, Peek, Peekable, SelectNextSome, Skip, SkipWhile, StreamExt, StreamFuture, Take,
+    TakeWhile, Then, Zip,
 };
 
 #[cfg(feature = "std")]

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -88,7 +88,7 @@ pub use self::select_next_some::SelectNextSome;
 
 mod peek;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::peek::Peekable;
+pub use self::peek::{Peek, Peekable};
 
 mod skip;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -150,7 +150,7 @@ where
     delegate_sink!(stream, Item);
 }
 
-/// Future for the [`peek()`] function from [`Peekable`]
+/// Future for the [`Peekable::peek()`](self::Peekable::peek) function from [`Peekable`]
 #[must_use = "futures do nothing unless polled"]
 pub struct Peek<'a, St: Stream> {
     inner: Option<Pin<&'a mut Peekable<St>>>,

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -1,5 +1,6 @@
 use crate::future::Either;
 use crate::stream::{Fuse, StreamExt};
+use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
@@ -7,7 +8,6 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use pin_utils::{unsafe_pinned, unsafe_unpinned};
-use std::fmt;
 
 /// A `Stream` that implements a `peek` method.
 ///

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -66,30 +66,47 @@ impl<St: Stream> Peekable<St> {
         self.stream.into_inner()
     }
 
-    /// Peek retrieves a reference to the next item in the stream.
-    ///
-    /// This method polls the underlying stream and return either a reference
-    /// to the next item if the stream is ready or passes through any errors.
+    /// Produces a `Peek` future which retrieves a reference to the next item
+    /// in the stream, or `None` if the underlying stream terminates.
     pub fn peek(self: Pin<&mut Self>) -> Peek<'_, St> {
         Peek { inner: Some(self) }
     }
 
-    fn poll_peek(
+    /// Attempt to poll the underlying stream, and return the mutable borrow
+    /// in case that is desirable to try for another time.
+    /// In case a peeking poll is successful, the reference to the next item
+    /// will be in the `Either::Right` variant; otherwise, the mutable borrow
+    /// will be in the `Either::Left` variant.
+    fn do_poll_peek(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Either<Pin<&mut Self>, Poll<Option<&St::Item>>> {
+    ) -> Either<Pin<&mut Self>, Option<&St::Item>> {
         if self.peeked.is_some() {
             let this: &Self = self.into_ref().get_ref();
-            return Either::Right(Poll::Ready(this.peeked.as_ref()));
+            return Either::Right(this.peeked.as_ref());
         }
         match self.as_mut().stream().poll_next(cx) {
-            Poll::Ready(None) => Either::Right(Poll::Ready(None)),
+            Poll::Ready(None) => Either::Right(None),
             Poll::Ready(Some(item)) => {
                 *self.as_mut().peeked() = Some(item);
                 let this: &Self = self.into_ref().get_ref();
-                Either::Right(Poll::Ready(this.peeked.as_ref()))
+                Either::Right(this.peeked.as_ref())
             }
             _ => Either::Left(self),
+        }
+    }
+
+    /// Peek retrieves a reference to the next item in the stream.
+    ///
+    /// This method polls the underlying stream and return either a reference
+    /// to the next item if the stream is ready or passes through any errors.
+    pub fn poll_peek(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<&St::Item>> {
+        match self.do_poll_peek(cx) {
+            Either::Left(_) => Poll::Pending,
+            Either::Right(poll) => Poll::Ready(poll),
         }
     }
 }
@@ -141,9 +158,14 @@ pub struct Peek<'a, St: Stream> {
 
 impl<St: Stream> Unpin for Peek<'_, St> {}
 
-impl<St: Stream> fmt::Debug for Peek<'_, St> {
+impl<St> fmt::Debug for Peek<'_, St>
+where
+    St: Stream + fmt::Debug,
+    St::Item: fmt::Debug,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Peek")
+            .field("inner", &self.inner)
             .finish()
     }
 }
@@ -161,15 +183,15 @@ where
     type Output = Option<&'a St::Item>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if let Some(peekable) = self.inner.take() {
-            match peekable.poll_peek(cx) {
+            match peekable.do_poll_peek(cx) {
                 Either::Left(peekable) => {
                     self.inner = Some(peekable);
                     Poll::Pending
                 }
-                Either::Right(poll) => poll,
+                Either::Right(peek) => Poll::Ready(peek),
             }
         } else {
-            Poll::Pending
+            panic!("Peek polled after completion")
         }
     }
 }

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -444,7 +444,7 @@ pub mod stream {
         StreamExt,
         Chain, Collect, Concat, Enumerate, Filter, FilterMap, Flatten, Fold,
         Forward, ForEach, Fuse, StreamFuture, Inspect, Map, Next,
-        SelectNextSome, Peekable, Skip, SkipWhile, Take, TakeWhile,
+        SelectNextSome, Peek, Peekable, Skip, SkipWhile, Take, TakeWhile,
         Then, Zip,
 
         TryStreamExt,

--- a/futures/tests/stream_peekable.rs
+++ b/futures/tests/stream_peekable.rs
@@ -1,0 +1,13 @@
+use futures::executor::block_on;
+use futures::pin_mut;
+use futures::stream::{self, Peekable, StreamExt};
+
+#[test]
+fn peekable() {
+    block_on(async {
+        let peekable: Peekable<_> = stream::iter(vec![1u8, 2, 3]).peekable();
+        pin_mut!(peekable);
+        assert_eq!(peekable.as_mut().peek().await, Some(&1u8));
+        assert_eq!(peekable.collect::<Vec<u8>>().await, vec![1, 2, 3]);
+    });
+}


### PR DESCRIPTION
Fix #1871 

This pull request is an attempt to provide a sensible peeking behaviour for `Peekable` streams. Instead of exposing wires that resembles `poll` from `Future`, this construction wraps this exposure into a proper `Future`, with pinned borrow of the underlying `Peekable`. It works by swapping out the mutable borrow, attempting a poll, then either swapping the mutable borrow back in if `Pending`, or producing the `Poll` directly.

By the construction, `peek()` can be reinstated and the documentation becomes accurate again.