### PR TITLE
Support reexport for procedural macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ members = [
   "futures-util",
   "futures-test",
 
+  "futures/tests/macro-tests",
+  "futures/tests/macro-reexport",
+
   "examples/functional",
   "examples/imperative",
 ]

--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -35,12 +35,12 @@ pub fn try_join_internal(input: TokenStream) -> TokenStream {
 
 /// The `select!` macro.
 #[proc_macro_hack]
-pub fn select(input: TokenStream) -> TokenStream {
+pub fn select_internal(input: TokenStream) -> TokenStream {
     crate::select::select(input)
 }
 
 /// The `select_biased!` macro.
 #[proc_macro_hack]
-pub fn select_biased(input: TokenStream) -> TokenStream {
+pub fn select_biased_internal(input: TokenStream) -> TokenStream {
     crate::select::select_biased(input)
 }

--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -23,13 +23,13 @@ mod select;
 
 /// The `join!` macro.
 #[proc_macro_hack]
-pub fn join(input: TokenStream) -> TokenStream {
+pub fn join_internal(input: TokenStream) -> TokenStream {
     crate::join::join(input)
 }
 
 /// The `try_join!` macro.
 #[proc_macro_hack]
-pub fn try_join(input: TokenStream) -> TokenStream {
+pub fn try_join_internal(input: TokenStream) -> TokenStream {
     crate::join::try_join(input)
 }
 

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -2,8 +2,6 @@
 
 use proc_macro_hack::proc_macro_hack;
 
-#[doc(hidden)]
-#[macro_export]
 macro_rules! document_join_macro {
     ($join:item $try_join:item) => {
         /// Polls multiple futures simultaneously, returning a tuple
@@ -73,10 +71,32 @@ macro_rules! document_join_macro {
     }
 }
 
-document_join_macro! {
-    #[proc_macro_hack(support_nested)]
-    pub use futures_macro::join;
+#[doc(hidden)]
+#[proc_macro_hack(support_nested)]
+pub use futures_macro::join_internal;
 
-    #[proc_macro_hack(support_nested)]
-    pub use futures_macro::try_join;
+#[doc(hidden)]
+#[proc_macro_hack(support_nested)]
+pub use futures_macro::try_join_internal;
+
+document_join_macro! {
+    #[macro_export]
+    macro_rules! join {
+        ($($tokens:tt)*) => {{
+            use $crate::__reexport as __futures_crate;
+            $crate::join_internal! {
+                $( $tokens )*
+            }
+        }}
+    }
+
+    #[macro_export]
+    macro_rules! try_join {
+        ($($tokens:tt)*) => {{
+            use $crate::__reexport as __futures_crate;
+            $crate::try_join_internal! {
+                $( $tokens )*
+            }
+        }}
+    }
 }

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -2,8 +2,6 @@
 
 use proc_macro_hack::proc_macro_hack;
 
-#[doc(hidden)]
-#[macro_export]
 macro_rules! document_select_macro {
     // This branch is required for `futures 0.3.1`, from before select_biased was introduced
     ($select:item) => {
@@ -158,7 +156,7 @@ macro_rules! document_select_macro {
     };
 
     ($select:item $select_biased:item) => {
-        $crate::document_select_macro!($select);
+        document_select_macro!($select);
 
         /// Polls multiple futures and streams simultaneously, executing the branch
         /// for the future that finishes first. Unlike [`select!`], if multiple futures are ready,
@@ -310,11 +308,34 @@ macro_rules! document_select_macro {
     };
 }
 
+#[cfg(feature = "std")]
+#[doc(hidden)]
+#[proc_macro_hack(support_nested)]
+pub use futures_macro::select_internal;
+
+#[doc(hidden)]
+#[proc_macro_hack(support_nested)]
+pub use futures_macro::select_biased_internal;
+
 document_select_macro! {
     #[cfg(feature = "std")]
-    #[proc_macro_hack(support_nested)]
-    pub use futures_macro::select;
+    #[macro_export]
+    macro_rules! select {
+        ($($tokens:tt)*) => {{
+            use $crate::__reexport as __futures_crate;
+            $crate::select_internal! {
+                $( $tokens )*
+            }
+        }}
+    }
 
-    #[proc_macro_hack(support_nested)]
-    pub use futures_macro::select_biased;
+    #[macro_export]
+    macro_rules! select_biased {
+        ($($tokens:tt)*) => {{
+            use $crate::__reexport as __futures_crate;
+            $crate::select_biased_internal! {
+                $( $tokens )*
+            }
+        }}
+    }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -51,6 +51,14 @@ pub use self::async_await::*;
 #[doc(hidden)]
 pub use futures_core::core_reexport;
 
+// Not public API.
+#[cfg(feature = "async-await")]
+#[doc(hidden)]
+pub mod __reexport {
+    #[doc(hidden)]
+    pub use crate::*;
+}
+
 macro_rules! cfg_target_has_atomic {
     ($($item:item)*) => {$(
         #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -550,35 +550,13 @@ pub use futures_util::async_await;
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod inner_macro {
-    pub use futures_util::join;
-    pub use futures_util::try_join;
     #[cfg(feature = "std")]
     pub use futures_util::select;
     pub use futures_util::select_biased;
 }
 
 #[cfg(feature = "async-await")]
-futures_util::document_join_macro! {
-    #[macro_export]
-    macro_rules! join { // replace `::futures_util` with `::futures` as the crate path
-        ($($tokens:tt)*) => {
-            $crate::inner_macro::join! {
-                futures_crate_path ( ::futures )
-                $( $tokens )*
-            }
-        }
-    }
-
-    #[macro_export]
-    macro_rules! try_join { // replace `::futures_util` with `::futures` as the crate path
-        ($($tokens:tt)*) => {
-            $crate::inner_macro::try_join! {
-                futures_crate_path ( ::futures )
-                $( $tokens )*
-            }
-        }
-    }
-}
+pub use futures_util::{join, try_join};
 
 #[cfg(feature = "async-await")]
 futures_util::document_select_macro! {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -537,47 +537,10 @@ pub mod never {
 
 // proc-macro re-export --------------------------------------
 
-// Not public API.
-#[doc(hidden)]
-pub use futures_core::core_reexport;
-
-// Not public API.
-#[cfg(feature = "async-await")]
-#[doc(hidden)]
-pub use futures_util::async_await;
-
-// Not public API.
-#[cfg(feature = "async-await")]
-#[doc(hidden)]
-pub mod inner_macro {
-    #[cfg(feature = "std")]
-    pub use futures_util::select;
-    pub use futures_util::select_biased;
-}
-
 #[cfg(feature = "async-await")]
 pub use futures_util::{join, try_join};
-
+#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
-futures_util::document_select_macro! {
-    #[cfg(feature = "std")]
-    #[macro_export]
-    macro_rules! select { // replace `::futures_util` with `::futures` as the crate path
-        ($($tokens:tt)*) => {
-            $crate::inner_macro::select! {
-                futures_crate_path ( ::futures )
-                $( $tokens )*
-            }
-        }
-    }
-
-    #[macro_export]
-    macro_rules! select_biased { // replace `::futures_util` with `::futures` as the crate path
-        ($($tokens:tt)*) => {
-            $crate::inner_macro::select_biased! {
-                futures_crate_path ( ::futures )
-                $( $tokens )*
-            }
-        }
-    }
-}
+pub use futures_util::select;
+#[cfg(feature = "async-await")]
+pub use futures_util::select_biased;

--- a/futures/tests/macro-reexport/Cargo.toml
+++ b/futures/tests/macro-reexport/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "macro-reexport"
+version = "0.1.0"
+authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+futures03 = { path = "../..", package = "futures" }

--- a/futures/tests/macro-reexport/src/lib.rs
+++ b/futures/tests/macro-reexport/src/lib.rs
@@ -1,0 +1,5 @@
+// normal reexport
+pub use futures03::{join, try_join};
+
+// reexport + rename
+pub use futures03::{join as join2, try_join as try_join2};

--- a/futures/tests/macro-reexport/src/lib.rs
+++ b/futures/tests/macro-reexport/src/lib.rs
@@ -1,5 +1,8 @@
 // normal reexport
-pub use futures03::{join, try_join};
+pub use futures03::{join, try_join, select, select_biased};
 
 // reexport + rename
-pub use futures03::{join as join2, try_join as try_join2};
+pub use futures03::{
+    join as join2, try_join as try_join2,
+    select as select2, select_biased as select_biased2,
+};

--- a/futures/tests/macro-tests/Cargo.toml
+++ b/futures/tests/macro-tests/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "macro-tests"
+version = "0.1.0"
+authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+futures03 = { path = "../..", package = "futures" }
+macro-reexport = { path = "../macro-reexport" }

--- a/futures/tests/macro-tests/src/main.rs
+++ b/futures/tests/macro-tests/src/main.rs
@@ -1,7 +1,7 @@
 // Check that it works even if proc-macros are reexported.
 
 fn main() {
-    use futures03::executor::block_on;
+    use futures03::{executor::block_on, future};
 
     // join! macro
     let _ = block_on(async {
@@ -18,6 +18,52 @@ fn main() {
         Ok::<(), ()>(())
     });
 
-    // TODO: add select! and select_biased!
+    // select! macro
+    let _ = block_on(async {
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = futures03::select! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = macro_reexport::select! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = macro_reexport::select2! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+    });
+
+    // select_biased! macro
+    let _ = block_on(async {
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = futures03::select_biased! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = macro_reexport::select_biased! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+
+        let mut a = future::ready(());
+        let mut b = future::pending::<()>();
+        let _ = macro_reexport::select_biased2! {
+            _ = a => {},
+            _ = b => unreachable!(),
+        };
+    });
 
 }

--- a/futures/tests/macro-tests/src/main.rs
+++ b/futures/tests/macro-tests/src/main.rs
@@ -1,0 +1,23 @@
+// Check that it works even if proc-macros are reexported.
+
+fn main() {
+    use futures03::executor::block_on;
+
+    // join! macro
+    let _ = block_on(async {
+        let _ = futures03::join!(async {}, async {});
+        let _ = macro_reexport::join!(async {}, async {});
+        let _ = macro_reexport::join2!(async {}, async {});
+    });
+
+    // try_join! macro
+    let _ = block_on(async {
+        let _ = futures03::try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
+        let _ = macro_reexport::try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
+        let _ = macro_reexport::try_join2!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
+        Ok::<(), ()>(())
+    });
+
+    // TODO: add select! and select_biased!
+
+}


### PR DESCRIPTION
Create a hidden module that reexports all items in the crate and import it at the beginning of the wrapper macro. This allows supporting not only rename but also reexport.

```rust
#[doc(hidden)]
pub mod __reexport {
    #[doc(hidden)]
    pub use crate::*;
}

#[doc(hidden)]
#[proc_macro_hack(support_nested)]
pub use futures_macro::join_internal;

#[macro_export]
macro_rules! join {
    ($($tokens:tt)*) => {{
        // The code generated by proc-macro uses a path starting with `__futures_crate`.
        // Also, `use $crate;` in macro is not allowed (https://github.com/rust-lang/rust/issues/37390),
        // so create hidden module `__reexport`.
        use $crate::__reexport as __futures_crate;
        $crate::join_internal! {
            $( $tokens )*
        }
    }}
}
```

Note that proc-macro is renamed to `*_internal`.
IIRC, it is not expected to use futures-macro directly, so this is probably fine...
(Maybe using `=` requirements would help to avoid some problems like #2061.)

Closes #2099