### PR TITLE
Add thread-pool feature for doc tests.

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -47,7 +47,7 @@ tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0-alpha.4"
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.4", features = ["async-await"] }
+futures = { path = "../futures", version = "0.3.4", features = ["async-await", "thread-pool"] }
 futures-test = { path = "../futures-test", version = "0.3.4" }
 tokio = "0.1.11"
 


### PR DESCRIPTION
The doc tests for futures-util require ThreadPool which is now behind a feature flag.