### PR TITLE
Fix compatibility of futures-util with futures 0.3.1

### DIFF
--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -5,7 +5,8 @@ use proc_macro_hack::proc_macro_hack;
 #[doc(hidden)]
 #[macro_export]
 macro_rules! document_select_macro {
-    ($select:item $select_biased:item) => {
+    // This branch is required for `futures 0.3.1`, from before select_biased was introduced
+    ($select:item) => {
         /// Polls multiple futures and streams simultaneously, executing the branch
         /// for the future that finishes first. If multiple futures are ready,
         /// one will be pseudo-randomly selected at runtime. Futures directly
@@ -154,6 +155,10 @@ macro_rules! document_select_macro {
         /// more complex behavior such as timer resets or writing into the head of
         /// a stream.
         $select
+    };
+
+    ($select:item $select_biased:item) => {
+        $crate::document_select_macro!($select);
 
         /// Polls multiple futures and streams simultaneously, executing the branch
         /// for the future that finishes first. Unlike [`select!`], if multiple futures are ready,
@@ -302,7 +307,7 @@ macro_rules! document_select_macro {
         ///
         /// [`select!`]: macro.select.html
         $select_biased
-    }
+    };
 }
 
 document_select_macro! {


### PR DESCRIPTION
Fixes the compilation error noted in #2061. Tested by locally patching `futures 0.3.1` to use a path dependency on this `futures-util` and checking it built.