### PR TITLE
SinkExt::feed

### DIFF
--- a/futures-util/src/sink/feed.rs
+++ b/futures-util/src/sink/feed.rs
@@ -1,0 +1,49 @@
+use core::pin::Pin;
+use futures_core::future::Future;
+use futures_core::ready;
+use futures_core::task::{Context, Poll};
+use futures_sink::Sink;
+
+/// Future for the [`feed`](super::SinkExt::feed) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct Feed<'a, Si: ?Sized, Item> {
+    sink: &'a mut Si,
+    item: Option<Item>,
+}
+
+// Pinning is never projected to children
+impl<Si: Unpin + ?Sized, Item> Unpin for Feed<'_, Si, Item> {}
+
+impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Feed<'a, Si, Item> {
+    pub(super) fn new(sink: &'a mut Si, item: Item) -> Self {
+        Feed {
+            sink,
+            item: Some(item),
+        }
+    }
+
+    pub(super) fn sink_pin_mut(&mut self) -> Pin<&mut Si> {
+        Pin::new(self.sink)
+    }
+
+    pub(super) fn is_item_pending(&self) -> bool {
+        self.item.is_some()
+    }
+}
+
+impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Feed<'_, Si, Item> {
+    type Output = Result<(), Si::Error>;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let mut sink = Pin::new(&mut this.sink);
+        ready!(sink.as_mut().poll_ready(cx))?;
+        let item = this.item.take().expect("polled Feed after completion");
+        sink.as_mut().start_send(item)?;
+        Poll::Ready(Ok(()))
+    }
+}

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -1,3 +1,4 @@
+use super::Feed;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
@@ -8,8 +9,7 @@ use futures_sink::Sink;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Send<'a, Si: ?Sized, Item> {
-    sink: &'a mut Si,
-    item: Option<Item>,
+    feed: Feed<'a, Si, Item>,
 }
 
 // Pinning is never projected to children
@@ -18,8 +18,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Send<'_, Si, Item> {}
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Send<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si, item: Item) -> Self {
         Self {
-            sink,
-            item: Some(item),
+            feed: Feed::new(sink, item),
         }
     }
 }
@@ -32,20 +31,15 @@ impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Send<'_, Si, Item> {
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
         let this = &mut *self;
-        if let Some(item) = this.item.take() {
-            let mut sink = Pin::new(&mut this.sink);
-            match sink.as_mut().poll_ready(cx)? {
-                Poll::Ready(()) => sink.as_mut().start_send(item)?,
-                Poll::Pending => {
-                    this.item = Some(item);
-                    return Poll::Pending;
-                }
-            }
+
+        if this.feed.is_item_pending() {
+            ready!(Pin::new(&mut this.feed).poll(cx))?;
+            debug_assert!(!this.feed.is_item_pending());
         }
 
         // we're done sending the item, but want to block on flushing the
         // sink
-        ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
+        ready!(this.feed.sink_pin_mut().poll_flush(cx))?;
 
         Poll::Ready(Ok(()))
     }

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -417,7 +417,7 @@ pub mod sink {
     pub use futures_sink::Sink;
 
     pub use futures_util::sink::{
-        Close, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
+        Close, Feed, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
         SinkExt, Fanout, Drain, drain, Unfold, unfold,
         WithFlatMap,
     };


### PR DESCRIPTION
Add `SinkExt` methods `feed` ~and `feed_all`~. These are like `send` and `send_all`, except that the sink is not flushed at the end, allowing a sequence of output operations to be performed in async code without intermittent flushing. As a downside, the user is responsible for flushing or closing the sink to ensure completion.

Resolves #2059