### PR TITLE
util: Relax bounds for FuturesUnordered

### DIFF
--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -121,7 +121,13 @@ impl LocalSpawn for FuturesUnordered<LocalFutureObj<'_, ()>> {
 // notifiaction is received, the task will only be inserted into the ready to
 // run queue if it isn't inserted already.
 
-impl<Fut: Future> FuturesUnordered<Fut> {
+impl<Fut> Default for FuturesUnordered<Fut> {
+    fn default() -> FuturesUnordered<Fut> {
+        FuturesUnordered::new()
+    }
+}
+
+impl<Fut> FuturesUnordered<Fut> {
     /// Constructs a new, empty [`FuturesUnordered`].
     ///
     /// The returned [`FuturesUnordered`] does not contain any futures.
@@ -151,15 +157,7 @@ impl<Fut: Future> FuturesUnordered<Fut> {
             is_terminated: AtomicBool::new(false),
         }
     }
-}
 
-impl<Fut: Future> Default for FuturesUnordered<Fut> {
-    fn default() -> FuturesUnordered<Fut> {
-        FuturesUnordered::new()
-    }
-}
-
-impl<Fut> FuturesUnordered<Fut> {
     /// Returns the number of futures contained in the set.
     ///
     /// This represents the total number of in-flight futures.
@@ -607,7 +605,7 @@ impl<Fut> Drop for FuturesUnordered<Fut> {
     }
 }
 
-impl<Fut: Future> FromIterator<Fut> for FuturesUnordered<Fut> {
+impl<Fut> FromIterator<Fut> for FuturesUnordered<Fut> {
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = Fut>,


### PR DESCRIPTION
There is no need for the `FuturesUnordered` constructors to require that
the provided `Fut` type implements `Future`. It needlessly requires
callers to also propagate that bound onto their constructors, all the
way up the chain. This patch removes the bounds except where necessary,
specifically for the `impl Stream`.