### PR TITLE
Remove impl Sync for FuturesUnordered

### DIFF
--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -67,7 +67,6 @@ pub struct FuturesUnordered<Fut> {
 }
 
 unsafe impl<Fut: Send> Send for FuturesUnordered<Fut> {}
-unsafe impl<Fut: Sync> Sync for FuturesUnordered<Fut> {}
 impl<Fut> Unpin for FuturesUnordered<Fut> {}
 
 impl Spawn for FuturesUnordered<FutureObj<'_, ()>> {


### PR DESCRIPTION
FuturesUnordered was previously modified to use interior mutability for
the len and head_all fields using Cell, but its Sync implementation was
left intact. This implementation is no longer valid, so it has been
removed.

Fixes #2050.