### PR TITLE
Fix/remote handle unwind safety

### DIFF
--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -107,7 +107,7 @@ impl<T> RemoteHandle<T> {
     }
 }
 
-impl<T: Send + 'static> Future for RemoteHandle<T> {
+impl<T: 'static> Future for RemoteHandle<T> {
     type Output = std::thread::Result<T>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -66,7 +66,7 @@ pub trait SpawnExt: Spawn {
     ///
     /// let future = future::ready(1);
     /// let join_handle_fut = executor.spawn_with_handle(future).unwrap();
-    /// assert_eq!(block_on(join_handle_fut), 1);
+    /// assert_eq!(block_on(join_handle_fut).expect("remote future doesn't panic"), 1);
     /// ```
     #[cfg(feature = "channel")]
     #[cfg(feature = "std")]
@@ -142,7 +142,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     ///
     /// let future = async { 1 };
     /// let join_handle_fut = spawner.spawn_local_with_handle(future).unwrap();
-    /// assert_eq!(executor.run_until(join_handle_fut), 1);
+    /// assert_eq!(executor.run_until(join_handle_fut).expect("remote future doesn't panic"), 1);
     /// ```
     #[cfg(feature = "channel")]
     #[cfg(feature = "std")]


### PR DESCRIPTION
closes #2077.

Please see detailed explanation in the commit messages.

This PR contains BREAKING CHANGES and version bumps are not included.