### PR TITLE
Simpler selection futures

### DIFF
--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -7,7 +7,7 @@ use futures_sink::Sink;
 
 /// Combines two different futures, streams, or sinks having the same associated types into a single
 /// type.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Either<A, B> {
     /// First branch of the type
     Left(A),
@@ -280,10 +280,7 @@ mod if_std {
         A: AsyncBufRead,
         B: AsyncBufRead,
     {
-        fn poll_fill_buf(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<&[u8]>> {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
             unsafe {
                 match self.get_unchecked_mut() {
                     Either::Left(x) => Pin::new_unchecked(x).poll_fill_buf(cx),

--- a/futures-util/src/future/first.rs
+++ b/futures-util/src/future/first.rs
@@ -1,0 +1,84 @@
+use crate::future::Either;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::task::{Context, Poll};
+use pin_utils::unsafe_pinned;
+
+/// Future for the [`first()`] function.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug, Clone, Default)]
+pub struct First<F1, F2> {
+    future1: F1,
+    future2: F2,
+}
+
+impl<F1, F2> First<F1, F2> {
+    unsafe_pinned!(future1: F1);
+    unsafe_pinned!(future2: F2);
+}
+
+impl<F1: Future, F2: Future> Future for First<F1, F2> {
+    type Output = Either<F1::Output, F2::Output>;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.as_mut().future1().poll(cx) {
+            Poll::Ready(out) => Poll::Ready(Either::Left(out)),
+            Poll::Pending => match self.future2().poll(cx) {
+                Poll::Ready(out) => Poll::Ready(Either::Right(out)),
+                Poll::Pending => Poll::Pending,
+            },
+        }
+    }
+}
+
+impl<F1: FusedFuture, F2: FusedFuture> FusedFuture for First<F1, F2> {
+    #[inline]
+    fn is_terminated(&self) -> bool {
+        self.future1.is_terminated() || self.future2.is_terminated()
+    }
+}
+
+/// Waits for either one of two differently-typed futures to complete.
+///
+/// This function will return a new future which awaits for either one of both
+/// futures to complete. The returned future will finish with the value of
+/// whichever future finishes first.
+///
+/// The future will discard the future that didn't complete; see `select` for
+/// a future that will instead return the incomplete future.
+///
+/// Note that this function consumes the receiving futures and returns a
+/// wrapped version of them.
+///
+/// Also note that if both this and the second future have the same
+/// output type you can use the `Either::factor_first` method to
+/// conveniently extract out the value at the end.
+pub fn first<F1, F2>(future1: F1, future2: F2) -> First<F1, F2> {
+    First { future1, future2 }
+}
+
+#[test]
+fn test_first() {
+    use crate::future::{pending, ready, FutureExt};
+    use crate::task::noop_waker_ref;
+
+    let mut context = Context::from_waker(noop_waker_ref());
+
+    assert_eq!(
+        first(ready(10), ready(20)).poll_unpin(&mut context),
+        Poll::Ready(Either::Left(10))
+    );
+    assert_eq!(
+        first(ready(10), pending::<()>()).poll_unpin(&mut context),
+        Poll::Ready(Either::Left(10))
+    );
+    assert_eq!(
+        first(pending::<()>(), ready(20)).poll_unpin(&mut context),
+        Poll::Ready(Either::Right(20))
+    );
+    assert_eq!(
+        first(pending::<()>(), pending::<()>()).poll_unpin(&mut context),
+        Poll::Pending
+    );
+}

--- a/futures-util/src/future/first_all.rs
+++ b/futures-util/src/future/first_all.rs
@@ -1,0 +1,86 @@
+use core::iter::FromIterator;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::task::{Context, Poll};
+
+/// Future for the [`first_all()`] function.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug, Clone)]
+pub struct FirstAll<F> {
+    // Critical safety invariant: after FirstAll is created, this vector can
+    // never be reallocated, in order to ensure that Pin is upheld.
+    futures: Vec<F>,
+}
+
+// Safety: once created, the contents of the vector don't change, and they'll
+// remain in place permanently.
+impl<F> Unpin for FirstAll<F> {}
+
+impl<F: Future> Future for FirstAll<F> {
+    type Output = F::Output;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match this.futures.iter_mut().find_map(move |fut| {
+            // Safety: we promise that the future is never moved out of the vec,
+            // and that the vec never reallocates once FirstAll has been created
+            // (specifically after the first poll)
+            let pinned = unsafe { Pin::new_unchecked(fut) };
+            match pinned.poll(cx) {
+                Poll::Ready(out) => Some(out),
+                Poll::Pending => None,
+            }
+        }) {
+            Some(out) => {
+                // Safety: safe because vec clears in place
+                this.futures.clear();
+                Poll::Ready(out)
+            }
+            None => Poll::Pending,
+        }
+    }
+}
+
+impl<F: FusedFuture> FusedFuture for FirstAll<F> {
+    #[inline]
+    fn is_terminated(&self) -> bool {
+        // Logic: it's possible for a future to independently become
+        // terminated, before it returns Ready, so we're not terminated unless
+        // *all* of our inner futures are terminated. When our own poll returns
+        // Ready, this vector is cleared, so the logic works correctly.
+        self.futures.iter().all(|fut| fut.is_terminated())
+    }
+}
+
+impl<Fut: Future> FromIterator<Fut> for FirstAll<Fut> {
+    fn from_iter<T: IntoIterator<Item = Fut>>(iter: T) -> Self {
+        first_all(iter)
+    }
+}
+
+/// Creates a new future which will return the result of the first completed
+/// future out of a list.
+///
+/// The returned future will wait for any future within `futures` to be ready.
+/// Upon completion the item resolved will be returned.
+///
+/// The remaining futures will be discarded when the returned future is
+/// dropped; see `select_all` for a version that returns the incomplete
+/// futures if you need to poll over them further.
+///
+/// This function is only available when the `std` or `alloc` feature of this
+/// library is activated, and it is activated by default.
+///
+/// # Panics
+///
+/// This function will panic if the iterator specified contains no items.
+pub fn first_all<I>(futures: I) -> FirstAll<I::Item>
+where
+    I: IntoIterator,
+    I::Item: Future,
+{
+    let futures = Vec::from_iter(futures);
+    assert!(!futures.is_empty(), "Need at least 1 future for first_any");
+    FirstAll { futures }
+}

--- a/futures-util/src/future/first_ok.rs
+++ b/futures-util/src/future/first_ok.rs
@@ -1,0 +1,133 @@
+use core::iter::FromIterator;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::task::{Context, Poll};
+
+/// Future for the [`first_ok()`] function.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug, Clone)]
+pub struct FirstOk<F> {
+    // Critical safety invariant: after FirstAll is created, this vector can
+    // never be reallocated, nor can its contents be moved, in order to ensure
+    // that Pin is upheld.
+    futures: Vec<F>,
+}
+
+// Safety: once created, the contents of the vector don't change, and they'll
+// remain in place permanently.
+impl<F> Unpin for FirstOk<F> {}
+
+impl<F: FusedFuture + TryFuture> Future for FirstOk<F> {
+    type Output = Result<F::Ok, F::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Basic logic diagram:
+        // - If all existing futures are terminated, return Pending. This means
+        //   someone polled after this future returned ready, or that this
+        //   future will never return ready because a future spuriously
+        //   terminated itself.
+        // - If a future returns Ok, clear the vector (this is safe because
+        //   vec drops in place), then return that value. We clear the vector
+        //   so that our FusedFuture impl, which checks `are all futures
+        //   terminated`, works correctly.
+        // - If all existing futures BECOME terminated while polling them, and
+        //   an error was returned, return the final error; otherwise return
+        //   pending.
+
+        /// Helper enum to track our state as we poll each future
+        enum State<E> {
+            /// Haven't seen any errors
+            NoErrors,
+
+            /// The last error we've seen
+            SeenError(E),
+
+            /// At least 1 future is still pending; there's no need to
+            /// track errors
+            SeenPending,
+        }
+
+        use State::*;
+
+        impl<E> State<E> {
+            fn apply_error(&mut self, err: E) {
+                match self {
+                    SeenError(..) | NoErrors => *self = SeenError(err),
+                    SeenPending => {}
+                }
+            }
+
+            fn apply_pending(&mut self) {
+                *self = SeenPending;
+            }
+        }
+
+        let mut state = State::NoErrors;
+        let this = self.get_mut();
+        for fut in this.futures.iter_mut() {
+            if !fut.is_terminated() {
+                // Safety: we promise that the future is never moved out of the vec,
+                // and that the vec never reallocates once FirstOk has been created
+                // (specifically after the first poll)
+                let pinned = unsafe { Pin::new_unchecked(fut) };
+                match pinned.try_poll(cx) {
+                    Poll::Ready(Ok(out)) => {
+                        // Safety: safe because vec clears in place
+                        this.futures.clear();
+                        return Poll::Ready(Ok(out));
+                    }
+                    Poll::Ready(Err(err)) => state.apply_error(err),
+                    Poll::Pending => state.apply_pending(),
+                }
+            }
+        }
+
+        match state {
+            SeenError(err) => Poll::Ready(Err(err)),
+            NoErrors | SeenPending => Poll::Pending,
+        }
+    }
+}
+
+impl<F: FusedFuture + TryFuture> FusedFuture for FirstOk<F> {
+    #[inline]
+    fn is_terminated(&self) -> bool {
+        self.futures.iter().all(|fut| fut.is_terminated())
+    }
+}
+
+impl<Fut: FusedFuture + TryFuture> FromIterator<Fut> for FirstOk<Fut> {
+    fn from_iter<T: IntoIterator<Item = Fut>>(iter: T) -> Self {
+        first_ok(iter)
+    }
+}
+
+/// Creates a new future which will return the result of the first successful
+/// future in a list of futures.
+///
+/// The returned future will wait for any future within `iter` to be ready
+/// and Ok. Unlike `first_all`, this will only return the first successful
+/// completion, or the last error. This is useful in contexts where any success
+/// is desired and failures are ignored, unless all the futures fail.
+///
+/// `first_ok` requires [`FusedFuture`], in order to track which futures have
+/// completed with errors and which are still pending. Many futures already
+/// implement this trait, but you can also use [`FutureExt::fuse`] to turn
+/// any future into a fused future.
+///
+/// This function is only available when the `std` or `alloc` feature of this
+/// library is activated, and it is activated by default.
+///
+/// # Panics
+///
+/// This function will panic if the iterator specified contains no items.
+pub fn first_ok<I>(futures: I) -> FirstOk<I::Item>
+where
+    I: IntoIterator,
+    I::Item: FusedFuture + TryFuture,
+{
+    let futures = Vec::from_iter(futures);
+    assert!(!futures.is_empty(), "Need at least 1 future for first_ok");
+    FirstOk { futures }
+}

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -90,6 +90,19 @@ mod select_ok;
 #[cfg(feature = "alloc")]
 pub use self::select_ok::{select_ok, SelectOk};
 
+mod first;
+pub use self::first::{first, First};
+
+#[cfg(feature = "alloc")]
+mod first_all;
+#[cfg(feature = "alloc")]
+pub use first_all::{first_all, FirstAll};
+
+#[cfg(feature = "alloc")]
+mod first_ok;
+#[cfg(feature = "alloc")]
+pub use first_ok::{first_ok, FirstOk};
+
 mod either;
 pub use self::either::Either;
 

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -101,7 +101,7 @@ pub use first_all::{first_all, FirstAll};
 #[cfg(feature = "alloc")]
 mod first_ok;
 #[cfg(feature = "alloc")]
-pub use first_ok::{first_ok, FirstOk};
+pub use first_ok::{first_ok, first_ok_fused, FirstOk};
 
 mod either;
 pub use self::either::Either;


### PR DESCRIPTION
This pull request adds `first`, `first_all`, `first_ok`, and `first!`. These are selection functions, similar to the existing `select` and friends, which (unlike select) don't return the incomplete futures after finishing (simply discards them instead). This allows them to have implementations that are simpler, have less overhead, and do not require `Unpin` on their contents.

This pull request is in progress:

- [ ] `first!` macro
- [ ] Tests
    - [x] `first`
    - [ ] `first_all`
    - [ ] `first_ok`, `first_ok_fused`
    - [ ] `first!`
- [ ] Resolve issues related to `FusedIterator` (requires #2111)

Fixes #2031 and #2110 