### PR TITLE
Allow in-place unwrapping of future::Ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.2 - 2020-??-??
+* Added `into_inner` method for `future::Ready` (#2055)
+
 # 0.3.1 - 2019-11-7
 * Fix signature of `LocalSpawn` trait (breaking change -- see #1959)
 
@@ -5,7 +8,7 @@
 * Stable release along with stable async/await!
 * Added async/await to default features (#1953)
 * Changed `Spawn` trait and `FuturesUnordered::push` to take `&self` (#1950)
-* Moved `Spawn` and `FutureObj` out of `futures-core` and into `futures-task (#1925)
+* Moved `Spawn` and `FutureObj` out of `futures-core` and into `futures-task` (#1925)
 * Changed case convention for feature names (#1937)
 * Added `executor` feature (#1949)
 * Moved `copy_into`/`copy_buf_into` (#1948)

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -7,6 +7,14 @@ use futures_core::task::{Context, Poll};
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Ready<T>(Option<T>);
 
+impl<T> Ready<T> {
+    /// Unwraps the value from this immediately ready future.
+    #[inline]
+    pub fn into_inner(mut self) -> T {
+        self.0.take().unwrap()
+    }
+}
+
 impl<T> Unpin for Ready<T> {}
 
 impl<T> FusedFuture for Ready<T> {
@@ -24,7 +32,7 @@ impl<T> Future for Ready<T> {
     }
 }
 
-/// Create a future that is immediately ready with a value.
+/// Creates a future that is immediately ready with a value.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR adds `into_inner` method for `future::Ready`.


## Motivation

Due to lack of supporting `async fn` or `impl Trait` in traits at the moment, there are a lot of situations we are made to introduce redundant boxing just for "things to work".

```rust
impl<T> SomeTrait for AnotherType<T> 
where 
    T: SomeTrait<Future = future::Ready<u8>> ,
{
    type Future = LocalBoxFuture<'static, u32>;

    fn do_some(&self) -> Self::Future {
        self.0.do_some().map(|v| u32::from(v) + 32).boxed_local()
    }
}
``` 

But if we know the concrete `Future`'s type being `future::Ready`, we could have been able to avoid this redundant boxing if we have direct access to the inner immediately ready value:
```rust
impl<T> SomeTrait for AnotherType<T> 
where 
    T: SomeTrait<Future = future::Ready<u8>> ,
{
    type Future = future::Ready<u32>;

    fn do_some(&self) -> Self::Future {
        future::ready(self.0.do_some().into_inner().into() + 32)
    }
}
```