### PR TITLE
Add `*_unpin` methods to `SinkExt`

### DIFF
--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -6,8 +6,10 @@
 //! This module is only available when the `sink` feature of this
 //! library is activated, and it is activated by default.
 
+use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{Stream, TryStream};
+use futures_core::task::{Context, Poll};
 use crate::future::Either;
 
 #[cfg(feature = "compat")]
@@ -260,5 +262,37 @@ pub trait SinkExt<Item>: Sink<Item> {
         where Self: Sized + Unpin,
     {
         CompatSink::new(self)
+    }
+    
+    /// A convenience method for calling [`Sink::poll_ready`] on [`Unpin`]
+    /// sink types.
+    fn poll_ready_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>
+        where Self: Unpin
+    {
+        Pin::new(self).poll_ready(cx)
+    }
+
+    /// A convenience method for calling [`Sink::start_send`] on [`Unpin`]
+    /// sink types.
+    fn start_send_unpin(&mut self, item: Item) -> Result<(), Self::Error>
+        where Self: Unpin
+    {
+        Pin::new(self).start_send(item)
+    }
+
+    /// A convenience method for calling [`Sink::poll_flush`] on [`Unpin`]
+    /// sink types.
+    fn poll_flush_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>
+        where Self: Unpin
+    {
+        Pin::new(self).poll_flush(cx)
+    }
+
+    /// A convenience method for calling [`Sink::poll_close`] on [`Unpin`]
+    /// sink types.
+    fn poll_close_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>
+        where Self: Unpin
+    {
+        Pin::new(self).poll_close(cx)
     }
 }


### PR DESCRIPTION
Added methods:
* `SinkExt::poll_ready_unpin`
* `SinkExt::start_send_unpin`
* `SinkExt::poll_flush_unpin`
* `SinkExt::poll_close_unpin`