### PR TITLE
Add MappedMutexGuard API

### DIFF
--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "std")]
 mod mutex;
 #[cfg(feature = "std")]
-pub use self::mutex::{Mutex, MutexLockFuture, MutexGuard};
+pub use self::mutex::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
 
 #[cfg(any(feature = "bilock", feature = "sink", feature = "io"))]
 #[cfg_attr(not(feature = "bilock"), allow(unreachable_pub))]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -349,7 +349,7 @@ pub mod lock {
     pub use futures_util::lock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
 
     #[cfg(feature = "std")]
-    pub use futures_util::lock::{Mutex, MutexLockFuture, MutexGuard};
+    pub use futures_util::lock::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
 }
 
 pub mod prelude {


### PR DESCRIPTION
MappedMutexGuard is used to map some locked data to a narrower
view of that data, while maintaining the lock in a new RAII wrapper.

This mirrors the same API in parking_lot.