### PR TITLE
Added a `is_connected_to` to (`Unbounded`)`Sender`

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -482,7 +482,7 @@ impl<T> UnboundedSenderInner<T> {
     }
 
     /// Returns whether the sender send to this receiver.
-    fn is_receiver(&self, inner: &Arc<UnboundedInner<T>>) -> bool {
+    fn is_connected_to(&self, inner: &Arc<UnboundedInner<T>>) -> bool {
         Arc::ptr_eq(&self.inner, &inner)
     }
 
@@ -663,7 +663,7 @@ impl<T> BoundedSenderInner<T> {
     }
 
     /// Returns whether the sender send to this receiver.
-    fn is_receiver(&self, receiver: &Arc<BoundedInner<T>>) -> bool {
+    fn is_connected_to(&self, receiver: &Arc<BoundedInner<T>>) -> bool {
         Arc::ptr_eq(&self.inner, &receiver)
     } 
 
@@ -790,9 +790,9 @@ impl<T> Sender<T> {
     }
 
     /// Returns whether the sender send to this receiver.
-    pub fn is_receiver(&self, receiver: &Receiver<T>) -> bool {
+    pub fn is_connected_to(&self, receiver: &Receiver<T>) -> bool {
         match (&self.0, &receiver.inner) {
-            (Some(inner), Some(receiver)) => inner.is_receiver(receiver),
+            (Some(inner), Some(receiver)) => inner.is_connected_to(receiver),
             _ => false,
         }
     }
@@ -879,9 +879,9 @@ impl<T> UnboundedSender<T> {
     }
 
     /// Returns whether the sender send to this receiver.
-    pub fn is_receiver(&self, receiver: &UnboundedReceiver<T>) -> bool {
+    pub fn is_connected_to(&self, receiver: &UnboundedReceiver<T>) -> bool {
         match (&self.0, &receiver.inner) {
-            (Some(inner), Some(receiver)) => inner.is_receiver(receiver),
+            (Some(inner), Some(receiver)) => inner.is_connected_to(receiver),
             _ => false,
         }
     }

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -481,6 +481,11 @@ impl<T> UnboundedSenderInner<T> {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 
+    /// Returns whether the sender send to this receiver.
+    fn is_receiver(&self, inner: &Arc<UnboundedInner<T>>) -> bool {
+        Arc::ptr_eq(&self.inner, &inner)
+    }
+
     /// Returns pointer to the Arc containing sender
     ///
     /// The returned pointer is not referenced and should be only used for hashing!
@@ -657,6 +662,11 @@ impl<T> BoundedSenderInner<T> {
         Arc::ptr_eq(&self.inner, &other.inner)
     }
 
+    /// Returns whether the sender send to this receiver.
+    fn is_receiver(&self, receiver: &Arc<BoundedInner<T>>) -> bool {
+        Arc::ptr_eq(&self.inner, &receiver)
+    } 
+
     /// Returns pointer to the Arc containing sender
     ///
     /// The returned pointer is not referenced and should be only used for hashing!
@@ -779,6 +789,14 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Returns whether the sender send to this receiver.
+    pub fn is_receiver(&self, receiver: &Receiver<T>) -> bool {
+        match (&self.0, &receiver.inner) {
+            (Some(inner), Some(receiver)) => inner.is_receiver(receiver),
+            _ => false,
+        }
+    }
+
     /// Hashes the receiver into the provided hasher
     pub fn hash_receiver<H>(&self, hasher: &mut H) where H: std::hash::Hasher {
         use std::hash::Hash;
@@ -856,6 +874,14 @@ impl<T> UnboundedSender<T> {
     pub fn same_receiver(&self, other: &Self) -> bool {
         match (&self.0, &other.0) {
             (Some(inner), Some(other)) => inner.same_receiver(other),
+            _ => false,
+        }
+    }
+
+    /// Returns whether the sender send to this receiver.
+    pub fn is_receiver(&self, receiver: &UnboundedReceiver<T>) -> bool {
+        match (&self.0, &receiver.inner) {
+            (Some(inner), Some(receiver)) => inner.is_receiver(receiver),
             _ => false,
         }
     }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -528,14 +528,14 @@ fn same_receiver() {
 }
 
 #[test]
-fn is_receiver() {
+fn is_connected_to() {
     let (txa, rxa) = mpsc::channel::<i32>(1);
     let (txb, rxb) = mpsc::channel::<i32>(1);
 
-    assert!(txa.is_receiver(&rxa));
-    assert!(txb.is_receiver(&rxb));
-    assert!(!txa.is_receiver(&rxb));
-    assert!(!txb.is_receiver(&rxa));
+    assert!(txa.is_connected_to(&rxa));
+    assert!(txb.is_connected_to(&rxb));
+    assert!(!txa.is_connected_to(&rxb));
+    assert!(!txb.is_connected_to(&rxa));
 }
 
 #[test]

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -528,6 +528,17 @@ fn same_receiver() {
 }
 
 #[test]
+fn is_receiver() {
+    let (txa, rxa) = mpsc::channel::<i32>(1);
+    let (txb, rxb) = mpsc::channel::<i32>(1);
+
+    assert!(txa.is_receiver(&rxa));
+    assert!(txb.is_receiver(&rxb));
+    assert!(!txa.is_receiver(&rxb));
+    assert!(!txb.is_receiver(&rxa));
+}
+
+#[test]
 fn hash_receiver() {
     use std::hash::Hasher;
     use std::collections::hash_map::DefaultHasher;


### PR DESCRIPTION
Hi,
I added a `is_receiver` function to the (`Unbounded`)`Sender` struct to check if a sender object belongs to this specific receiver object. The code is similar to `same_receiver` function.