### PR TITLE
futures: enable testing without --features thread-pool

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -25,11 +25,16 @@
 //! within macros and keywords such as async and await!.
 //!
 //! ```rust
+//! # #[cfg(features = "thread-pool")]
 //! # use futures::channel::mpsc;
+//! # #[cfg(features = "thread-pool")]
 //! # use futures::executor; ///standard executors to provide a context for futures and streams
+//! # #[cfg(features = "thread-pool")]
 //! # use futures::executor::ThreadPool;
+//! # #[cfg(features = "thread-pool")]
 //! # use futures::StreamExt;
 //!
+//! # #[cfg(features = "thread-pool")]
 //! fn main() {
 //!     let pool = ThreadPool::new().expect("Failed to build pool");
 //!     let (tx, rx) = mpsc::unbounded::<i32>();
@@ -73,6 +78,9 @@
 //!
 //!     println!("Values={:?}", values);
 //! }
+//!
+//! # #[cfg(not(features = "thread-pool"))]
+//! # fn main() { }
 //! ```
 //!
 //! The majority of examples and code snippets in this crate assume that they are

--- a/futures/tests/eventual.rs
+++ b/futures/tests/eventual.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "thread-pool")]
 use futures::channel::oneshot;
 use futures::executor::ThreadPool;
 use futures::future::{self, ok, Future, FutureExt, TryFutureExt};
@@ -9,7 +10,6 @@ fn run<F: Future + Send + 'static>(future: F) {
     let tp = ThreadPool::new().unwrap();
     tp.spawn(future.map(drop)).unwrap();
 }
-
 #[test]
 fn join1() {
     let (tx, rx) = mpsc::channel();

--- a/futures/tests/mutex.rs
+++ b/futures/tests/mutex.rs
@@ -1,11 +1,20 @@
+#[cfg(feature = "thread-pool")]
 use futures::channel::mpsc;
+#[cfg(feature = "thread-pool")]
 use futures::executor::block_on;
-use futures::future::{ready, FutureExt};
+#[cfg(feature = "thread-pool")]
+use futures::future::ready;
+use futures::future::FutureExt;
 use futures::lock::Mutex;
+#[cfg(feature = "thread-pool")]
 use futures::stream::StreamExt;
-use futures::task::{Context, SpawnExt};
+use futures::task::Context;
+#[cfg(feature = "thread-pool")]
+use futures::task::SpawnExt;
+#[cfg(feature = "thread-pool")]
 use futures_test::future::FutureTestExt;
 use futures_test::task::{new_count_waker, panic_context};
+#[cfg(feature = "thread-pool")]
 use std::sync::Arc;
 
 #[test]
@@ -34,6 +43,7 @@ fn mutex_wakes_waiters() {
     assert!(waiter.poll_unpin(&mut panic_context()).is_ready());
 }
 
+#[cfg(feature = "thread-pool")]
 #[test]
 fn mutex_contested() {
     let (tx, mut rx) = mpsc::unbounded();


### PR DESCRIPTION
As is, running `cargo test` in the futures root directory
fails, as some of the tests are dependent on this functionality.

* <code>src/lib.rs</code>: The doc tests are a little hairy in `src/lib.rs` due to
default warnings about unused import,  combined with warnings
being `deny()`'d

* <code>tests/eventual.rs</code>: This whole test suite needs this functionality
so the test suite is turned into "no code to see here" without this
feature.

* <code>tests/mutex.rs</code>: Only one test relies on this feature, but a lot
of `cfg()` modifiers are employed to keep warnings about unused imports
to a minimum.