### PR TITLE
Add oneshot::Sender::is_connected_to method

### DIFF
--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -377,6 +377,12 @@ impl<T> Sender<T> {
     pub fn is_canceled(&self) -> bool {
         self.inner.is_canceled()
     }
+
+    /// Tests to see whether this `Sender` is connected to the given `Receiver`. That is, whether
+    /// they were created by the same call to `channel`.
+    pub fn is_connected_to(&self, receiver: &Receiver<T>) -> bool {
+        Arc::ptr_eq(&self.inner, &receiver.inner)
+    }
 }
 
 impl<T> Drop for Sender<T> {


### PR DESCRIPTION
I was gonna open an issue asking for this, but it was trivial to implement so I figured I'd just go straight to a PR.

This adds a method to `oneshot::Sender` to check whether it's connected to a given `Receiver`:

```rust
/// Tests to see whether this `Sender` is connected to the given `Receiver`. That is, whether
/// they were created by the same call to `channel`.
pub fn is_connected_to(&self, receiver: &Receiver<T>) -> bool {
    Arc::ptr_eq(&self.inner, &receiver.inner)
}
```

Does this seem like a good idea? It would be useful for me.