### PR TITLE
future-utils: Avoid compile failures in tests w/o "std"

### DIFF
--- a/futures-util/src/future/try_future/try_chain.rs
+++ b/futures-util/src/future/try_future/try_chain.rs
@@ -79,17 +79,19 @@ impl<Fut1, Fut2, Data> TryChain<Fut1, Fut2, Data>
 
 #[cfg(test)]
 mod tests {
-    use std::pin::Pin;
-    use std::task::Poll;
 
-    use futures_test::task::noop_context;
-
-    use crate::future::ready;
-
-    use super::{TryChain, TryChainAction};
-
+    #[cfg(feature = "std")] // dont test with no_std
     #[test]
     fn try_chain_is_terminated() {
+        use std::pin::Pin;
+        use std::task::Poll;
+
+        use futures_test::task::noop_context;
+
+        use crate::future::ready;
+
+        use super::{TryChain, TryChainAction};
+
         let mut cx = noop_context();
 
         let mut future = TryChain::new(ready(Ok(1)), ());


### PR DESCRIPTION
This failure is not reproducable under the main futures workspace.

To replicate, one must first:
```
  future-utils/: cargo package
```
And then:
```
  cd "<prefix>/target/package/future-utils-0.3.4"
  cargo test --no-default-features
```
This patch remedies this issue by:

- Moving the imports required for this test into the test itself
- Gating the test so it only compiles when `--feature=std` (and thus,
  the `#[no_std]` in `lib.rs` doesn't activate)

This approach also future proofs the code somewhat and makes it
potentially easier to relocate to `tests/` one day.

Closes: https://github.com/rust-lang/futures-rs/issues/2102