### PR TITLE
Stop using impl_trait_in_bindings feature in example

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -380,15 +380,13 @@ mod io {
         /// [`AsyncRead`](futures_io::AsyncRead).
         ///
         /// ```
-        /// #![feature(impl_trait_in_bindings)]
-        /// # #![allow(incomplete_features)]
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncReadExt;
         /// use futures_util::compat::AsyncRead01CompatExt;
         ///
         /// let input = b"Hello World!";
-        /// let reader: impl tokio_io::AsyncRead = std::io::Cursor::new(input);
-        /// let mut reader: impl futures::io::AsyncRead + Unpin = reader.compat();
+        /// let reader /* : impl tokio_io::AsyncRead */ = std::io::Cursor::new(input);
+        /// let mut reader /* : impl futures::io::AsyncRead + Unpin */ = reader.compat();
         ///
         /// let mut output = Vec::with_capacity(12);
         /// reader.read_to_end(&mut output).await.unwrap();


### PR DESCRIPTION
Just leave the type annotations in as comments, could be changed back once this feature is stabilised.

Fixes #2089.