### PR TITLE
Remove the Send bound on the output type of RemoteHandle.

### DIFF
--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -39,7 +39,7 @@ impl<T> RemoteHandle<T> {
     }
 }
 
-impl<T: Send + 'static> Future for RemoteHandle<T> {
+impl<T: 'static> Future for RemoteHandle<T> {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {


### PR DESCRIPTION
Currently `Future` is only implemented for `RemoteHandle<T>` if `T: Send + 'static`

I think these bounds don't do anything useful, yet disable valid use cases
of the API. The compiler doesn't require them and I can find no good reason
for them to be there.

In particular if output is not `Send`, nor will the `Remote` or the `RemoteHandle`.
Nothing can move to other threads, and if the future panics, the thread will unwind.
Seems completely valid to allow that.

As for `'static`, I find it harder to imagine what all the possible consequences
might be, but I think it has no reason for being there. I feel less confident
to propose a PR to remove it than for `Send`, so I left it for now.

If others agree that it's fine to remove it I can update the PR. 

The risk is that if ever I'm mistaken and we need to re-add the bounds later, that
would be a breaking change.