### PR TITLE
Allow unused crate warning for newer compilers

### DIFF
--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -10,6 +10,9 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-join-macro/0.3.0")]
 
+// Since https://github.com/rust-lang/cargo/pull/7700 `proc_macro` is part of the prelude for
+// proc-macro crates, but to support older compilers we still need this explicit `extern crate`.
+#[allow(unused_extern_crates)]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;


### PR DESCRIPTION
Current nightly adds `proc_macro` as an implicit dependency, making the `extern crate` redundant and warned against. Since we support older compilers as well we have to just suppress this warning in new compilers. Fixes CI failures.