### PR TITLE
Revert "Allow unused_braces in cargo doc test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,8 +145,7 @@ matrix:
     - name: cargo doc
       rust: nightly
       script:
-        # TODO: Remove -Aunused_braces once https://github.com/rust-lang/rust/issues/70814 is fixed
-        - RUSTDOCFLAGS="-Dwarnings -Aunused_braces" cargo doc --workspace --no-deps --all-features
+        - RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --no-deps --all-features
 
 script:
   - cargo test --workspace --all-features


### PR DESCRIPTION
This reverts commit e679f3b54329323811401776fab3782f37356653.

Seems fixed in https://github.com/rust-lang/rust/pull/71517.