### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3.5", path = "../futures-util", default-features =
 futures-executor = { version = "0.3.5", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
-pin-project = "0.4.17"
+pin-project = "0.4.20"
 
 [dev-dependencies]
 futures = { version = "0.3.5", path = "../futures", default-features = false, features = ["std", "executor"] }

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,7 +19,7 @@ futures-util = { version = "0.3.5", path = "../futures-util", default-features =
 futures-executor = { version = "0.3.5", path = "../futures-executor", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
-pin-project = "0.4.15"
+pin-project = "0.4.17"
 
 [dev-dependencies]
 futures = { version = "0.3.5", path = "../futures", default-features = false, features = ["std", "executor"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "0.4.17"
+pin-project = "0.4.20"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.5", features = ["async-await", "thread-pool"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "0.4.15"
+pin-project = "0.4.17"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.5", features = ["async-await", "thread-pool"] }

--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -4,11 +4,11 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Combines two different futures, streams, or sinks having the same associated types into a single
 /// type.
-#[pin_project]
+#[pin_project(project = EitherProj)]
 #[derive(Debug, Clone)]
 pub enum Either<A, B> {
     /// First branch of the type
@@ -58,12 +58,10 @@ where
 {
     type Output = A::Output;
 
-    #[project]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<A::Output> {
-        #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project() {
-            Either::Left(x) => x.poll(cx),
-            Either::Right(x) => x.poll(cx),
+            EitherProj::Left(x) => x.poll(cx),
+            EitherProj::Right(x) => x.poll(cx),
         }
     }
 }
@@ -88,12 +86,10 @@ where
 {
     type Item = A::Item;
 
-    #[project]
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<A::Item>> {
-        #[project]
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.project() {
-            Either::Left(x) => x.poll_next(cx),
-            Either::Right(x) => x.poll_next(cx),
+            EitherProj::Left(x) => x.poll_next(cx),
+            EitherProj::Right(x) => x.poll_next(cx),
         }
     }
 }
@@ -119,39 +115,31 @@ where
 {
     type Error = A::Error;
 
-    #[project]
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        #[project]
         match self.project() {
-            Either::Left(x) => x.poll_ready(cx),
-            Either::Right(x) => x.poll_ready(cx),
+            EitherProj::Left(x) => x.poll_ready(cx),
+            EitherProj::Right(x) => x.poll_ready(cx),
         }
     }
 
-    #[project]
     fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
-        #[project]
         match self.project() {
-            Either::Left(x) => x.start_send(item),
-            Either::Right(x) => x.start_send(item),
+            EitherProj::Left(x) => x.start_send(item),
+            EitherProj::Right(x) => x.start_send(item),
         }
     }
 
-    #[project]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        #[project]
         match self.project() {
-            Either::Left(x) => x.poll_flush(cx),
-            Either::Right(x) => x.poll_flush(cx),
+            EitherProj::Left(x) => x.poll_flush(cx),
+            EitherProj::Right(x) => x.poll_flush(cx),
         }
     }
 
-    #[project]
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        #[project]
         match self.project() {
-            Either::Left(x) => x.poll_close(cx),
-            Either::Right(x) => x.poll_close(cx),
+            EitherProj::Left(x) => x.poll_close(cx),
+            EitherProj::Right(x) => x.poll_close(cx),
         }
     }
 }
@@ -182,29 +170,25 @@ mod if_std {
             }
         }
 
-        #[project]
         fn poll_read(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             buf: &mut [u8],
         ) -> Poll<Result<usize>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_read(cx, buf),
-                Either::Right(x) => x.poll_read(cx, buf),
+                EitherProj::Left(x) => x.poll_read(cx, buf),
+                EitherProj::Right(x) => x.poll_read(cx, buf),
             }
         }
 
-        #[project]
         fn poll_read_vectored(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             bufs: &mut [IoSliceMut<'_>],
         ) -> Poll<Result<usize>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_read_vectored(cx, bufs),
-                Either::Right(x) => x.poll_read_vectored(cx, bufs),
+                EitherProj::Left(x) => x.poll_read_vectored(cx, bufs),
+                EitherProj::Right(x) => x.poll_read_vectored(cx, bufs),
             }
         }
     }
@@ -214,47 +198,39 @@ mod if_std {
         A: AsyncWrite,
         B: AsyncWrite,
     {
-        #[project]
         fn poll_write(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<Result<usize>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_write(cx, buf),
-                Either::Right(x) => x.poll_write(cx, buf),
+                EitherProj::Left(x) => x.poll_write(cx, buf),
+                EitherProj::Right(x) => x.poll_write(cx, buf),
             }
         }
 
-        #[project]
         fn poll_write_vectored(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             bufs: &[IoSlice<'_>],
         ) -> Poll<Result<usize>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_write_vectored(cx, bufs),
-                Either::Right(x) => x.poll_write_vectored(cx, bufs),
+                EitherProj::Left(x) => x.poll_write_vectored(cx, bufs),
+                EitherProj::Right(x) => x.poll_write_vectored(cx, bufs),
             }
         }
 
-        #[project]
         fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_flush(cx),
-                Either::Right(x) => x.poll_flush(cx),
+                EitherProj::Left(x) => x.poll_flush(cx),
+                EitherProj::Right(x) => x.poll_flush(cx),
             }
         }
 
-        #[project]
         fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_close(cx),
-                Either::Right(x) => x.poll_close(cx),
+                EitherProj::Left(x) => x.poll_close(cx),
+                EitherProj::Right(x) => x.poll_close(cx),
             }
         }
     }
@@ -264,16 +240,14 @@ mod if_std {
         A: AsyncSeek,
         B: AsyncSeek,
     {
-        #[project]
         fn poll_seek(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
             pos: SeekFrom,
         ) -> Poll<Result<u64>> {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.poll_seek(cx, pos),
-                Either::Right(x) => x.poll_seek(cx, pos),
+                EitherProj::Left(x) => x.poll_seek(cx, pos),
+                EitherProj::Right(x) => x.poll_seek(cx, pos),
             }
         }
     }
@@ -283,24 +257,17 @@ mod if_std {
         A: AsyncBufRead,
         B: AsyncBufRead,
     {
-        #[project]
-        fn poll_fill_buf(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<&[u8]>> {
-            #[project]
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
             match self.project() {
-                Either::Left(x) => x.poll_fill_buf(cx),
-                Either::Right(x) => x.poll_fill_buf(cx),
+                EitherProj::Left(x) => x.poll_fill_buf(cx),
+                EitherProj::Right(x) => x.poll_fill_buf(cx),
             }
         }
 
-        #[project]
         fn consume(self: Pin<&mut Self>, amt: usize) {
-            #[project]
             match self.project() {
-                Either::Left(x) => x.consume(amt),
-                Either::Right(x) => x.consume(amt),
+                EitherProj::Left(x) => x.consume(amt),
+                EitherProj::Right(x) => x.consume(amt),
             }
         }
     }

--- a/futures-util/src/future/future/flatten.rs
+++ b/futures-util/src/future/future/flatten.rs
@@ -4,9 +4,9 @@ use futures_core::stream::{FusedStream, Stream};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
-#[pin_project]
+#[pin_project(project = FlattenProj)]
 #[derive(Debug)]
 pub enum Flatten<Fut1, Fut2> {
     First(#[pin] Fut1),
@@ -38,21 +38,19 @@ impl<Fut> Future for Flatten<Fut, Fut::Output>
 {
     type Output = <Fut::Output as Future>::Output;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                Flatten::First(f) => {
+                FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
                     self.set(Flatten::Second(f));
                 },
-                Flatten::Second(f) => {
+                FlattenProj::Second(f) => {
                     let output = ready!(f.poll(cx));
                     self.set(Flatten::Empty);
                     break output;
                 },
-                Flatten::Empty => panic!("Flatten polled after completion"),
+                FlattenProj::Empty => panic!("Flatten polled after completion"),
             }
         })
     }
@@ -76,23 +74,21 @@ impl<Fut> Stream for Flatten<Fut, Fut::Output>
 {
     type Item = <Fut::Output as Stream>::Item;
 
-    #[project]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                Flatten::First(f) => {
+                FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
                     self.set(Flatten::Second(f));
                 },
-                Flatten::Second(f) => {
+                FlattenProj::Second(f) => {
                     let output = ready!(f.poll_next(cx));
                     if output.is_none() {
                         self.set(Flatten::Empty);
                     }
                     break output;
                 },
-                Flatten::Empty => break None,
+                FlattenProj::Empty => break None,
             }
         })
     }
@@ -107,54 +103,46 @@ where
 {
     type Error = <Fut::Output as Sink<Item>>::Error;
 
-    #[project]
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                Flatten::First(f) => {
+                FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
                     self.set(Flatten::Second(f));
                 },
-                Flatten::Second(f) => {
+                FlattenProj::Second(f) => {
                     break ready!(f.poll_ready(cx));
                 },
-                Flatten::Empty => panic!("poll_ready called after eof"),
+                FlattenProj::Empty => panic!("poll_ready called after eof"),
             }
         })
     }
 
-    #[project]
     fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
-        #[project]
         match self.project() {
-            Flatten::First(_) => panic!("poll_ready not called first"),
-            Flatten::Second(f) => f.start_send(item),
-            Flatten::Empty => panic!("start_send called after eof"),
+            FlattenProj::First(_) => panic!("poll_ready not called first"),
+            FlattenProj::Second(f) => f.start_send(item),
+            FlattenProj::Empty => panic!("start_send called after eof"),
         }
     }
 
-    #[project]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        #[project]
         match self.project() {
-            Flatten::First(_) => Poll::Ready(Ok(())),
-            Flatten::Second(f) => f.poll_flush(cx),
-            Flatten::Empty => panic!("poll_flush called after eof"),
+            FlattenProj::First(_) => Poll::Ready(Ok(())),
+            FlattenProj::Second(f) => f.poll_flush(cx),
+            FlattenProj::Empty => panic!("poll_flush called after eof"),
         }
     }
 
-    #[project]
     fn poll_close(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        #[project]
         let res = match self.as_mut().project() {
-            Flatten::Second(f) => f.poll_close(cx),
+            FlattenProj::Second(f) => f.poll_close(cx),
             _ => Poll::Ready(Ok(())),
         };
         if res.is_ready() {

--- a/futures-util/src/future/future/map.rs
+++ b/futures-util/src/future/future/map.rs
@@ -6,7 +6,7 @@ use pin_project::pin_project;
 use crate::fns::FnOnce1;
 
 /// Internal Map future
-#[pin_project(Replace, project = MapProj, project_replace = MapProjOwn)]
+#[pin_project(project = MapProj, project_replace = MapProjOwn)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub enum Map<Fut, F> {

--- a/futures-util/src/future/future/map.rs
+++ b/futures-util/src/future/future/map.rs
@@ -1,12 +1,12 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use crate::fns::FnOnce1;
 
 /// Internal Map future
-#[pin_project(Replace)]
+#[pin_project(Replace, project = MapProj, project_replace = MapProjOwn)]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub enum Map<Fut, F> {
@@ -43,19 +43,16 @@ impl<Fut, F, T> Future for Map<Fut, F>
 {
     type Output = T;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        #[project]
         match self.as_mut().project() {
-            Map::Incomplete { future, .. } => {
+            MapProj::Incomplete { future, .. } => {
                 let output = ready!(future.poll(cx));
-                #[project_replace]
                 match self.project_replace(Map::Complete) {
-                    Map::Incomplete { f, .. } => Poll::Ready(f.call_once(output)),
-                    Map::Complete => unreachable!(),
+                    MapProjOwn::Incomplete { f, .. } => Poll::Ready(f.call_once(output)),
+                    MapProjOwn::Complete => unreachable!(),
                 }
             },
-            Map::Complete => panic!("Map must not be polled after it returned `Poll::Ready`"),
+            MapProj::Complete => panic!("Map must not be polled after it returned `Poll::Ready`"),
         }
     }
 }

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -16,7 +16,7 @@ use {
         },
         thread,
     },
-    pin_project::{pin_project, project},
+    pin_project::pin_project,
 };
 
 /// The handle to a remote future returned by
@@ -90,23 +90,21 @@ impl<Fut: Future + fmt::Debug> fmt::Debug for Remote<Fut> {
 impl<Fut: Future> Future for Remote<Fut> {
     type Output = ();
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        #[project]
-        let Remote { tx, keep_running, future } = self.project();
+        let this = self.project();
 
-        if let Poll::Ready(_) = tx.as_mut().unwrap().poll_canceled(cx) {
-            if !keep_running.load(Ordering::SeqCst) {
+        if let Poll::Ready(_) = this.tx.as_mut().unwrap().poll_canceled(cx) {
+            if !this.keep_running.load(Ordering::SeqCst) {
                 // Cancelled, bail out
                 return Poll::Ready(())
             }
         }
 
-        let output = ready!(future.poll(cx));
+        let output = ready!(this.future.poll(cx));
 
         // if the receiving end has gone away then that's ok, we just ignore the
         // send error here.
-        drop(tx.take().unwrap().send(output));
+        drop(this.tx.take().unwrap().send(output));
         Poll::Ready(())
     }
 }

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -8,7 +8,7 @@ use pin_project::pin_project;
 /// A future that may have completed.
 ///
 /// This is created by the [`maybe_done()`] function.
-#[pin_project(Replace, project = MaybeDoneProj, project_replace = MaybeDoneProjOwn)]
+#[pin_project(project = MaybeDoneProj, project_replace = MaybeDoneProjOwn)]
 #[derive(Debug)]
 pub enum MaybeDone<Fut: Future> {
     /// A not-yet-completed future

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -3,12 +3,12 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project, project_replace};
+use pin_project::pin_project;
 
 /// A future that may have completed.
 ///
 /// This is created by the [`maybe_done()`] function.
-#[pin_project(Replace)]
+#[pin_project(Replace, project = MaybeDoneProj, project_replace = MaybeDoneProjOwn)]
 #[derive(Debug)]
 pub enum MaybeDone<Fut: Future> {
     /// A not-yet-completed future
@@ -46,29 +46,25 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take_output`](MaybeDone::take_output)
     /// has not yet been called.
-    #[project]
     #[inline]
     pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
-        #[project]
         match self.project() {
-            MaybeDone::Done(res) => Some(res),
+            MaybeDoneProj::Done(res) => Some(res),
             _ => None,
         }
     }
 
     /// Attempt to take the output of a `MaybeDone` without driving it
     /// towards completion.
-    #[project_replace]
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Output> {
         match &*self {
-            MaybeDone::Done(_) => {},
+            MaybeDone::Done(_) => {}
             MaybeDone::Future(_) | MaybeDone::Gone => return None,
         }
-        #[project_replace]
         match self.project_replace(MaybeDone::Gone) {
-            MaybeDone::Done(output) => Some(output),
-            _ => unreachable!()
+            MaybeDoneProjOwn::Done(output) => Some(output),
+            _ => unreachable!(),
         }
     }
 }
@@ -85,16 +81,14 @@ impl<Fut: Future> FusedFuture for MaybeDone<Fut> {
 impl<Fut: Future> Future for MaybeDone<Fut> {
     type Output = ();
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[project]
         match self.as_mut().project() {
-            MaybeDone::Future(f) => {
+            MaybeDoneProj::Future(f) => {
                 let res = ready!(f.poll(cx));
                 self.set(MaybeDone::Done(res));
-            },
-            MaybeDone::Done(_) => {},
-            MaybeDone::Gone => panic!("MaybeDone polled after value taken"),
+            }
+            MaybeDoneProj::Done(_) => {}
+            MaybeDoneProj::Gone => panic!("MaybeDone polled after value taken"),
         }
         Poll::Ready(())
     }

--- a/futures-util/src/future/try_future/try_flatten.rs
+++ b/futures-util/src/future/try_future/try_flatten.rs
@@ -4,9 +4,9 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
-#[pin_project]
+#[pin_project(project = TryFlattenProj)]
 #[derive(Debug)]
 pub enum TryFlatten<Fut1, Fut2> {
     First(#[pin] Fut1),
@@ -38,12 +38,10 @@ impl<Fut> Future for TryFlatten<Fut, Fut::Ok>
 {
     type Output = Result<<Fut::Ok as TryFuture>::Ok, Fut::Error>;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                TryFlatten::First(f) => {
+                TryFlattenProj::First(f) => {
                     match ready!(f.try_poll(cx)) {
                         Ok(f) => self.set(TryFlatten::Second(f)),
                         Err(e) => {
@@ -52,12 +50,12 @@ impl<Fut> Future for TryFlatten<Fut, Fut::Ok>
                         }
                     }
                 },
-                TryFlatten::Second(f) => {
+                TryFlattenProj::Second(f) => {
                     let output = ready!(f.try_poll(cx));
                     self.set(TryFlatten::Empty);
                     break output;
                 },
-                TryFlatten::Empty => panic!("TryFlatten polled after completion"),
+                TryFlattenProj::Empty => panic!("TryFlatten polled after completion"),
             }
         })
     }
@@ -81,12 +79,10 @@ impl<Fut> Stream for TryFlatten<Fut, Fut::Ok>
 {
     type Item = Result<<Fut::Ok as TryStream>::Ok, Fut::Error>;
 
-    #[project]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                TryFlatten::First(f) => {
+                TryFlattenProj::First(f) => {
                     match ready!(f.try_poll(cx)) {
                         Ok(f) => self.set(TryFlatten::Second(f)),
                         Err(e) => {
@@ -95,14 +91,14 @@ impl<Fut> Stream for TryFlatten<Fut, Fut::Ok>
                         }
                     }
                 },
-                TryFlatten::Second(f) => {
+                TryFlattenProj::Second(f) => {
                     let output = ready!(f.try_poll_next(cx));
                     if output.is_none() {
                         self.set(TryFlatten::Empty);
                     }
                     break output;
                 },
-                TryFlatten::Empty => break None,
+                TryFlattenProj::Empty => break None,
             }
         })
     }
@@ -117,15 +113,13 @@ where
 {
     type Error = Fut::Error;
 
-    #[project]
     fn poll_ready(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(loop {
-            #[project]
             match self.as_mut().project() {
-                TryFlatten::First(f) => {
+                TryFlattenProj::First(f) => {
                     match ready!(f.try_poll(cx)) {
                         Ok(f) => self.set(TryFlatten::Second(f)),
                         Err(e) => {
@@ -134,42 +128,36 @@ where
                         }
                     }
                 },
-                TryFlatten::Second(f) => {
+                TryFlattenProj::Second(f) => {
                     break ready!(f.poll_ready(cx));
                 },
-                TryFlatten::Empty => panic!("poll_ready called after eof"),
+                TryFlattenProj::Empty => panic!("poll_ready called after eof"),
             }
         })
     }
 
-    #[project]
     fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
-        #[project]
         match self.project() {
-            TryFlatten::First(_) => panic!("poll_ready not called first"),
-            TryFlatten::Second(f) => f.start_send(item),
-            TryFlatten::Empty => panic!("start_send called after eof"),
+            TryFlattenProj::First(_) => panic!("poll_ready not called first"),
+            TryFlattenProj::Second(f) => f.start_send(item),
+            TryFlattenProj::Empty => panic!("start_send called after eof"),
         }
     }
 
-    #[project]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        #[project]
         match self.project() {
-            TryFlatten::First(_) => Poll::Ready(Ok(())),
-            TryFlatten::Second(f) => f.poll_flush(cx),
-            TryFlatten::Empty => panic!("poll_flush called after eof"),
+            TryFlattenProj::First(_) => Poll::Ready(Ok(())),
+            TryFlattenProj::Second(f) => f.poll_flush(cx),
+            TryFlattenProj::Empty => panic!("poll_flush called after eof"),
         }
     }
 
-    #[project]
     fn poll_close(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        #[project]
         let res = match self.as_mut().project() {
-            TryFlatten::Second(f) => f.poll_close(cx),
+            TryFlattenProj::Second(f) => f.poll_close(cx),
             _ => Poll::Ready(Ok(())),
         };
         if res.is_ready() {

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -8,7 +8,7 @@ use pin_project::pin_project;
 /// A future that may have completed with an error.
 ///
 /// This is created by the [`try_maybe_done()`] function.
-#[pin_project(Replace, project = TryMaybeDoneProj, project_replace = TryMaybeDoneProjOwn)]
+#[pin_project(project = TryMaybeDoneProj, project_replace = TryMaybeDoneProjOwn)]
 #[derive(Debug)]
 pub enum TryMaybeDone<Fut: TryFuture> {
     /// A not-yet-completed future

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -3,12 +3,12 @@
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project, project_replace};
+use pin_project::pin_project;
 
 /// A future that may have completed with an error.
 ///
 /// This is created by the [`try_maybe_done()`] function.
-#[pin_project(Replace)]
+#[pin_project(Replace, project = TryMaybeDoneProj, project_replace = TryMaybeDoneProjOwn)]
 #[derive(Debug)]
 pub enum TryMaybeDone<Fut: TryFuture> {
     /// A not-yet-completed future
@@ -31,28 +31,24 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has completed successfully and [`take_output`](TryMaybeDone::take_output)
     /// has not yet been called.
-    #[project]
     #[inline]
     pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Ok> {
-        #[project]
         match self.project() {
-            TryMaybeDone::Done(res) => Some(res),
+            TryMaybeDoneProj::Done(res) => Some(res),
             _ => None,
         }
     }
 
     /// Attempt to take the output of a `TryMaybeDone` without driving it
     /// towards completion.
-    #[project_replace]
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Ok> {
         match &*self {
             TryMaybeDone::Done(_) => {},
             TryMaybeDone::Future(_) | TryMaybeDone::Gone => return None,
         }
-        #[project_replace]
         match self.project_replace(TryMaybeDone::Gone) {
-            TryMaybeDone::Done(output) => Some(output),
+            TryMaybeDoneProjOwn::Done(output) => Some(output),
             _ => unreachable!()
         }
     }
@@ -70,11 +66,9 @@ impl<Fut: TryFuture> FusedFuture for TryMaybeDone<Fut> {
 impl<Fut: TryFuture> Future for TryMaybeDone<Fut> {
     type Output = Result<(), Fut::Error>;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[project]
         match self.as_mut().project() {
-            TryMaybeDone::Future(f) => {
+            TryMaybeDoneProj::Future(f) => {
                 match ready!(f.try_poll(cx)) {
                     Ok(res) => self.set(TryMaybeDone::Done(res)),
                     Err(e) => {
@@ -83,8 +77,8 @@ impl<Fut: TryFuture> Future for TryMaybeDone<Fut> {
                     }
                 }
             },
-            TryMaybeDone::Done(_) => {},
-            TryMaybeDone::Gone => panic!("TryMaybeDone polled after value taken"),
+            TryMaybeDoneProj::Done(_) => {},
+            TryMaybeDoneProj::Gone => panic!("TryMaybeDone polled after value taken"),
         }
         Poll::Ready(Ok(()))
     }

--- a/futures-util/src/io/copy_buf.rs
+++ b/futures-util/src/io/copy_buf.rs
@@ -3,7 +3,7 @@ use futures_core::task::{Context, Poll};
 use futures_io::{AsyncBufRead, AsyncWrite};
 use std::io;
 use std::pin::Pin;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Creates a future which copies all the bytes from one object to another.
 ///
@@ -59,23 +59,21 @@ impl<R, W> Future for CopyBuf<'_, R, W>
 {
     type Output = io::Result<u64>;
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        #[project]
-        let CopyBuf { mut reader, mut writer, amt } = self.project();
+        let mut this = self.project();
         loop {
-            let buffer = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            let buffer = ready!(this.reader.as_mut().poll_fill_buf(cx))?;
             if buffer.is_empty() {
-                ready!(Pin::new(&mut writer).poll_flush(cx))?;
-                return Poll::Ready(Ok(*amt));
+                ready!(Pin::new(&mut this.writer).poll_flush(cx))?;
+                return Poll::Ready(Ok(*this.amt));
             }
 
-            let i = ready!(Pin::new(&mut writer).poll_write(cx, buffer))?;
+            let i = ready!(Pin::new(&mut this.writer).poll_write(cx, buffer))?;
             if i == 0 {
                 return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
             }
-            *amt += i as u64;
-            reader.as_mut().consume(i);
+            *this.amt += i as u64;
+            this.reader.as_mut().consume(i);
         }
     }
 }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -1,7 +1,7 @@
 use crate::sink::{SinkExt, SinkMapErr};
 use futures_core::stream::{Stream, FusedStream};
 use futures_sink::{Sink};
-use pin_project::{pin_project};
+use pin_project::pin_project;
 
 /// Sink for the [`sink_err_into`](super::SinkExt::sink_err_into) method.
 #[pin_project]

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -2,7 +2,7 @@ use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Creates a stream of a single element.
 ///
@@ -39,16 +39,14 @@ impl<Fut> Once<Fut> {
 impl<Fut: Future> Stream for Once<Fut> {
     type Item = Fut::Output;
 
-    #[project]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        #[project]
-        let Once { mut future } = self.project();
-        let v = match future.as_mut().as_pin_mut() {
+        let mut this = self.project();
+        let v = match this.future.as_mut().as_pin_mut() {
             Some(fut) => ready!(fut.poll(cx)),
             None => return Poll::Ready(None),
         };
 
-        future.set(None);
+        this.future.set(None);
         Poll::Ready(Some(v))
     }
 

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -2,7 +2,7 @@ use crate::stream::{StreamExt, Fuse};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`select()`] function.
 #[pin_project]
@@ -87,18 +87,15 @@ impl<St1, St2> Stream for Select<St1, St2>
 {
     type Item = St1::Item;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St1::Item>> {
-        #[project]
-        let Select { flag, stream1, stream2 } = self.project();
-
-        if !*flag {
-            poll_inner(flag, stream1, stream2, cx)
+        let this = self.project();
+        if !*this.flag {
+            poll_inner(this.flag, this.stream1, this.stream2, cx)
         } else {
-            poll_inner(flag, stream2, stream1, cx)
+            poll_inner(this.flag, this.stream2, this.stream1, cx)
         }
     }
 }

--- a/futures-util/src/stream/stream/buffered.rs
+++ b/futures-util/src/stream/stream/buffered.rs
@@ -4,7 +4,7 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use core::fmt;
 use core::pin::Pin;
 
@@ -59,31 +59,29 @@ where
 {
     type Item = <St::Item as Future>::Output;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        #[project]
-        let Buffered { mut stream, in_progress_queue, max } = self.project();
+        let mut this = self.project();
 
         // First up, try to spawn off as many futures as possible by filling up
         // our queue of futures.
-        while in_progress_queue.len() < *max {
-            match stream.as_mut().poll_next(cx) {
-                Poll::Ready(Some(fut)) => in_progress_queue.push(fut),
+        while this.in_progress_queue.len() < *this.max {
+            match this.stream.as_mut().poll_next(cx) {
+                Poll::Ready(Some(fut)) => this.in_progress_queue.push(fut),
                 Poll::Ready(None) | Poll::Pending => break,
             }
         }
 
         // Attempt to pull the next value from the in_progress_queue
-        let res = in_progress_queue.poll_next_unpin(cx);
+        let res = this.in_progress_queue.poll_next_unpin(cx);
         if let Some(val) = ready!(res) {
             return Poll::Ready(Some(val))
         }
 
         // If more values are still coming from the stream, we're not done yet
-        if stream.is_done() {
+        if this.stream.is_done() {
             Poll::Ready(None)
         } else {
             Poll::Pending

--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -1,7 +1,7 @@
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`chain`](super::StreamExt::chain) method.
 #[pin_project]
@@ -42,20 +42,18 @@ where St1: Stream,
 {
     type Item = St1::Item;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        #[project]
-        let Chain { mut first, second } = self.project();
-        if let Some(first) = first.as_mut().as_pin_mut() {
+        let mut this = self.project();
+        if let Some(first) = this.first.as_mut().as_pin_mut() {
             if let Some(item) = ready!(first.poll_next(cx)) {
                 return Poll::Ready(Some(item))
             }
         }
-        first.set(None);
-        second.poll_next(cx)
+        this.first.set(None);
+        this.second.poll_next(cx)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Future for the [`collect`](super::StreamExt::collect) method.
 #[pin_project]
@@ -43,13 +43,11 @@ where St: Stream,
 {
     type Output = C;
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<C> {
-        #[project]
-        let Collect { mut stream, collection } = self.as_mut().project();
+        let mut this = self.as_mut().project();
         loop {
-            match ready!(stream.as_mut().poll_next(cx)) {
-                Some(e) => collection.extend(Some(e)),
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                Some(e) => this.collection.extend(Some(e)),
                 None => return Poll::Ready(self.finish()),
             }
         }

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -2,7 +2,7 @@ use core::pin::Pin;
 use futures_core::future::{Future, FusedFuture};
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Future for the [`concat`](super::StreamExt::concat) method.
 #[pin_project]
@@ -34,23 +34,21 @@ where St: Stream,
 {
     type Output = St::Item;
 
-    #[project]
     fn poll(
         self: Pin<&mut Self>, cx: &mut Context<'_>
     ) -> Poll<Self::Output> {
-        #[project]
-        let Concat { mut stream, accum } = self.project();
+        let mut this = self.project();
 
         loop {
-            match ready!(stream.as_mut().poll_next(cx)) {
+            match ready!(this.stream.as_mut().poll_next(cx)) {
                 None => {
-                    return Poll::Ready(accum.take().unwrap_or_default())
+                    return Poll::Ready(this.accum.take().unwrap_or_default())
                 }
                 Some(e) => {
-                    if let Some(a) = accum {
+                    if let Some(a) = this.accum {
                         a.extend(e)
                     } else {
-                        *accum = Some(e)
+                        *this.accum = Some(e)
                     }
                 }
             }

--- a/futures-util/src/stream/stream/enumerate.rs
+++ b/futures-util/src/stream/stream/enumerate.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`enumerate`](super::StreamExt::enumerate) method.
 #[pin_project]
@@ -35,18 +35,16 @@ impl<St: Stream + FusedStream> FusedStream for Enumerate<St> {
 impl<St: Stream> Stream for Enumerate<St> {
     type Item = (usize, St::Item);
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        #[project]
-        let Enumerate { stream, count } = self.project();
+        let this = self.project();
 
-        match ready!(stream.poll_next(cx)) {
+        match ready!(this.stream.poll_next(cx)) {
             Some(item) => {
-                let prev_count = *count;
-                *count += 1;
+                let prev_count = *this.count;
+                *this.count += 1;
                 Poll::Ready(Some((prev_count, item)))
             }
             None => Poll::Ready(None),

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -5,7 +5,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use crate::fns::FnMut1;
 
 /// Stream for the [`filter`](super::StreamExt::filter) method.
@@ -73,24 +73,22 @@ impl<St, Fut, F> Stream for Filter<St, Fut, F>
 {
     type Item = St::Item;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<St::Item>> {
-        #[project]
-        let Filter { mut stream, f, mut pending_fut, pending_item } = self.project();
+        let mut this = self.project();
         Poll::Ready(loop {
-            if let Some(fut) = pending_fut.as_mut().as_pin_mut() {
+            if let Some(fut) = this.pending_fut.as_mut().as_pin_mut() {
                 let res = ready!(fut.poll(cx));
-                pending_fut.set(None);
+                this.pending_fut.set(None);
                 if res {
-                    break pending_item.take();
+                    break this.pending_item.take();
                 }
-                *pending_item = None;
-            } else if let Some(item) = ready!(stream.as_mut().poll_next(cx)) {
-                pending_fut.set(Some(f.call_mut(&item)));
-                *pending_item = Some(item);
+                *this.pending_item = None;
+            } else if let Some(item) = ready!(this.stream.as_mut().poll_next(cx)) {
+                this.pending_fut.set(Some(this.f.call_mut(&item)));
+                *this.pending_item = Some(item);
             } else {
                 break None;
             }

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`flatten`](super::StreamExt::flatten) method.
 #[pin_project]
@@ -41,19 +41,17 @@ where
 {
     type Item = <St::Item as Stream>::Item;
 
-    #[project]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        #[project]
-        let Flatten { mut stream, mut next } = self.project();
+        let mut this = self.project();
         Poll::Ready(loop {
-            if let Some(s) = next.as_mut().as_pin_mut() {
+            if let Some(s) = this.next.as_mut().as_pin_mut() {
                 if let Some(item) = ready!(s.poll_next(cx)) {
                     break Some(item);
                 } else {
-                    next.set(None);
+                    this.next.set(None);
                 }
-            } else if let Some(s) = ready!(stream.as_mut().poll_next(cx)) {
-                next.set(Some(s));
+            } else if let Some(s) = ready!(this.stream.as_mut().poll_next(cx)) {
+                this.next.set(Some(s));
             } else {
                 break None;
             }

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Future for the [`fold`](super::StreamExt::fold) method.
 #[pin_project]
@@ -64,21 +64,19 @@ impl<St, Fut, T, F> Future for Fold<St, Fut, T, F>
 {
     type Output = T;
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        #[project]
-        let Fold { mut stream, f, accum, mut future } = self.project();
+        let mut this = self.project();
         Poll::Ready(loop {
-            if let Some(fut) = future.as_mut().as_pin_mut() {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 // we're currently processing a future to produce a new accum value
-                *accum = Some(ready!(fut.poll(cx)));
-                future.set(None);
-            } else if accum.is_some() {
+                *this.accum = Some(ready!(fut.poll(cx)));
+                this.future.set(None);
+            } else if this.accum.is_some() {
                 // we're waiting on a new item from the stream
-                let res = ready!(stream.as_mut().poll_next(cx));
-                let a = accum.take().unwrap();
+                let res = ready!(this.stream.as_mut().poll_next(cx));
+                let a = this.accum.take().unwrap();
                 if let Some(item) = res {
-                    future.set(Some(f(a, item)));
+                    this.future.set(Some((this.f)(a, item)));
                 } else {
                     break a;
                 }

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Future for the [`for_each`](super::StreamExt::for_each) method.
 #[pin_project]
@@ -60,16 +60,14 @@ impl<St, Fut, F> Future for ForEach<St, Fut, F>
 {
     type Output = ();
 
-    #[project]
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        #[project]
-        let ForEach { mut stream, f, mut future } = self.project();
+        let mut this = self.project();
         loop {
-            if let Some(fut) = future.as_mut().as_pin_mut() {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 ready!(fut.poll(cx));
-                future.set(None);
-            } else if let Some(item) = ready!(stream.as_mut().poll_next(cx)) {
-                future.set(Some(f(item)));
+                this.future.set(None);
+            } else if let Some(item) = ready!(this.stream.as_mut().poll_next(cx)) {
+                this.future.set(Some((this.f)(item)));
             } else {
                 break;
             }

--- a/futures-util/src/stream/stream/fuse.rs
+++ b/futures-util/src/stream/stream/fuse.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`fuse`](super::StreamExt::fuse) method.
 #[pin_project]
@@ -41,21 +41,19 @@ impl<S: Stream> FusedStream for Fuse<S> {
 impl<S: Stream> Stream for Fuse<S> {
     type Item = S::Item;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<S::Item>> {
-        #[project]
-        let Fuse { stream, done } = self.project();
+        let this = self.project();
 
-        if *done {
+        if *this.done {
             return Poll::Ready(None);
         }
 
-        let item = ready!(stream.poll_next(cx));
+        let item = ready!(this.stream.poll_next(cx));
         if item.is_none() {
-            *done = true;
+            *this.done = true;
         }
         Poll::Ready(item)
     }

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use core::mem;
 use core::pin::Pin;
 use alloc::vec::Vec;
@@ -36,23 +36,21 @@ impl<St: Stream> ReadyChunks<St> where St: Stream {
 impl<St: Stream> Stream for ReadyChunks<St> {
     type Item = Vec<St::Item>;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        #[project]
-        let ReadyChunks { items, cap, mut stream } = self.project();
+        let mut this = self.project();
 
         loop {
-            match stream.as_mut().poll_next(cx) {
+            match this.stream.as_mut().poll_next(cx) {
                 // Flush all collected data if underlying stream doesn't contain
                 // more ready values
                 Poll::Pending => {
-                    return if items.is_empty() {
+                    return if this.items.is_empty() {
                         Poll::Pending
                     } else {
-                        Poll::Ready(Some(mem::replace(items, Vec::with_capacity(*cap))))
+                        Poll::Ready(Some(mem::replace(this.items, Vec::with_capacity(*this.cap))))
                     }
                 }
 
@@ -60,19 +58,19 @@ impl<St: Stream> Stream for ReadyChunks<St> {
                 // If so, replace our buffer with a new and empty one and return
                 // the full one.
                 Poll::Ready(Some(item)) => {
-                    items.push(item);
-                    if items.len() >= *cap {
-                        return Poll::Ready(Some(mem::replace(items, Vec::with_capacity(*cap))))
+                    this.items.push(item);
+                    if this.items.len() >= *this.cap {
+                        return Poll::Ready(Some(mem::replace(this.items, Vec::with_capacity(*this.cap))))
                     }
                 }
 
                 // Since the underlying stream ran out of values, return what we
                 // have buffered, if we have anything.
                 Poll::Ready(None) => {
-                    let last = if items.is_empty() {
+                    let last = if this.items.is_empty() {
                         None
                     } else {
-                        let full_buf = mem::replace(items, Vec::new());
+                        let full_buf = mem::replace(this.items, Vec::new());
                         Some(full_buf)
                     };
 

--- a/futures-util/src/stream/stream/take.rs
+++ b/futures-util/src/stream/stream/take.rs
@@ -4,7 +4,7 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`take`](super::StreamExt::take) method.
 #[pin_project]
@@ -32,7 +32,6 @@ impl<St> Stream for Take<St>
 {
     type Item = St::Item;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -40,13 +39,12 @@ impl<St> Stream for Take<St>
         if self.remaining == 0 {
             Poll::Ready(None)
         } else {
-            #[project]
-            let Take { stream, remaining } = self.project();
-            let next = ready!(stream.poll_next(cx));
+            let this = self.project();
+            let next = ready!(this.stream.poll_next(cx));
             if next.is_some() {
-                *remaining -= 1;
+                *this.remaining -= 1;
             } else {
-                *remaining = 0;
+                *this.remaining = 0;
             }
             Poll::Ready(next)
         }

--- a/futures-util/src/stream/try_stream/and_then.rs
+++ b/futures-util/src/stream/try_stream/and_then.rs
@@ -5,7 +5,7 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`and_then`](super::TryStreamExt::and_then) method.
 #[pin_project]
@@ -50,21 +50,19 @@ impl<St, Fut, F> Stream for AndThen<St, Fut, F>
 {
     type Item = Result<Fut::Ok, St::Error>;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        #[project]
-        let AndThen { mut stream, mut future, f } = self.project();
+        let mut this = self.project();
 
         Poll::Ready(loop {
-            if let Some(fut) = future.as_mut().as_pin_mut() {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 let item = ready!(fut.try_poll(cx));
-                future.set(None);
+                this.future.set(None);
                 break Some(item);
-            } else if let Some(item) = ready!(stream.as_mut().try_poll_next(cx)?) {
-                future.set(Some(f(item)));
+            } else if let Some(item) = ready!(this.stream.as_mut().try_poll_next(cx)?) {
+                this.future.set(Some((this.f)(item)));
             } else {
                 break None;
             }

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{Context, Poll};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Future for the [`try_collect`](super::TryStreamExt::try_collect) method.
 #[pin_project]
@@ -41,17 +41,15 @@ where
 {
     type Output = Result<C, St::Error>;
 
-    #[project]
     fn poll(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Self::Output> {
-        #[project]
-        let TryCollect { mut stream, items } = self.project();
+        let mut this = self.project();
         Poll::Ready(Ok(loop {
-            match ready!(stream.as_mut().try_poll_next(cx)?) {
-                Some(x) => items.extend(Some(x)),
-                None => break mem::replace(items, Default::default()),
+            match ready!(this.stream.as_mut().try_poll_next(cx)?) {
+                Some(x) => this.items.extend(Some(x)),
+                None => break mem::replace(this.items, Default::default()),
             }
         }))
     }

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -5,7 +5,7 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Stream for the [`try_filter`](super::TryStreamExt::try_filter)
 /// method.
@@ -69,24 +69,23 @@ impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
 {
     type Item = Result<St::Ok, St::Error>;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<St::Ok, St::Error>>> {
-        #[project]
-        let TryFilter { mut stream, f, mut pending_fut, pending_item } = self.project();
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
         Poll::Ready(loop {
-            if let Some(fut) = pending_fut.as_mut().as_pin_mut() {
+            if let Some(fut) = this.pending_fut.as_mut().as_pin_mut() {
                 let res = ready!(fut.poll(cx));
-                pending_fut.set(None);
+                this.pending_fut.set(None);
                 if res {
-                    break pending_item.take().map(Ok);
+                    break this.pending_item.take().map(Ok);
                 }
-                *pending_item = None;
-            } else if let Some(item) = ready!(stream.as_mut().try_poll_next(cx)?) {
-                pending_fut.set(Some(f(&item)));
-                *pending_item = Some(item);
+                *this.pending_item = None;
+            } else if let Some(item) = ready!(this.stream.as_mut().try_poll_next(cx)?) {
+                this.pending_fut.set(Some((this.f)(&item)));
+                *this.pending_item = Some(item);
             } else {
                 break None;
             }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,7 +33,7 @@ futures-executor = { path = "../futures-executor", version = "0.3.5", features =
 futures-test = { path = "../futures-test", version = "0.3.5" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
-pin-project = "0.4.17"
+pin-project = "0.4.20"
 
 [features]
 default = ["std", "async-await", "executor"]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -33,7 +33,7 @@ futures-executor = { path = "../futures-executor", version = "0.3.5", features =
 futures-test = { path = "../futures-test", version = "0.3.5" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
-pin-project = "0.4.15"
+pin-project = "0.4.17"
 
 [features]
 default = ["std", "async-await", "executor"]


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
