### PR TITLE
Add a `Cancellation` utility to `oneshot::Sender`

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -358,6 +358,15 @@ impl<T> Sender<T> {
         self.inner.poll_canceled(cx)
     }
 
+    /// Creates a future that resolves when this `Sender`'s corresponding
+    /// [`Receiver`](Receiver) half has hung up.
+    ///
+    /// This is a utility wrapping [`poll_canceled`](Sender::poll_canceled)
+    /// to expose a `Future`. 
+    pub fn await_canceled(&mut self) -> AwaitCanceled<'_, T> {
+        AwaitCanceled { inner: self }
+    }
+
     /// Tests to see whether this `Sender`'s corresponding `Receiver`
     /// has been dropped.
     ///
@@ -372,6 +381,23 @@ impl<T> Sender<T> {
 impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         self.inner.drop_tx()
+    }
+}
+
+/// A future that resolves when the receiving end of a channel has hung up.
+///
+/// This is an `.await`-friendly interface around [`poll_canceled`](Sender::poll_canceled).
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug)]
+pub struct AwaitCanceled<'a, T> {
+    inner: &'a mut Sender<T>,
+}
+
+impl<T> Future for AwaitCanceled<'_, T> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        self.inner.poll_canceled(cx)
     }
 }
 

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -362,9 +362,9 @@ impl<T> Sender<T> {
     /// [`Receiver`](Receiver) half has hung up.
     ///
     /// This is a utility wrapping [`poll_canceled`](Sender::poll_canceled)
-    /// to expose a `Future`. 
-    pub fn await_canceled(&mut self) -> AwaitCanceled<'_, T> {
-        AwaitCanceled { inner: self }
+    /// to expose a [`Future`](core::future::Future). 
+    pub fn cancellation(&mut self) -> Cancellation<'_, T> {
+        Cancellation { inner: self }
     }
 
     /// Tests to see whether this `Sender`'s corresponding `Receiver`
@@ -389,11 +389,11 @@ impl<T> Drop for Sender<T> {
 /// This is an `.await`-friendly interface around [`poll_canceled`](Sender::poll_canceled).
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
-pub struct AwaitCanceled<'a, T> {
+pub struct Cancellation<'a, T> {
     inner: &'a mut Sender<T>,
 }
 
-impl<T> Future for AwaitCanceled<'_, T> {
+impl<T> Future for Cancellation<'_, T> {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -1,9 +1,8 @@
 use futures::channel::oneshot::{self, Sender};
 use futures::executor::block_on;
-use futures::future::{Future, FutureExt, poll_fn};
+use futures::future::{FutureExt, poll_fn};
 use futures::task::{Context, Poll};
 use futures_test::task::panic_waker_ref;
-use std::pin::Pin;
 use std::sync::mpsc;
 use std::thread;
 
@@ -32,18 +31,6 @@ fn cancel_notifies() {
     });
     drop(rx);
     t.join().unwrap();
-}
-
-struct WaitForCancel {
-    tx: Sender<u32>,
-}
-
-impl Future for WaitForCancel {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.tx.poll_canceled(cx)
-    }
 }
 
 #[test]

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -27,7 +27,7 @@ fn cancel_notifies() {
     let (mut tx, rx) = oneshot::channel::<u32>();
 
     let t = thread::spawn(move || {
-        block_on(tx.await_canceled());
+        block_on(tx.cancellation());
     });
     drop(rx);
     t.join().unwrap();
@@ -38,7 +38,7 @@ fn cancel_lots() {
     let (tx, rx) = mpsc::channel::<(Sender<_>, mpsc::Sender<_>)>();
     let t = thread::spawn(move || {
         for (mut tx, tx2) in rx {
-            block_on(tx.await_canceled());
+            block_on(tx.cancellation());
             tx2.send(()).unwrap();
         }
     });
@@ -86,7 +86,7 @@ fn close_wakes() {
         rx.close();
         rx2.recv().unwrap();
     });
-    block_on(tx.await_canceled());
+    block_on(tx.cancellation());
     tx2.send(()).unwrap();
     t.join().unwrap();
 }


### PR DESCRIPTION
This is a simple wrapper around the `poll_canceled` call, which is not `async/await` friendly. The primary motivation of this is to make writing code like this easier: 

```rust
let long_running_future = ...;
let mut my_sender = ...;

if let Either::Left(val) = future::select(
    long_running_future, 
    my_sender.cancellation(),
).await {
    let _ = my_sender.send(val);
} else {
    // the listener has dropped, so we can pre-emptively drop the long-running future.
}
```

Before this API, one either has to include this utility in their own codebase, or end up writing code which waits for the `long_running_future` to complete before attempting to send. This may be bad, because there are certain futures that may be incompletable but will never time out on their own.