### PR TITLE
Fix clippy issues in tests and add to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,13 @@ matrix:
           fi
       script:
         # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
-        - cargo hack --remove-dev-deps --all
+        - cargo hack --remove-dev-deps --workspace
         # Check no-default-features
-        - cargo hack check --all --exclude futures-test --ignore-private --no-default-features
+        - cargo hack check --workspace --exclude futures-test --ignore-private --no-default-features
         # Check alloc feature
-        - cargo hack check --all --exclude futures-test --ignore-private --no-default-features --features alloc --ignore-unknown-features
+        - cargo hack check --workspace --exclude futures-test --ignore-private --no-default-features --features alloc --ignore-unknown-features
         # Check std feature
-        - cargo hack check --all --ignore-private --no-default-features --features std --ignore-unknown-features
+        - cargo hack check --workspace --ignore-private --no-default-features --features std --ignore-unknown-features
         # Check compat feature (futures, futures-util)
         - cargo hack check -p futures -p futures-util --no-default-features --features std,io-compat
         # Check thread-pool feature (futures, futures-executor)
@@ -41,19 +41,19 @@ matrix:
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         # async-await feature is activated by default.
-        - cargo build --all
+        - cargo build --workspace
 
     - name: cargo +stable build
       rust: stable
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
-        - cargo build --all
+        - cargo build --workspace
 
     - name: cargo +beta build
       rust: beta
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
-        - cargo build --all
+        - cargo build --workspace
 
     - name: cargo test
       rust: nightly
@@ -68,7 +68,7 @@ matrix:
       script:
         - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         - cargo update -Zminimal-versions
-        - cargo build --all --all-features
+        - cargo build --workspace --all-features
 
     - name: cargo clippy
       rust: nightly
@@ -81,12 +81,12 @@ matrix:
             rustup component add clippy;
           fi
       script:
-        - cargo clippy --all --all-features --all-targets
+        - cargo clippy --workspace --all-features --all-targets
 
     - name: cargo bench
       rust: nightly
       script:
-        - cargo bench --all
+        - cargo bench --workspace
         - cargo bench --manifest-path futures-util/Cargo.toml --features=bilock,unstable
 
     - name: cargo build --target=thumbv6m-none-eabi
@@ -139,17 +139,17 @@ matrix:
         # * `--ignore-unknown-features` - some crates doesn't have 'unstable' feature
         - cargo hack check
             --each-feature --no-dev-deps
-            --all --exclude futures-test
+            --workspace --exclude futures-test
             --features unstable --ignore-unknown-features
 
     - name: cargo doc
       rust: nightly
       script:
-        - RUSTDOCFLAGS=-Dwarnings cargo doc --all --no-deps --all-features
+        - RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features
 
 script:
-  - cargo test --all --all-features
-  - cargo test --all --all-features --release
+  - cargo test --workspace --all-features
+  - cargo test --workspace --all-features --release
 
 env:
   - RUSTFLAGS=-Dwarnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ matrix:
             rustup component add clippy;
           fi
       script:
-        - cargo clippy --all --all-features
+        - cargo clippy --all --all-features --all-targets
 
     - name: cargo bench
       rust: nightly

--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -48,10 +48,10 @@ fn unbounded_100_tx(b: &mut Bencher) {
 
         // 1000 send/recv operations total, result should be divided by 1000
         for _ in 0..10 {
-            for i in 0..tx.len() {
+            for (i, x) in tx.iter().enumerate() {
                 assert_eq!(Poll::Pending, rx.poll_next_unpin(&mut cx));
 
-                UnboundedSender::unbounded_send(&tx[i], i).unwrap();
+                UnboundedSender::unbounded_send(x, i).unwrap();
 
                 assert_eq!(Poll::Ready(Some(i)), rx.poll_next_unpin(&mut cx));
             }
@@ -131,11 +131,11 @@ fn bounded_100_tx(b: &mut Bencher) {
         }).collect();
 
         for i in 0..10 {
-            for j in 0..tx.len() {
+            for x in &mut tx {
                 // Send an item
-                assert_eq!(Poll::Ready(Some(i + 1)), tx[j].poll_next_unpin(&mut cx));
+                assert_eq!(Poll::Ready(Some(i + 1)), x.poll_next_unpin(&mut cx));
                 // Then block
-                assert_eq!(Poll::Pending, tx[j].poll_next_unpin(&mut cx));
+                assert_eq!(Poll::Pending, x.poll_next_unpin(&mut cx));
                 // Recv the item
                 assert_eq!(Poll::Ready(Some(i + 1)), rx.poll_next_unpin(&mut cx));
             }

--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -16,7 +16,7 @@ fn sequence() {
     });
     let list: Vec<_> = block_on(rx.collect());
     let mut list = list.into_iter();
-    for i in (1..amt + 1).rev() {
+    for i in (1..=amt).rev() {
         assert_eq!(list.next(), Some(i));
     }
     assert_eq!(list.next(), None);

--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -13,7 +13,7 @@ fn smoke() {
     });
 
     // `receiver` needs to be dropped for `sender` to stop sending and therefore before the join.
-    drop(block_on(receiver.take(3).for_each(|_| futures::future::ready(()))));
+    block_on(receiver.take(3).for_each(|_| futures::future::ready(())));
 
     t.join().unwrap()
 }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -116,8 +116,6 @@ fn recv_close_gets_none() {
             Poll::Ready(Err(e)) => assert!(e.is_disconnected()),
         };
 
-        drop(&tx);
-
         Poll::Ready(())
     }));
 }
@@ -357,7 +355,7 @@ fn stress_close_receiver_iter() {
     let (unwritten_tx, unwritten_rx) = std::sync::mpsc::channel();
     let th = thread::spawn(move || {
         for i in 1.. {
-            if let Err(_) = tx.unbounded_send(i) {
+            if tx.unbounded_send(i).is_err() {
                 unwritten_tx.send(i).expect("unwritten_tx");
                 return;
             }
@@ -469,7 +467,7 @@ fn try_send_2() {
         block_on(tx.send("goodbye")).unwrap();
     });
 
-    drop(block_on(readyrx));
+    let _ = block_on(readyrx);
     assert_eq!(rx.next(), Some("hello"));
     assert_eq!(rx.next(), Some("goodbye"));
     assert_eq!(rx.next(), None);

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -28,7 +28,7 @@ fn cancel_notifies() {
     let (tx, rx) = oneshot::channel::<u32>();
 
     let t = thread::spawn(|| {
-        block_on(WaitForCancel { tx: tx });
+        block_on(WaitForCancel { tx });
     });
     drop(rx);
     t.join().unwrap();
@@ -99,7 +99,7 @@ fn close_wakes() {
         rx.close();
         rx2.recv().unwrap();
     });
-    block_on(WaitForCancel { tx: tx });
+    block_on(WaitForCancel { tx });
     tx2.send(()).unwrap();
     t.join().unwrap();
 }
@@ -126,7 +126,7 @@ fn cancel_sends() {
         tx.send(otx).unwrap();
 
         orx.close();
-        drop(block_on(orx));
+        let _ = block_on(orx);
     }
 
     drop(tx);

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -32,9 +32,8 @@ fn run_until_single_future() {
         let mut pool = LocalPool::new();
         let fut = lazy(|_| {
             cnt += 1;
-            ()
         });
-        assert_eq!(pool.run_until(fut), ());
+        pool.run_until(fut);
     }
 
     assert_eq!(cnt, 1);
@@ -45,7 +44,7 @@ fn run_until_ignores_spawned() {
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
     spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
-    assert_eq!(pool.run_until(lazy(|_| ())), ());
+    pool.run_until(lazy(|_| ()));
 }
 
 #[test]
@@ -55,7 +54,6 @@ fn run_until_executes_spawned() {
     let spawn = pool.spawner();
     spawn.spawn_local_obj(Box::pin(lazy(move |_| {
         tx.send(()).unwrap();
-        ()
     })).into()).unwrap();
     pool.run_until(rx).unwrap();
 }
@@ -79,9 +77,7 @@ fn run_executes_spawned() {
     spawn.spawn_local_obj(Box::pin(lazy(move |_| {
         spawn2.spawn_local_obj(Box::pin(lazy(move |_| {
             cnt2.set(cnt2.get() + 1);
-            ()
         })).into()).unwrap();
-        ()
     })).into()).unwrap();
 
     pool.run();
@@ -103,7 +99,6 @@ fn run_spawn_many() {
         let cnt = cnt.clone();
         spawn.spawn_local_obj(Box::pin(lazy(move |_| {
             cnt.set(cnt.get() + 1);
-            ()
         })).into()).unwrap();
     }
 
@@ -115,7 +110,7 @@ fn run_spawn_many() {
 #[test]
 fn try_run_one_returns_if_empty() {
     let mut pool = LocalPool::new();
-    assert!(pool.try_run_one() == false);
+    assert!(!pool.try_run_one());
 }
 
 #[test]
@@ -133,7 +128,6 @@ fn try_run_one_executes_one_ready() {
         let cnt = cnt.clone();
         spawn.spawn_local_obj(Box::pin(lazy(move |_| {
             cnt.set(cnt.get() + 1);
-            ()
         })).into()).unwrap();
 
         spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
@@ -144,7 +138,7 @@ fn try_run_one_executes_one_ready() {
         assert!(pool.try_run_one());
         assert_eq!(cnt.get(), i + 1);
     }
-    assert!(pool.try_run_one() == false);
+    assert!(!pool.try_run_one());
 }
 
 #[test]
@@ -270,7 +264,6 @@ fn run_until_stalled_executes_all_ready() {
             let cnt = cnt.clone();
             spawn.spawn_local_obj(Box::pin(lazy(move |_| {
                 cnt.set(cnt.get() + 1);
-                ()
             })).into()).unwrap();
 
             // also add some pending tasks to test if they are ignored
@@ -355,7 +348,7 @@ fn tasks_are_scheduled_fairly() {
     }).into()).unwrap();
 
     spawn.spawn_local_obj(Box::pin(Spin {
-        state: state,
+        state,
         idx: 1,
     }).into()).unwrap();
 

--- a/futures-macro/src/join.rs
+++ b/futures-macro/src/join.rs
@@ -152,6 +152,7 @@ pub(crate) fn try_join(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! { {
         #( #future_let_bindings )*
 
+        #[allow(clippy::diverging_sub_expression)]
         #futures_crate::future::poll_fn(move |__cx: &mut #futures_crate::task::Context<'_>| {
             let mut __all_done = true;
             #( #poll_futures )*

--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -10,6 +10,9 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-join-macro/0.3.0")]
 
+// Since https://github.com/rust-lang/cargo/pull/7700 `proc_macro` is part of the prelude for
+// proc-macro crates, but to support older compilers we still need this explicit `extern crate`.
+#[allow(unused_extern_crates)]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -284,11 +284,11 @@ async fn async_noop() {}
 #[test]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
     block_on(async {
-        let mut foo = 234;
+        let mut value = 234;
         select! {
-            x = require_mutable(&mut foo).fuse() => { },
+            x = require_mutable(&mut value).fuse() => { },
             y = async_noop().fuse() => {
-                foo += 5;
+                value += 5;
             },
         }
     });
@@ -297,14 +297,14 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
 #[test]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
     block_on(async {
-        let mut foo = 234;
+        let mut value = 234;
         select! {
-            x = require_mutable(&mut foo).fuse() => { },
+            x = require_mutable(&mut value).fuse() => { },
             y = async_noop().fuse() => {
-                foo += 5;
+                value += 5;
             },
             default => {
-                foo += 27;
+                value += 27;
             },
         }
     });

--- a/futures/tests/buffer_unordered.rs
+++ b/futures/tests/buffer_unordered.rs
@@ -15,7 +15,7 @@ fn works() {
     let (tx2, rx2) = std_mpsc::channel();
     let (tx3, rx3) = std_mpsc::channel();
     let t1 = thread::spawn(move || {
-        for _ in 0..N+1 {
+        for _ in 0..=N {
             let (mytx, myrx) = oneshot::channel();
             block_on(tx.send(myrx)).unwrap();
             tx3.send(mytx).unwrap();

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -126,7 +126,7 @@ fn test_buffered_reader_seek_underflow() {
     assert_eq!(block_on(reader.seek(SeekFrom::End(-5))).ok(), Some(u64::max_value()-5));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // the following seek will require two underlying seeks
-    let expected = 9223372036854775802;
+    let expected = 9_223_372_036_854_775_802;
     assert_eq!(block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), Some(expected));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // seeking to 0 should empty the buffer.

--- a/futures/tests/io_read_exact.rs
+++ b/futures/tests/io_read_exact.rs
@@ -3,7 +3,7 @@ use futures::io::AsyncReadExt;
 
 #[test]
 fn read_exact() {
-    let mut reader: &[u8] = &vec![1,2,3,4,5u8];
+    let mut reader: &[u8] = &[1, 2, 3, 4, 5];
     let mut out = [0u8; 3];
 
     let res = block_on(reader.read_exact(&mut out)); // read 3 bytes out

--- a/futures/tests/mutex.rs
+++ b/futures/tests/mutex.rs
@@ -61,7 +61,7 @@ fn mutex_contested() {
 
     block_on(async {
         for _ in 0..num_tasks {
-            let () = rx.next().await.unwrap();
+            rx.next().await.unwrap();
         }
         let lock = mutex.lock().await;
         assert_eq!(num_tasks, *lock);

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -128,8 +128,8 @@ fn stress() {
 
             rx.sort();
 
-            for num in 0..n {
-                assert_eq!(rx[num], num);
+            for (i, x) in rx.into_iter().enumerate() {
+                assert_eq!(i, x);
             }
 
             queue = sync.into_inner();

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -306,7 +306,7 @@ impl<T: Unpin> ManualFlush<T> {
 // but doesn't claim to be flushed until the underlying sink is
 #[test]
 fn with_flush_propagate() {
-    let mut sink = ManualFlush::new().with(|x| future::ok::<Option<i32>, ()>(x));
+    let mut sink = ManualFlush::new().with(future::ok::<Option<i32>, ()>);
     flag_cx(|flag, cx| {
         unwrap(Pin::new(&mut sink).poll_ready(cx));
         Pin::new(&mut sink).start_send(Some(0)).unwrap();


### PR DESCRIPTION
There were some "errors" detected with explicitly dropping `Copy` values (mostly I think to discard unchecked `Result`s), the rest is just minor stylistic cleanups that doesn't matter much, but still makes some tests a little more readable.