### PR TITLE
JoinAllFirstError: A combinator for an iterator of Result Futures

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -62,7 +62,7 @@ pub use self::join::{join, join3, join4, join5, Join, Join3, Join4, Join5};
 #[cfg(feature = "alloc")]
 mod join_all;
 #[cfg(feature = "alloc")]
-pub use self::join_all::{join_all, JoinAll};
+pub use self::join_all::{join_all, join_all_or_first_error, JoinAll, JoinAllFirstError};
 
 mod select;
 pub use self::select::{select, Select};


### PR DESCRIPTION
This function and future pair is very similar to `join_all` but works only on `std::future::Future`'s whose `type Output = Result<T, E>`.

The return value of this future is `Result<Vec<T>, E>` where the possible `Err(e)` is the first error that is encountered during the polling.