### PR TITLE
Add doc feature flags.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ matrix:
       rust: nightly
       script:
         # TODO: Remove -Aunused_braces once https://github.com/rust-lang/rust/issues/70814 is fixed
-        - RUSTDOCFLAGS="-Dwarnings -Aunused_braces" cargo doc --workspace --no-deps --all-features
+        - RUSTDOCFLAGS="-Dwarnings -Aunused_braces --cfg docsrs" cargo doc --workspace --no-deps --all-features
 
 script:
   - cargo test --workspace --all-features

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -33,3 +33,4 @@ futures-test = { path = "../futures-test", version = "0.3.5", default-features =
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -29,3 +29,4 @@ futures = { path = "../futures", version = "0.3.5" }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -27,3 +27,4 @@ futures = { path = "../futures", version = "0.3.5" }
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-executor/0.3.5")]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
@@ -23,9 +25,11 @@ pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool
 #[cfg(feature = "std")]
 mod unpark_mutex;
 #[cfg(feature = "thread-pool")]
+#[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]
 mod thread_pool;
 #[cfg(feature = "thread-pool")]
+#[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]
 pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -24,6 +24,7 @@ use std::thread;
 ///
 /// This type is only available when the `thread-pool` feature of this
 /// library is activated.
+#[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 pub struct ThreadPool {
     state: Arc<PoolState>,
 }
@@ -32,6 +33,7 @@ pub struct ThreadPool {
 ///
 /// This type is only available when the `thread-pool` feature of this
 /// library is activated.
+#[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 pub struct ThreadPoolBuilder {
     pool_size: usize,
     stack_size: usize,

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -25,3 +25,4 @@ read-initializer = []
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -21,6 +21,8 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-io/0.3.5")]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
 compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
@@ -44,6 +46,7 @@ mod if_std {
     };
 
     #[cfg(feature = "read-initializer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
     pub use io::Initializer as Initializer;
 
@@ -70,6 +73,7 @@ mod if_std {
         /// return a non-zeroing `Initializer` from another `AsyncRead` type
         /// without an `unsafe` block.
         #[cfg(feature = "read-initializer")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
         #[inline]
         unsafe fn initializer(&self) -> Initializer {
             Initializer::zeroing()

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -55,3 +55,4 @@ tokio = "0.1.11"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -15,6 +15,7 @@ use std::task::Context;
 use futures_sink::Sink as Sink03;
 
 #[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use io::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 
@@ -115,6 +116,7 @@ impl<St: Stream01> Stream01CompatExt for St {}
 
 /// Extension trait for futures 0.1 [`Sink`](futures_01::sink::Sink)
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub trait Sink01CompatExt: Sink01 {
     /// Converts a futures 0.1
     /// [`Sink<SinkItem = T, SinkError = E>`](futures_01::sink::Sink)
@@ -180,6 +182,7 @@ impl<St: Stream01> Stream03 for Compat01As03<St> {
 
 /// Converts a futures 0.1 Sink object to a futures 0.3-compatible version
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct Compat01As03Sink<S, SinkItem> {
@@ -366,6 +369,7 @@ unsafe impl UnsafeNotify01 for NotifyWaker {
 }
 
 #[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
 mod io {
     use super::*;
     #[cfg(feature = "read-initializer")]
@@ -375,6 +379,7 @@ mod io {
     use tokio_io::{AsyncRead as AsyncRead01, AsyncWrite as AsyncWrite01};
 
     /// Extension trait for tokio-io [`AsyncRead`](tokio_io::AsyncRead)
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
     pub trait AsyncRead01CompatExt: AsyncRead01 {
         /// Converts a tokio-io [`AsyncRead`](tokio_io::AsyncRead) into a futures-io 0.3
         /// [`AsyncRead`](futures_io::AsyncRead).
@@ -403,6 +408,7 @@ mod io {
     impl<R: AsyncRead01> AsyncRead01CompatExt for R {}
 
     /// Extension trait for tokio-io [`AsyncWrite`](tokio_io::AsyncWrite)
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
     pub trait AsyncWrite01CompatExt: AsyncWrite01 {
         /// Converts a tokio-io [`AsyncWrite`](tokio_io::AsyncWrite) into a futures-io 0.3
         /// [`AsyncWrite`](futures_io::AsyncWrite).

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -40,6 +40,7 @@ pub struct Compat<T> {
 /// Converts a futures 0.3 [`Sink`](futures_sink::Sink) into a futures 0.1
 /// [`Sink`](futures_01::sink::Sink).
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
 pub struct CompatSink<T, Item> {
@@ -236,6 +237,7 @@ where
 }
 
 #[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
 mod io {
     use super::*;
     use futures_io::{AsyncRead as AsyncRead03, AsyncWrite as AsyncWrite03};

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -9,11 +9,14 @@ pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
 mod compat01as03;
 pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt};
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::compat01as03::{Compat01As03Sink, Sink01CompatExt};
 #[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
 pub use self::compat01as03::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::compat03as01::CompatSink;

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -100,9 +100,11 @@ mod catch_unwind;
 pub use self::catch_unwind::CatchUnwind;
 
 #[cfg(feature = "channel")]
+#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 #[cfg(feature = "std")]
 mod remote_handle;
 #[cfg(feature = "channel")]
+#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 #[cfg(feature = "std")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::remote_handle::{Remote, RemoteHandle};
@@ -495,6 +497,7 @@ pub trait FutureExt: Future {
     /// This method is only available when the `std` feature of this
     /// library is activated, and it is activated by default.
     #[cfg(feature = "channel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
     #[cfg(feature = "std")]
     fn remote_handle(self) -> (Remote<Self>, RemoteHandle<Self::Output>)
     where

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -37,6 +37,7 @@ use {
 /// will unwind.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 pub struct RemoteHandle<T> {
     rx: Receiver<thread::Result<T>>,
     keep_running: Arc<AtomicBool>,
@@ -72,6 +73,7 @@ type SendMsg<Fut> = Result<<Fut as Future>::Output, Box<(dyn Any + Send + 'stati
 /// Created by [`remote_handle`](crate::future::FutureExt::remote_handle).
 #[pin_project]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
+#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 pub struct Remote<Fut: Future> {
     tx: Option<Sender<SendMsg<Fut>>>,
     keep_running: Arc<AtomicBool>,

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -23,6 +23,7 @@ pub use self::future::FlattenStream;
 pub use self::future::CatchUnwind;
 
 #[cfg(feature = "channel")]
+#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
 #[cfg(feature = "std")]
 pub use self::future::{Remote, RemoteHandle};
 
@@ -36,6 +37,7 @@ pub use self::try_future::{
 };
 
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::try_future::FlattenSink;
 
 // Primitive futures

--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -52,6 +52,7 @@ delegate_all!(
 #[cfg(feature = "sink")]
 delegate_all!(
     /// Sink for the [`flatten_sink`](TryFutureExt::flatten_sink) method.
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     FlattenSink<Fut, Si>(
         try_flatten::TryFlatten<Fut, Si>
     ): Debug + Sink + Stream + FusedStream + New[|x: Fut| try_flatten::TryFlatten::new(x)]
@@ -166,6 +167,7 @@ pub trait TryFutureExt: TryFuture {
     /// take_sink(fut.flatten_sink())
     /// ```
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     fn flatten_sink<Item>(self) -> FlattenSink<Self, Self::Ok>
     where
         Self::Ok: Sink<Item, Error = Self::Error>,
@@ -568,6 +570,7 @@ pub trait TryFutureExt: TryFuture {
     /// Wraps a [`TryFuture`] into a future compatable with libraries using
     /// futures 0.1 future definitons. Requires the `compat` feature to enable.
     #[cfg(feature = "compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
     fn compat(self) -> Compat<Self>
     where
         Self: Sized + Unpin,

--- a/futures-util/src/io/into_sink.rs
+++ b/futures-util/src/io/into_sink.rs
@@ -15,6 +15,7 @@ struct Block<Item> {
 #[pin_project]
 #[must_use = "sinks do nothing unless polled"]
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub struct IntoSink<W, Item> {
     #[pin]
     writer: W,

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -10,6 +10,7 @@
 //! library is activated, and it is activated by default.
 
 #[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
 use crate::compat::Compat;
 use std::ptr;
 
@@ -18,6 +19,7 @@ pub use futures_io::{
     IoSlice, IoSliceMut, Result, SeekFrom,
 };
 #[cfg(feature = "read-initializer")]
+#[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
 pub use futures_io::Initializer;
 
 // used by `BufReader` and `BufWriter`
@@ -69,8 +71,10 @@ mod flush;
 pub use self::flush::Flush;
 
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 mod into_sink;
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::into_sink::IntoSink;
 
 mod lines;
@@ -372,6 +376,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// Requires the `io-compat` feature to enable.
     #[cfg(feature = "io-compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
     fn compat(self) -> Compat<Self>
         where Self: Sized + Unpin,
     {
@@ -523,6 +528,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// used as a futures 0.1 / tokio-io 0.1 `AsyncWrite`.
     /// Requires the `io-compat` feature to enable.
     #[cfg(feature = "io-compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
     fn compat_write(self) -> Compat<Self>
         where Self: Sized + Unpin,
     {
@@ -556,6 +562,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     fn into_sink<Item: AsRef<[u8]>>(self) -> IntoSink<Self, Item>
         where Self: Sized,
     {

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -20,6 +20,8 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-util/0.3.5")]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
@@ -310,6 +312,7 @@ pub mod stream;
 #[doc(hidden)] pub use crate::stream::{StreamExt, TryStreamExt};
 
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub mod sink;
 #[cfg(feature = "sink")]
 #[doc(hidden)] pub use crate::sink::SinkExt;
@@ -319,9 +322,11 @@ pub mod task;
 pub mod never;
 
 #[cfg(feature = "compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
 pub mod compat;
 
 #[cfg(feature = "io")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 #[cfg(feature = "std")]
 pub mod io;
 #[cfg(feature = "io")]

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -34,6 +34,7 @@ use alloc::sync::Arc;
 /// This type is only available when the `bilock` feature of this
 /// library is activated.
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 pub struct BiLock<T> {
     arc: Arc<Inner<T>>,
 }
@@ -142,6 +143,7 @@ impl<T> BiLock<T> {
     ///
     /// Note that the returned future will never resolve to an error.
     #[cfg(feature = "bilock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
     pub fn lock(&self) -> BiLockAcquire<'_, T> {
         BiLockAcquire {
             bilock: self,
@@ -198,6 +200,7 @@ impl<T> Drop for Inner<T> {
 
 /// Error indicating two `BiLock<T>`s were not two halves of a whole, and
 /// thus could not be `reunite`d.
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 pub struct ReuniteError<T>(pub BiLock<T>, pub BiLock<T>);
 
 impl<T> fmt::Debug for ReuniteError<T> {
@@ -223,6 +226,7 @@ impl<T: core::any::Any> std::error::Error for ReuniteError<T> {}
 /// implementing `Deref` and `DerefMut` to `T`. When dropped, the lock will be
 /// unlocked.
 #[derive(Debug)]
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 pub struct BiLockGuard<'a, T> {
     bilock: &'a BiLock<T>,
 }
@@ -258,6 +262,7 @@ impl<T> Drop for BiLockGuard<'_, T> {
 /// Future returned by `BiLock::lock` which will resolve when the lock is
 /// acquired.
 #[cfg(feature = "bilock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug)]
 pub struct BiLockAcquire<'a, T> {

--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -9,9 +9,11 @@ mod mutex;
 pub use self::mutex::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
 
 #[cfg(any(feature = "bilock", feature = "sink", feature = "io"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 #[cfg_attr(not(feature = "bilock"), allow(unreachable_pub))]
 mod bilock;
 #[cfg(feature = "bilock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
 #[cfg(any(feature = "sink", feature = "io"))]
 #[cfg(not(feature = "bilock"))]

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -258,6 +258,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// Wraps a [`Sink`] into a sink compatible with libraries using
     /// futures 0.1 `Sink`. Requires the `compat` feature to be enabled.
     #[cfg(feature = "compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
     fn compat(self) -> CompatSink<Self, Item>
         where Self: Sized + Unpin,
     {

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -28,6 +28,7 @@ pub use self::stream::Chunks;
 pub use self::stream::ReadyChunks;
 
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::stream::Forward;
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
@@ -36,6 +37,7 @@ pub use self::stream::{BufferUnordered, Buffered, ForEachConcurrent};
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "sink")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[cfg(feature = "alloc")]
 pub use self::stream::{ReuniteError, SplitSink, SplitStream};
 
@@ -47,6 +49,7 @@ pub use self::try_stream::{
 };
 
 #[cfg(feature = "io")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 #[cfg(feature = "std")]
 pub use self::try_stream::IntoAsyncRead;
 

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -65,6 +65,7 @@ mod forward;
 #[cfg(feature = "sink")]
 delegate_all!(
     /// Future for the [`forward`](super::StreamExt::forward) method.
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     Forward<St, Si>(
         forward::Forward<St, Si, St::Ok>
     ): Debug + Future + FusedFuture + New[|x: St, y: Si| forward::Forward::new(x, y)]
@@ -177,9 +178,11 @@ cfg_target_has_atomic! {
     pub use self::for_each_concurrent::ForEachConcurrent;
 
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     #[cfg(feature = "alloc")]
     mod split;
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     #[cfg(feature = "alloc")]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
     pub use self::split::{SplitStream, SplitSink, ReuniteError};
@@ -1248,6 +1251,7 @@ pub trait StreamExt: Stream {
     /// (for example, via `forward(&mut sink)` inside an `async` fn/block) in
     /// order to preserve access to the `Sink`.
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     fn forward<S>(self, sink: S) -> Forward<Self, S>
     where
         S: Sink<Self::Ok, Error = Self::Error>,
@@ -1266,6 +1270,7 @@ pub trait StreamExt: Stream {
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.
     #[cfg(feature = "sink")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
     #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
     #[cfg(feature = "alloc")]
     fn split<Item>(self) -> (SplitSink<Self, Item>, SplitStream<Self>)

--- a/futures-util/src/stream/stream/split.rs
+++ b/futures-util/src/stream/stream/split.rs
@@ -9,6 +9,7 @@ use crate::lock::BiLock;
 /// A `Stream` part of the split pair
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub struct SplitStream<S>(BiLock<S>);
 
 impl<S> Unpin for SplitStream<S> {}
@@ -43,6 +44,7 @@ fn SplitSink<S: Sink<Item>, Item>(lock: BiLock<S>) -> SplitSink<S, Item> {
 /// A `Sink` part of the split pair
 #[derive(Debug)]
 #[must_use = "sinks do nothing unless polled"]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub struct SplitSink<S, Item> {
     lock: BiLock<S>,
     slot: Option<Item>,
@@ -119,6 +121,7 @@ pub(super) fn split<S: Stream + Sink<Item>, Item>(s: S) -> (SplitSink<S, Item>, 
 
 /// Error indicating a `SplitSink<S>` and `SplitStream<S>` were not two halves
 /// of a `Stream + Split`, and thus could not be `reunite`d.
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub struct ReuniteError<T, Item>(pub SplitSink<T, Item>, pub SplitStream<T>);
 
 impl<T, Item> fmt::Debug for ReuniteError<T, Item> {

--- a/futures-util/src/stream/try_stream/into_async_read.rs
+++ b/futures-util/src/stream/try_stream/into_async_read.rs
@@ -9,6 +9,7 @@ use std::io::{Error, Result};
 /// Reader for the [`into_async_read`](super::TryStreamExt::into_async_read) method.
 #[derive(Debug)]
 #[must_use = "readers do nothing unless polled"]
+#[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 pub struct IntoAsyncRead<St>
 where
     St: TryStream<Error = Error> + Unpin,

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -121,6 +121,7 @@ cfg_target_has_atomic! {
 #[cfg(feature = "std")]
 mod into_async_read;
 #[cfg(feature = "io")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io")))]
 #[cfg(feature = "std")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::into_async_read::IntoAsyncRead;
@@ -831,6 +832,7 @@ pub trait TryStreamExt: TryStream {
     /// # assert_eq!(42, futures::executor::block_on(rx).unwrap());
     /// ```
     #[cfg(feature = "compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
     fn compat(self) -> Compat<Self>
     where
         Self: Sized + Unpin,
@@ -864,6 +866,7 @@ pub trait TryStreamExt: TryStream {
     /// # })
     /// ```
     #[cfg(feature = "io")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "io")))]
     #[cfg(feature = "std")]
     fn into_async_read(self) -> IntoAsyncRead<Self>
     where

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -69,6 +69,7 @@ pub trait SpawnExt: Spawn {
     /// assert_eq!(block_on(join_handle_fut), 1);
     /// ```
     #[cfg(feature = "channel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
     #[cfg(feature = "std")]
     fn spawn_with_handle<Fut>(&self, future: Fut) -> Result<RemoteHandle<Fut::Output>, SpawnError>
     where
@@ -83,6 +84,7 @@ pub trait SpawnExt: Spawn {
     /// Wraps a [`Spawn`] and makes it usable as a futures 0.1 `Executor`.
     /// Requires the `compat` feature to enable.
     #[cfg(feature = "compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
     fn compat(self) -> Compat<Self>
     where
         Self: Sized,
@@ -145,6 +147,7 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// assert_eq!(executor.run_until(join_handle_fut), 1);
     /// ```
     #[cfg(feature = "channel")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
     #[cfg(feature = "std")]
     fn spawn_local_with_handle<Fut>(
         &self,

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -56,6 +56,7 @@ write-all-vectored = ["futures-util/write-all-vectored"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["std", "async-await", "compat", "io-compat", "executor", "thread-pool"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -92,6 +92,8 @@
 
 #![doc(html_root_url = "https://docs.rs/futures/0.3.5")]
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
@@ -148,6 +150,7 @@ pub mod channel {
 }
 
 #[cfg(feature = "compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
 pub mod compat {
     //! Interop between `futures` 0.1 and 0.3.
     //!
@@ -168,6 +171,7 @@ pub mod compat {
     };
 
     #[cfg(feature = "io-compat")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
     pub use futures_util::compat::{
         AsyncRead01CompatExt,
         AsyncWrite01CompatExt,
@@ -225,6 +229,7 @@ pub mod executor {
     };
 
     #[cfg(feature = "thread-pool")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
     pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
 }
 
@@ -327,6 +332,7 @@ pub mod io {
     };
 
     #[cfg(feature = "read-initializer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
     pub use futures_io::Initializer;
 
     pub use futures_util::io::{
@@ -348,6 +354,7 @@ pub mod lock {
     //! library is activated, and it is activated by default.
 
     #[cfg(feature = "bilock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
     pub use futures_util::lock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
Is it a good idea to add some feature flags in `docs.rs`, just like `tokio` or `async-std`? For the users to read the docs friendly.
And the other `futures` crates also should have feature flags if it is a good idea.