### PR TITLE
Allow to configure the max size for unbounded queue

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -266,7 +266,7 @@ impl std::error::Error for TryRecvError {}
 #[derive(Debug)]
 struct UnboundedInner<T> {
     // Maximum number of items to buffer, if 0 is disabled
-    buffer: usize,
+    max_buffer: usize,
     // Internal channel state. Consists of the number of messages stored in the
     // channel as well as a flag signalling that the channel is closed.
     state: AtomicUsize,
@@ -414,11 +414,10 @@ pub fn unbounded<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
 /// the channel. Using an `unbounded` channel has the ability of causing the
 /// process to run out of memory. In this case, the process will be aborted.
 
-pub fn unbounded_max_buf<T>(buffer: usize) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
-    assert!(buffer < MAX_BUFFER, "requested buffer size too large");
+pub fn unbounded_max_buf<T>(max_buffer: usize) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
 
     let inner = Arc::new(UnboundedInner {
-        buffer,
+        max_buffer,
         state: AtomicUsize::new(INIT_STATE),
         message_queue: Queue::new(),
         num_senders: AtomicUsize::new(1),
@@ -841,7 +840,7 @@ impl<T> UnboundedSender<T> {
         if let Some(inner) = &self.0 {
             
             if let Some(num) = inner.inc_num_messages() {
-                if inner.inner.buffer > 0 && num > inner.inner.buffer {
+                if inner.inner.max_buffer > 0 && num > inner.inner.max_buffer {
                     return Err(TrySendError {
                         err: SendError {
                             kind: SendErrorKind::Full,

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -265,8 +265,6 @@ impl std::error::Error for TryRecvError {}
 
 #[derive(Debug)]
 struct UnboundedInner<T> {
-    // Maximum number of items to buffer, if 0 is disabled
-    max_buffer: usize,
     // Internal channel state. Consists of the number of messages stored in the
     // channel as well as a flag signalling that the channel is closed.
     state: AtomicUsize,
@@ -400,24 +398,8 @@ pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
 /// the channel. Using an `unbounded` channel has the ability of causing the
 /// process to run out of memory. In this case, the process will be aborted.
 pub fn unbounded<T>() -> (UnboundedSender<T>, UnboundedReceiver<T>) {
-    unbounded_max_buf(0)
-}
-
-/// Creates an unbounded mpsc channel for communicating between asynchronous
-/// tasks buffering a specific number of items.
-///
-/// A `send` on this channel will always succeed as long as the receive half has
-/// not been closed. If the receiver falls behind, messages will be buffered
-/// to the given count. Given `0` it is abirtrarily buffered.
-///
-/// **Note** that the amount of available system memory is an implicit bound to
-/// the channel. Using an `unbounded` channel has the ability of causing the
-/// process to run out of memory. In this case, the process will be aborted.
-
-pub fn unbounded_max_buf<T>(max_buffer: usize) -> (UnboundedSender<T>, UnboundedReceiver<T>) {
 
     let inner = Arc::new(UnboundedInner {
-        max_buffer,
         state: AtomicUsize::new(INIT_STATE),
         message_queue: Queue::new(),
         num_senders: AtomicUsize::new(1),
@@ -838,17 +820,7 @@ impl<T> UnboundedSender<T> {
     // Do the send without parking current task.
     fn do_send_nb(&self, msg: T) -> Result<(), TrySendError<T>> {
         if let Some(inner) = &self.0 {
-            
-            if let Some(num) = inner.inc_num_messages() {
-                if inner.inner.max_buffer > 0 && num > inner.inner.max_buffer {
-                    return Err(TrySendError {
-                        err: SendError {
-                            kind: SendErrorKind::Full,
-                        },
-                        val: msg,
-                    })
-
-                }
+            if inner.inc_num_messages().is_some() {
                 inner.queue_push_and_signal(msg);
                 return Ok(());
             }

--- a/futures-channel/src/mpsc/sink_impl.rs
+++ b/futures-channel/src/mpsc/sink_impl.rs
@@ -1,4 +1,4 @@
-use super::{SendError, Sender, TrySendError, UnboundedSender};
+use super::{SendError, Sender};
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
 use std::pin::Pin;
@@ -12,7 +12,7 @@ impl<T> Sink<T> for Sender<T> {
     ) -> Poll<Result<(), Self::Error>> {
         (*self).poll_ready(cx)
     }
-
+ 
     fn start_send(
         mut self: Pin<&mut Self>,
         msg: T,
@@ -38,70 +38,6 @@ impl<T> Sink<T> for Sender<T> {
         _: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         self.disconnect();
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl<T> Sink<T> for UnboundedSender<T> {
-    type Error = SendError;
-
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        UnboundedSender::poll_ready(&*self, cx)
-    }
-
-    fn start_send(
-        mut self: Pin<&mut Self>,
-        msg: T,
-    ) -> Result<(), Self::Error> {
-        UnboundedSender::start_send(&mut *self, msg)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(
-        mut self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        self.disconnect();
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl<T> Sink<T> for &UnboundedSender<T> {
-    type Error = SendError;
-
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        UnboundedSender::poll_ready(*self, cx)
-    }
-
-    fn start_send(self: Pin<&mut Self>, msg: T) -> Result<(), Self::Error> {
-        self.unbounded_send(msg)
-            .map_err(TrySendError::into_send_error)
-    }
-
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(
-        self: Pin<&mut Self>,
-        _: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
-        self.close_channel();
         Poll::Ready(Ok(()))
     }
 }

--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -69,7 +69,7 @@ fn multiple_senders_disconnect() {
 #[test]
 fn multiple_senders_close_channel() {
     {
-        let (mut tx1, mut rx) = mpsc::channel(1);
+        let (tx1, mut rx) = mpsc::channel(1);
         let mut tx2 = tx1.clone();
 
         // close_channel should shut down the whole channel


### PR DESCRIPTION
We are using the unbounded queue for its nice non-blocking behavior, but it being a potentially-endless sink for data and thus memory leaks, if the other end isn't polled properly makes it harder to reason about the code.

This adds a `buffer` parameter analogous as to the bounded channel to allow the user of the API to ensure the queue is never overflowing more than a predefined number of items.

Right now this just errors with `Full` if an attempt to `send` is made but the max number is reached. I am thinking about allowing to define other strategies, like dropping that new entry or dropping the first entry to create ring-queues – depending on the usage scenarios, these might be good coping strategies.