### PR TITLE
Refactor StreamExt#forward type bounds

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1199,8 +1199,8 @@ pub trait StreamExt: Stream {
     #[cfg(feature = "sink")]
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
-        S: Sink<<Self as TryStream>::Ok>,
-        Self: TryStream<Error = S::Error> + Sized,
+        S: Sink<Self::Ok, Error = Self::Error>,
+        Self: TryStream + Sized,
     {
         Forward::new(self, sink)
     }


### PR DESCRIPTION
This makes the bounds easier to understand in documentation by removing bounds referring to each other.

Previously, the bounds in documentation appeared as such:

```rust
S: Sink<Self::Ok>,
Self: TryStream<Error = <S as Sink<Self::Ok>>::Error>,
```

This changes them to the following simpler to understand form.

```rust
S: Sink<Self::Ok, Error = Self::Error>,
Self: TryStream,
```