### PR TITLE
impl AsyncRead/AsyncWrite for Arc<T>

### DIFF
--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -348,6 +348,7 @@ mod if_std {
         deref_async_read!();
     }
 
+    #[allow(single_use_lifetimes)] // FIXME: https://github.com/rust-lang/rust/issues/69952
     impl<T: ?Sized + Unpin> AsyncRead for Arc<T>
     where
         for<'a> &'a T: AsyncRead,
@@ -450,6 +451,7 @@ mod if_std {
         deref_async_write!();
     }
 
+    #[allow(single_use_lifetimes)] // FIXME: https://github.com/rust-lang/rust/issues/69952
     impl<T: ?Sized + Unpin> AsyncWrite for Arc<T>
     where
         for<'a> &'a T: AsyncWrite,

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -29,6 +29,7 @@ mod if_std {
     use std::io;
     use std::ops::DerefMut;
     use std::pin::Pin;
+    use std::sync::Arc;
     use std::task::{Context, Poll};
 
     // Re-export some types from `std::io` so that users don't have to deal
@@ -347,6 +348,28 @@ mod if_std {
         deref_async_read!();
     }
 
+    impl<T: ?Sized + Unpin> AsyncRead for Arc<T>
+    where
+        for<'a> &'a T: AsyncRead,
+    {
+        #[cfg(feature = "read-initializer")]
+        unsafe fn initializer(&self) -> Initializer {
+            (&**self).initializer()
+        }
+
+        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
+            -> Poll<Result<usize>>
+        {
+            Pin::new(&mut &**self).poll_read(cx, buf)
+        }
+
+        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
+            -> Poll<Result<usize>>
+        {
+            Pin::new(&mut &**self).poll_read_vectored(cx, bufs)
+        }
+    }
+
     impl<P> AsyncRead for Pin<P>
     where
         P: DerefMut + Unpin,
@@ -425,6 +448,31 @@ mod if_std {
 
     impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for &mut T {
         deref_async_write!();
+    }
+
+    impl<T: ?Sized + Unpin> AsyncWrite for Arc<T>
+    where
+        for<'a> &'a T: AsyncWrite,
+    {
+        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
+            -> Poll<Result<usize>>
+        {
+            Pin::new(&mut &**self).poll_write(cx, buf)
+        }
+
+        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
+            -> Poll<Result<usize>>
+        {
+            Pin::new(&mut &**self).poll_write_vectored(cx, bufs)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut &**self).poll_flush(cx)
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut &**self).poll_close(cx)
+        }
     }
 
     impl<P> AsyncWrite for Pin<P>


### PR DESCRIPTION
In `async-std` it is common to share I/O types by storing them inside an `Arc`. It would be nice then for `Arc<T>` to also be an I/O type by implementing `AsyncRead` and `AsyncWrite`. In fact, this is exactly why the `io-arc` crate was invented: https://docs.rs/io-arc/1.0.0/io_arc/

I'm now working on a new runtime where this pattern is pervasive and am also using a variant of `IoArc`. It would be nice for `futures` to add this impl instead.