### PR TITLE
Reduce pin related unsafe code

### DIFF
--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3.5", path = "../futures-util", default-features =
 futures-executor = { version = "0.3.5", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
-pin-project = "0.4.10"
+pin-project = "0.4.14"
 
 [dev-dependencies]
 futures = { version = "0.3.5", path = "../futures", default-features = false, features = ["std", "executor"] }

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3.5", path = "../futures-util", default-features =
 futures-executor = { version = "0.3.5", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
-pin-project = "0.4.14"
+pin-project = "0.4.15"
 
 [dev-dependencies]
 futures = { version = "0.3.5", path = "../futures", default-features = false, features = ["std", "executor"] }

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,6 +19,7 @@ futures-util = { version = "0.3.5", path = "../futures-util", default-features =
 futures-executor = { version = "0.3.5", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
+pin-project = "0.4.10"
 
 [dev-dependencies]
 futures = { version = "0.3.5", path = "../futures", default-features = false, features = ["std", "executor"] }

--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -1,7 +1,6 @@
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 use pin_project::{pin_project, pinned_drop};
-use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr;
 use std::thread::panicking;
@@ -9,15 +8,13 @@ use std::thread::panicking;
 /// Combinator for the
 /// [`FutureTestExt::assert_unmoved`](super::FutureTestExt::assert_unmoved)
 /// method.
-#[pin_project(PinnedDrop)]
+#[pin_project(PinnedDrop, !Unpin)]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct AssertUnmoved<Fut> {
     #[pin]
     future: Fut,
     this_ptr: *const AssertUnmoved<Fut>,
-    #[pin]
-    _pinned: PhantomPinned,
 }
 
 // Safety: having a raw pointer in a struct makes it `!Send`, however the
@@ -30,7 +27,6 @@ impl<Fut> AssertUnmoved<Fut> {
         Self {
             future,
             this_ptr: ptr::null(),
-            _pinned: PhantomPinned,
         }
     }
 }

--- a/futures-test/src/future/assert_unmoved.rs
+++ b/futures-test/src/future/assert_unmoved.rs
@@ -1,6 +1,6 @@
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::{pin_project, pinned_drop};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr;
@@ -9,11 +9,14 @@ use std::thread::panicking;
 /// Combinator for the
 /// [`FutureTestExt::assert_unmoved`](super::FutureTestExt::assert_unmoved)
 /// method.
+#[pin_project(PinnedDrop)]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct AssertUnmoved<Fut> {
+    #[pin]
     future: Fut,
     this_ptr: *const AssertUnmoved<Fut>,
+    #[pin]
     _pinned: PhantomPinned,
 }
 
@@ -23,9 +26,6 @@ unsafe impl<Fut: Send> Send for AssertUnmoved<Fut> {}
 unsafe impl<Fut: Sync> Sync for AssertUnmoved<Fut> {}
 
 impl<Fut> AssertUnmoved<Fut> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(this_ptr: *const Self);
-
     pub(super) fn new(future: Fut) -> Self {
         Self {
             future,
@@ -42,16 +42,17 @@ impl<Fut: Future> Future for AssertUnmoved<Fut> {
         let cur_this = &*self as *const Self;
         if self.this_ptr.is_null() {
             // First time being polled
-            *self.as_mut().this_ptr() = cur_this;
+            *self.as_mut().project().this_ptr = cur_this;
         } else {
             assert_eq!(self.this_ptr, cur_this, "Future moved between poll calls");
         }
-        self.as_mut().future().poll(cx)
+        self.project().future.poll(cx)
     }
 }
 
-impl<Fut> Drop for AssertUnmoved<Fut> {
-    fn drop(&mut self) {
+#[pinned_drop]
+impl<Fut> PinnedDrop for AssertUnmoved<Fut> {
+    fn drop(self: Pin<&mut Self>) {
         // If the thread is panicking then we can't panic again as that will
         // cause the process to be aborted.
         if !panicking() && !self.this_ptr.is_null() {

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -1,7 +1,7 @@
 use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{Context, Poll};
 use std::pin::Pin;
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::pin_project;
 
 /// Combinator that guarantees one [`Poll::Pending`] before polling its inner
 /// future.
@@ -9,17 +9,16 @@ use pin_utils::{unsafe_pinned, unsafe_unpinned};
 /// This is created by the
 /// [`FutureTestExt::pending_once`](super::FutureTestExt::pending_once)
 /// method.
+#[pin_project]
 #[derive(Debug, Clone)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct PendingOnce<Fut> {
+    #[pin]
     future: Fut,
     polled_before: bool,
 }
 
 impl<Fut: Future> PendingOnce<Fut> {
-    unsafe_pinned!(future: Fut);
-    unsafe_unpinned!(polled_before: bool);
-
     pub(super) fn new(future: Fut) -> Self {
         Self {
             future,
@@ -32,13 +31,14 @@ impl<Fut: Future> Future for PendingOnce<Fut> {
     type Output = Fut::Output;
 
     fn poll(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        if self.polled_before {
-            self.as_mut().future().poll(cx)
+        let this = self.project();
+        if *this.polled_before {
+            this.future.poll(cx)
         } else {
-            *self.as_mut().polled_before() = true;
+            *this.polled_before = true;
             cx.waker().wake_by_ref();
             Poll::Pending
         }

--- a/futures-test/src/interleave_pending.rs
+++ b/futures-test/src/interleave_pending.rs
@@ -1,7 +1,7 @@
 use futures_core::future::{Future, FusedFuture};
 use futures_core::stream::{Stream, FusedStream};
 use futures_io::{self as io, AsyncBufRead, AsyncRead, AsyncWrite};
-use pin_utils::{unsafe_pinned, unsafe_unpinned};
+use pin_project::pin_project;
 use std::{
     pin::Pin,
     task::{Context, Poll},
@@ -14,18 +14,15 @@ use std::{
 /// * [`StreamTestExt`](crate::stream::StreamTestExt::interleave_pending)
 /// * [`AsyncReadTestExt`](crate::io::AsyncReadTestExt::interleave_pending)
 /// * [`AsyncWriteTestExt`](crate::io::AsyncWriteTestExt::interleave_pending_write)
+#[pin_project]
 #[derive(Debug)]
 pub struct InterleavePending<T> {
+    #[pin]
     inner: T,
     pended: bool,
 }
 
-impl<T: Unpin> Unpin for InterleavePending<T> {}
-
 impl<T> InterleavePending<T> {
-    unsafe_pinned!(inner: T);
-    unsafe_unpinned!(pended: bool);
-
     pub(crate) fn new(inner: T) -> Self {
         Self {
             inner,
@@ -48,19 +45,12 @@ impl<T> InterleavePending<T> {
     /// Acquires a pinned mutable reference to the underlying I/O object that
     /// this adaptor is wrapping.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
-        self.project().0
+        self.project().inner
     }
 
     /// Consumes this adaptor returning the underlying I/O object.
     pub fn into_inner(self) -> T {
         self.inner
-    }
-
-    fn project(self: Pin<&mut Self>) -> (Pin<&mut T>, &mut bool) {
-        unsafe {
-            let this = self.get_unchecked_mut();
-            (Pin::new_unchecked(&mut this.inner), &mut this.pended)
-        }
     }
 }
 
@@ -68,18 +58,19 @@ impl<Fut: Future> Future for InterleavePending<Fut> {
     type Output = Fut::Output;
 
     fn poll(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        if *self.as_mut().pended() {
-            let next = self.as_mut().inner().poll(cx);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll(cx);
             if next.is_ready() {
-                *self.pended() = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *self.pended() = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -95,18 +86,19 @@ impl<St: Stream> Stream for InterleavePending<St> {
     type Item = St::Item;
 
     fn poll_next(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        if *self.as_mut().pended() {
-            let next = self.as_mut().inner().poll_next(cx);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_next(cx);
             if next.is_ready() {
-                *self.pended() = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *self.pended() = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -128,16 +120,16 @@ impl<W: AsyncWrite> AsyncWrite for InterleavePending<W> {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        let (writer, pended) = self.project();
-        if *pended {
-            let next = writer.poll_write(cx, buf);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_write(cx, buf);
             if next.is_ready() {
-                *pended = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *pended = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -146,16 +138,16 @@ impl<W: AsyncWrite> AsyncWrite for InterleavePending<W> {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<()>> {
-        let (writer, pended) = self.project();
-        if *pended {
-            let next = writer.poll_flush(cx);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_flush(cx);
             if next.is_ready() {
-                *pended = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *pended = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -164,16 +156,16 @@ impl<W: AsyncWrite> AsyncWrite for InterleavePending<W> {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<()>> {
-        let (writer, pended) = self.project();
-        if *pended {
-            let next = writer.poll_close(cx);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_close(cx);
             if next.is_ready() {
-                *pended = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *pended = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -185,16 +177,16 @@ impl<R: AsyncRead> AsyncRead for InterleavePending<R> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        let (reader, pended) = self.project();
-        if *pended {
-            let next = reader.poll_read(cx, buf);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_read(cx, buf);
             if next.is_ready() {
-                *pended = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *pended = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
@@ -205,21 +197,21 @@ impl<R: AsyncBufRead> AsyncBufRead for InterleavePending<R> {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<&[u8]>> {
-        let (reader, pended) = self.project();
-        if *pended {
-            let next = reader.poll_fill_buf(cx);
+        let this = self.project();
+        if *this.pended {
+            let next = this.inner.poll_fill_buf(cx);
             if next.is_ready() {
-                *pended = false;
+                *this.pended = false;
             }
             next
         } else {
             cx.waker().wake_by_ref();
-            *pended = true;
+            *this.pended = true;
             Poll::Pending
         }
     }
 
     fn consume(self: Pin<&mut Self>, amount: usize) {
-        self.inner().consume(amount)
+        self.project().inner.consume(amount)
     }
 }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "0.4.14"
+pin-project = "0.4.15"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.5", features = ["async-await", "thread-pool"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "0.4.10"
+pin-project = "0.4.14"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.5", features = ["async-await", "thread-pool"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "0.4.8"
+pin-project = "0.4.10"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.5", features = ["async-await", "thread-pool"] }

--- a/futures-util/src/fns.rs
+++ b/futures-util/src/fns.rs
@@ -140,6 +140,7 @@ trivial_fn_impls!(merge_result_fn <> MergeResultFn = "merge_result");
 #[derive(Debug, Copy, Clone, Default)]
 pub struct InspectFn<F>(F);
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> FnOnce1<A> for InspectFn<F>
 where
     F: for<'a> FnOnce1<&'a A, Output=()>,
@@ -150,6 +151,7 @@ where
         arg
     }
 }
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> FnMut1<A> for InspectFn<F>
 where
     F: for<'a> FnMut1<&'a A, Output=()>,
@@ -159,6 +161,7 @@ where
         arg
     }
 }
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> Fn1<A> for InspectFn<F>
 where
     F: for<'a> Fn1<&'a A, Output=()>,

--- a/futures-util/src/future/future/map.rs
+++ b/futures-util/src/future/future/map.rs
@@ -1,7 +1,7 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project, project_replace};
+use pin_project::{pin_project, project};
 
 use crate::fns::FnOnce1;
 
@@ -44,7 +44,6 @@ impl<Fut, F, T> Future for Map<Fut, F>
     type Output = T;
 
     #[project]
-    #[project_replace]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
         #[project]
         match self.as_mut().project() {

--- a/futures-util/src/future/future/map.rs
+++ b/futures-util/src/future/future/map.rs
@@ -1,13 +1,12 @@
 use core::pin::Pin;
-use core::ptr;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::{pin_project, project, project_replace};
 
 use crate::fns::FnOnce1;
 
 /// Internal Map future
-#[pin_project]
+#[pin_project(Replace)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub enum Map<Fut, F> {
@@ -17,17 +16,6 @@ pub enum Map<Fut, F> {
         f: F,
     },
     Complete,
-}
-
-// Helper type to mark a `Map` as complete without running its destructor.
-struct UnsafeMarkAsComplete<Fut, F>(*mut Map<Fut, F>);
-
-impl<Fut, F> Drop for UnsafeMarkAsComplete<Fut, F> {
-    fn drop(&mut self) {
-        unsafe {
-            ptr::write(self.0, Map::Complete);
-        }
-    }
 }
 
 impl<Fut, F> Map<Fut, F> {
@@ -56,34 +44,19 @@ impl<Fut, F, T> Future for Map<Fut, F>
     type Output = T;
 
     #[project]
+    #[project_replace]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        unsafe {
-            // Store this pointer for later...
-            let self_ptr: *mut Self = self.as_mut().get_unchecked_mut();
-            
-            match &mut *self_ptr {
-                Map::Incomplete { future, f } => {
-                    let mut future = Pin::new_unchecked(future);
-                    let output = match future.as_mut().poll(cx) {
-                        Poll::Ready(x) => x,
-                        Poll::Pending => return Poll::Pending,
-                    };
-    
-                    // Here be dragons
-                    let f = ptr::read(f);
-                    {
-                        // The ordering here is important, the call to `drop_in_place` must be
-                        // last as it may panic. Other lines must not panic.
-                        let _cleanup = UnsafeMarkAsComplete(self_ptr);
-                        ptr::drop_in_place(future.get_unchecked_mut());
-                    };
-
-                    // Phew, everything is back to normal, and we should be in the
-                    // `Complete` state!
-                    Poll::Ready(f.call_once(output))
-                },
-                Map::Complete => panic!("Map must not be polled after it returned `Poll::Ready`"),
-            }
+        #[project]
+        match self.as_mut().project() {
+            Map::Incomplete { future, .. } => {
+                let output = ready!(future.poll(cx));
+                #[project_replace]
+                match self.project_replace(Map::Complete) {
+                    Map::Incomplete { f, .. } => Poll::Ready(f.call_once(output)),
+                    Map::Complete => unreachable!(),
+                }
+            },
+            Map::Complete => panic!("Map must not be polled after it returned `Poll::Ready`"),
         }
     }
 }

--- a/futures-util/src/io/chain.rs
+++ b/futures-util/src/io/chain.rs
@@ -51,10 +51,8 @@ where
     /// underlying readers as doing so may corrupt the internal state of this
     /// `Chain`.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut T>, Pin<&mut U>) {
-        unsafe {
-            let Self { first, second, .. } = self.get_unchecked_mut();
-            (Pin::new_unchecked(first), Pin::new_unchecked(second))
-        }
+        let this = self.project();
+        (this.first, this.second)
     }
 
     /// Consumes the `Chain`, returning the wrapped readers.

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -7,6 +7,8 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+// It cannot be included in the published code because this lints have false positives in the minimum required version.
+#![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 
 // The solution for this lint is not available on 1.39 which is the current minimum supported version.
@@ -183,7 +185,7 @@ macro_rules! delegate_async_buf_read {
         ) -> core::task::Poll<std::io::Result<&[u8]>> {
             self.project().$field.poll_fill_buf(cx)
         }
-    
+
         fn consume(self: core::pin::Pin<&mut Self>, amt: usize) {
             self.project().$field.consume(amt)
         }

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -33,11 +33,9 @@ impl<Si1, Si2> Fanout<Si1, Si2> {
     }
 
     /// Get a pinned mutable reference to the inner sinks.
-    #[project]
     pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut Si1>, Pin<&mut Si2>) {
-        #[project]
-        let Fanout { sink1, sink2 } = self.project();
-        (sink1, sink2)
+        let this = self.project();
+        (this.sink1, this.sink2)
     }
 
     /// Consumes this combinator, returning the underlying sinks.

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -58,11 +58,9 @@ impl<St1, St2> Select<St1, St2> {
     ///
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
-    #[project]
     pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>) {
-        #[project]
-        let Select { stream1, stream2, .. } = self.project();
-        (stream1.get_pin_mut(), stream2.get_pin_mut())
+        let this = self.project();
+        (this.stream1.get_pin_mut(), this.stream2.get_pin_mut())
     }
 
     /// Consumes this combinator, returning the underlying streams.

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -37,6 +37,7 @@ where
     }
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<St, Fut, F> Filter<St, Fut, F>
 where St: Stream,
       F: for<'a> FnMut1<&'a St::Item, Output=Fut>,
@@ -64,6 +65,7 @@ impl<St, Fut, F> FusedStream for Filter<St, Fut, F>
     }
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<St, Fut, F> Stream for Filter<St, Fut, F>
     where St: Stream,
           F: for<'a> FnMut1<&'a St::Item, Output=Fut>,

--- a/futures-util/src/stream/stream/into_future.rs
+++ b/futures-util/src/stream/stream/into_future.rs
@@ -52,7 +52,7 @@ impl<St: Stream + Unpin> StreamFuture<St> {
     /// in order to return it to the caller of `Future::poll` if the stream yielded
     /// an element.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> Option<Pin<&mut St>> {
-        Pin::get_mut(self).stream.as_mut().map(Pin::new)
+        self.get_mut().stream.as_mut().map(Pin::new)
     }
 
     /// Consumes this combinator, returning the underlying stream.

--- a/futures-util/src/stream/stream/zip.rs
+++ b/futures-util/src/stream/stream/zip.rs
@@ -49,10 +49,8 @@ impl<St1: Stream, St2: Stream> Zip<St1, St2> {
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>) {
-        unsafe {
-            let Self { stream1, stream2, .. } = self.get_unchecked_mut();
-            (Pin::new_unchecked(stream1).get_pin_mut(), Pin::new_unchecked(stream2).get_pin_mut())
-        }
+        let this = self.project();
+        (this.stream1.get_pin_mut(), this.stream2.get_pin_mut())
     }
 
     /// Consumes this combinator, returning the underlying streams.

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,7 +33,7 @@ futures-executor = { path = "../futures-executor", version = "0.3.5", features =
 futures-test = { path = "../futures-test", version = "0.3.5" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
-pin-project = "0.4.14"
+pin-project = "0.4.15"
 
 [features]
 default = ["std", "async-await", "executor"]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,6 +33,7 @@ futures-executor = { path = "../futures-executor", version = "0.3.5", features =
 futures-test = { path = "../futures-test", version = "0.3.5" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
+pin-project = "0.4.10"
 
 [features]
 default = ["std", "async-await", "executor"]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,7 +33,7 @@ futures-executor = { path = "../futures-executor", version = "0.3.5", features =
 futures-test = { path = "../futures-test", version = "0.3.5" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
-pin-project = "0.4.10"
+pin-project = "0.4.14"
 
 [features]
 default = ["std", "async-await", "executor"]

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -43,25 +43,23 @@ fn map_err() {
 }
 
 mod channelled {
-    use pin_utils::unsafe_pinned;
     use futures::future::Future;
-    use std::pin::Pin;
     use futures::task::{Context,Poll};
+    use pin_project::pin_project;
+    use std::pin::Pin;
 
+    #[pin_project]
     struct FutureData<F, T> {
         _data: T,
+        #[pin]
         future: F,
-    }
-
-    impl<F, T> FutureData<F, T> {
-        unsafe_pinned!(future: F);
     }
 
     impl<F: Future, T: Send + 'static> Future for FutureData<F, T> {
         type Output = F::Output;
 
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
-            self.future().poll(cx)
+            self.project().future.poll(cx)
         }
     }
 


### PR DESCRIPTION
This removes many of the remaining pin related unsafe code in futures-util and futures-test.


r? @cramertj @Nemo157 