### PR TITLE
Add a `no_std` compatible `LocalPool`

### DIFF
--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -14,6 +14,7 @@ Executors for asynchronous tasks based on the futures-rs library.
 [features]
 default = ["std"]
 std = ["futures-core/std", "futures-task/std", "futures-util/std"]
+alloc = ["futures-core/alloc", "futures-task/alloc", "futures-util/alloc"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]

--- a/futures-executor/src/custom_local_pool.rs
+++ b/futures-executor/src/custom_local_pool.rs
@@ -1,0 +1,402 @@
+use crate::enter;
+use futures_core::future::Future;
+use futures_core::stream::Stream;
+use futures_core::task::{Context, Poll};
+use futures_task::{waker_ref, ArcWake};
+use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
+use futures_util::pin_mut;
+use futures_util::stream::FuturesUnordered;
+use futures_util::stream::StreamExt;
+use std::cell::RefCell;
+use std::ops::{Deref, DerefMut};
+use std::rc::{Rc, Weak};
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::thread::{self, Thread};
+
+/// A single-threaded task pool for polling futures to completion.
+///
+/// This executor allows you to multiplex any number of tasks onto a single
+/// thread. It's appropriate to poll strictly I/O-bound futures that do very
+/// little work in between I/O actions.
+///
+/// To get a handle to the pool that implements
+/// [`Spawn`](futures_task::Spawn), use the
+/// [`spawner()`](LocalPool::spawner) method. Because the executor is
+/// single-threaded, it supports a special form of task spawning for non-`Send`
+/// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
+#[derive(Debug)]
+pub struct LocalPool {
+    pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
+    incoming: Rc<Incoming>,
+}
+
+/// A handle to a [`LocalPool`](LocalPool) that implements
+/// [`Spawn`](futures_task::Spawn).
+#[derive(Clone, Debug)]
+pub struct LocalSpawner {
+    incoming: Weak<Incoming>,
+}
+
+type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
+
+pub(crate) struct ThreadNotify {
+    /// The (single) executor thread.
+    thread: Thread,
+    /// A flag to ensure a wakeup (i.e. `unpark()`) is not "forgotten"
+    /// before the next `park()`, which may otherwise happen if the code
+    /// being executed as part of the future(s) being polled makes use of
+    /// park / unpark calls of its own, i.e. we cannot assume that no other
+    /// code uses park / unpark on the executing `thread`.
+    unparked: AtomicBool,
+}
+
+thread_local! {
+    static CURRENT_THREAD_NOTIFY: Arc<ThreadNotify> = Arc::new(ThreadNotify {
+        thread: thread::current(),
+        unparked: AtomicBool::new(false),
+    });
+}
+
+impl ArcWake for ThreadNotify {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        // Make sure the wakeup is remembered until the next `park()`.
+        let unparked = arc_self.unparked.swap(true, Ordering::Relaxed);
+        if !unparked {
+            // If the thread has not been unparked yet, it must be done
+            // now. If it was actually parked, it will run again,
+            // otherwise the token made available by `unpark`
+            // may be consumed before reaching `park()`, but `unparked`
+            // ensures it is not forgotten.
+            arc_self.thread.unpark();
+        }
+    }
+}
+
+// Set up and run a basic single-threaded spawner loop, invoking `f` on each
+// turn.
+fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(mut f: F) -> T {
+    let _enter = enter().expect(
+        "cannot execute `LocalPool` executor from within \
+         another executor",
+    );
+
+    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
+        let waker = waker_ref(thread_notify);
+        let mut cx = Context::from_waker(&waker);
+        loop {
+            if let Poll::Ready(t) = f(&mut cx) {
+                return t;
+            }
+            // Consume the wakeup that occurred while executing `f`, if any.
+            let unparked = thread_notify.unparked.swap(false, Ordering::Acquire);
+            if !unparked {
+                // No wakeup occurred. It may occur now, right before parking,
+                // but in that case the token made available by `unpark()`
+                // is guaranteed to still be available and `park()` is a no-op.
+                thread::park();
+                // When the thread is unparked, `unparked` will have been set
+                // and needs to be unset before the next call to `f` to avoid
+                // a redundant loop iteration.
+                thread_notify.unparked.store(false, Ordering::Release);
+            }
+        }
+    })
+}
+
+fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
+    let _enter = enter().expect(
+        "cannot execute `LocalPool` executor from within \
+         another executor",
+    );
+
+    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
+        let waker = waker_ref(thread_notify);
+        let mut cx = Context::from_waker(&waker);
+        f(&mut cx)
+    })
+}
+
+impl LocalPool {
+    /// Create a new, empty pool of tasks.
+    pub fn new() -> LocalPool {
+        LocalPool {
+            pool: FuturesUnordered::new(),
+            incoming: Default::default(),
+        }
+    }
+
+    /// Get a clonable handle to the pool as a [`Spawn`].
+    pub fn spawner(&self) -> LocalSpawner {
+        LocalSpawner {
+            incoming: Rc::downgrade(&self.incoming),
+        }
+    }
+
+    /// Run all tasks in the pool to completion.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    ///
+    /// let mut pool = LocalPool::new();
+    ///
+    /// // ... spawn some initial tasks using `spawn.spawn()` or `spawn.spawn_local()`
+    ///
+    /// // run *all* tasks in the pool to completion, including any newly-spawned ones.
+    /// pool.run();
+    /// ```
+    ///
+    /// The function will block the calling thread until *all* tasks in the pool
+    /// are complete, including any spawned while running existing tasks.
+    pub fn run(&mut self) {
+        run_executor(|cx| self.poll_pool(cx))
+    }
+
+    /// Runs all the tasks in the pool until the given future completes.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    ///
+    /// let mut pool = LocalPool::new();
+    /// # let my_app  = async {};
+    ///
+    /// // run tasks in the pool until `my_app` completes
+    /// pool.run_until(my_app);
+    /// ```
+    ///
+    /// The function will block the calling thread *only* until the future `f`
+    /// completes; there may still be incomplete tasks in the pool, which will
+    /// be inert after the call completes, but can continue with further use of
+    /// one of the pool's run or poll methods. While the function is running,
+    /// however, all tasks in the pool will try to make progress.
+    pub fn run_until<F: Future>(&mut self, future: F) -> F::Output {
+        pin_mut!(future);
+
+        run_executor(|cx| {
+            {
+                // if our main task is done, so are we
+                let result = future.as_mut().poll(cx);
+                if let Poll::Ready(output) = result {
+                    return Poll::Ready(output);
+                }
+            }
+
+            let _ = self.poll_pool(cx);
+            Poll::Pending
+        })
+    }
+
+    /// Runs all tasks and returns after completing one future or until no more progress
+    /// can be made. Returns `true` if one future was completed, `false` otherwise.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    /// use futures::task::LocalSpawnExt;
+    /// use futures::future::{ready, pending};
+    ///
+    /// let mut pool = LocalPool::new();
+    /// let spawner = pool.spawner();
+    ///
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
+    ///
+    /// // Run the two ready tasks and return true for them.
+    /// pool.try_run_one(); // returns true after completing one of the ready futures
+    /// pool.try_run_one(); // returns true after completing the other ready future
+    ///
+    /// // the remaining task can not be completed
+    /// assert!(!pool.try_run_one()); // returns false
+    /// ```
+    ///
+    /// This function will not block the calling thread and will return the moment
+    /// that there are no tasks left for which progress can be made or after exactly one
+    /// task was completed; Remaining incomplete tasks in the pool can continue with
+    /// further use of one of the pool's run or poll methods.
+    /// Though only one task will be completed, progress may be made on multiple tasks.
+    pub fn try_run_one(&mut self) -> bool {
+        poll_executor(|ctx| {
+            loop {
+                let ret = self.poll_pool_once(ctx);
+
+                // return if we have executed a future
+                if let Poll::Ready(Some(_)) = ret {
+                    return true;
+                }
+
+                // if there are no new incoming futures
+                // then there is no feature that can make progress
+                // and we can return without having completed a single future
+                if self.incoming.borrow().is_empty() {
+                    return false;
+                }
+            }
+        })
+    }
+
+    /// Runs all tasks in the pool and returns if no more progress can be made
+    /// on any task.
+    ///
+    /// ```
+    /// use futures::executor::LocalPool;
+    /// use futures::task::LocalSpawnExt;
+    /// use futures::future::{ready, pending};
+    ///
+    /// let mut pool = LocalPool::new();
+    /// let spawner = pool.spawner();
+    ///
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(ready(())).unwrap();
+    /// spawner.spawn_local(pending()).unwrap();
+    ///
+    /// // Runs the two ready task and returns.
+    /// // The empty task remains in the pool.
+    /// pool.run_until_stalled();
+    /// ```
+    ///
+    /// This function will not block the calling thread and will return the moment
+    /// that there are no tasks left for which progress can be made;
+    /// remaining incomplete tasks in the pool can continue with further use of one
+    /// of the pool's run or poll methods. While the function is running, all tasks
+    /// in the pool will try to make progress.
+    pub fn run_until_stalled(&mut self) {
+        poll_executor(|ctx| {
+            let _ = self.poll_pool(ctx);
+        });
+    }
+
+    // Make maximal progress on the entire pool of spawned task, returning `Ready`
+    // if the pool is empty and `Pending` if no further progress can be made.
+    fn poll_pool(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        // state for the FuturesUnordered, which will never be used
+        loop {
+            let ret = self.poll_pool_once(cx);
+
+            // we queued up some new tasks; add them and poll again
+            if !self.incoming.borrow().is_empty() {
+                continue;
+            }
+
+            // no queued tasks; we may be done
+            match ret {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => return Poll::Ready(()),
+                _ => {}
+            }
+        }
+    }
+
+    // Try make minimal progress on the pool of spawned tasks
+    fn poll_pool_once(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
+        // empty the incoming queue of newly-spawned tasks
+        {
+            let mut incoming = self.incoming.borrow_mut();
+            for task in incoming.drain(..) {
+                self.pool.push(task)
+            }
+        }
+
+        // try to execute the next ready future
+        self.pool.poll_next_unpin(cx)
+    }
+}
+
+impl Default for LocalPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Run a future to completion on the current thread.
+///
+/// This function will block the caller until the given future has completed.
+///
+/// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
+/// spawned tasks.
+pub fn block_on<F: Future>(f: F) -> F::Output {
+    pin_mut!(f);
+    run_executor(|cx| f.as_mut().poll(cx))
+}
+
+/// Turn a stream into a blocking iterator.
+///
+/// When `next` is called on the resulting `BlockingStream`, the caller
+/// will be blocked until the next element of the `Stream` becomes available.
+pub fn block_on_stream<S: Stream + Unpin>(stream: S) -> BlockingStream<S> {
+    BlockingStream { stream }
+}
+
+/// An iterator which blocks on values from a stream until they become available.
+#[derive(Debug)]
+pub struct BlockingStream<S: Stream + Unpin> {
+    stream: S,
+}
+
+impl<S: Stream + Unpin> Deref for BlockingStream<S> {
+    type Target = S;
+    fn deref(&self) -> &Self::Target {
+        &self.stream
+    }
+}
+
+impl<S: Stream + Unpin> DerefMut for BlockingStream<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.stream
+    }
+}
+
+impl<S: Stream + Unpin> BlockingStream<S> {
+    /// Convert this `BlockingStream` into the inner `Stream` type.
+    pub fn into_inner(self) -> S {
+        self.stream
+    }
+}
+
+impl<S: Stream + Unpin> Iterator for BlockingStream<S> {
+    type Item = S::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        LocalPool::new().run_until(self.stream.next())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+impl Spawn for LocalSpawner {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
+        if let Some(incoming) = self.incoming.upgrade() {
+            incoming.borrow_mut().push(future.into());
+            Ok(())
+        } else {
+            Err(SpawnError::shutdown())
+        }
+    }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        if self.incoming.upgrade().is_some() {
+            Ok(())
+        } else {
+            Err(SpawnError::shutdown())
+        }
+    }
+}
+
+impl LocalSpawn for LocalSpawner {
+    fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        if let Some(incoming) = self.incoming.upgrade() {
+            incoming.borrow_mut().push(future);
+            Ok(())
+        } else {
+            Err(SpawnError::shutdown())
+        }
+    }
+
+    fn status_local(&self) -> Result<(), SpawnError> {
+        if self.incoming.upgrade().is_some() {
+            Ok(())
+        } else {
+            Err(SpawnError::shutdown())
+        }
+    }
+}

--- a/futures-executor/src/custom_local_pool.rs
+++ b/futures-executor/src/custom_local_pool.rs
@@ -1,4 +1,14 @@
-use crate::enter;
+//! `no_std` local task execution.
+//!
+//! This module is only available when the `alloc` feature of this library is
+//! activated, and it is activated by default.
+
+use alloc::rc::{Rc, Weak};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::ops::{Deref, DerefMut};
+use core::sync::atomic::{AtomicBool, Ordering};
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
@@ -7,13 +17,9 @@ use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
 use futures_util::pin_mut;
 use futures_util::stream::FuturesUnordered;
 use futures_util::stream::StreamExt;
-use std::cell::RefCell;
-use std::ops::{Deref, DerefMut};
-use std::rc::{Rc, Weak};
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-use std::thread::{self, Thread};
 
-/// A single-threaded task pool for polling futures to completion.
+/// A custom single-threaded task pool for polling futures to completion in
+/// `no_std` environments.
 ///
 /// This executor allows you to multiplex any number of tasks onto a single
 /// thread. It's appropriate to poll strictly I/O-bound futures that do very
@@ -25,9 +31,11 @@ use std::thread::{self, Thread};
 /// single-threaded, it supports a special form of task spawning for non-`Send`
 /// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
 #[derive(Debug)]
-pub struct LocalPool {
+pub struct LocalPool<P, U> {
     pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
     incoming: Rc<Incoming>,
+    park: P,
+    notify: Arc<Notify<U>>,
 }
 
 /// A handle to a [`LocalPool`](LocalPool) that implements
@@ -39,9 +47,10 @@ pub struct LocalSpawner {
 
 type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
 
-pub(crate) struct ThreadNotify {
-    /// The (single) executor thread.
-    thread: Thread,
+#[derive(Debug)]
+struct Notify<U> {
+    /// The function to unpark the current thread.
+    unpark: U,
     /// A flag to ensure a wakeup (i.e. `unpark()`) is not "forgotten"
     /// before the next `park()`, which may otherwise happen if the code
     /// being executed as part of the future(s) being polled makes use of
@@ -50,14 +59,7 @@ pub(crate) struct ThreadNotify {
     unparked: AtomicBool,
 }
 
-thread_local! {
-    static CURRENT_THREAD_NOTIFY: Arc<ThreadNotify> = Arc::new(ThreadNotify {
-        thread: thread::current(),
-        unparked: AtomicBool::new(false),
-    });
-}
-
-impl ArcWake for ThreadNotify {
+impl<U: Fn() + Send + Sync> ArcWake for Notify<U> {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         // Make sure the wakeup is remembered until the next `park()`.
         let unparked = arc_self.unparked.swap(true, Ordering::Relaxed);
@@ -67,61 +69,66 @@ impl ArcWake for ThreadNotify {
             // otherwise the token made available by `unpark`
             // may be consumed before reaching `park()`, but `unparked`
             // ensures it is not forgotten.
-            arc_self.thread.unpark();
+            (arc_self.unpark)();
         }
     }
 }
 
 // Set up and run a basic single-threaded spawner loop, invoking `f` on each
 // turn.
-fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(mut f: F) -> T {
-    let _enter = enter().expect(
-        "cannot execute `LocalPool` executor from within \
-         another executor",
-    );
-
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
-        let waker = waker_ref(thread_notify);
-        let mut cx = Context::from_waker(&waker);
-        loop {
-            if let Poll::Ready(t) = f(&mut cx) {
-                return t;
-            }
-            // Consume the wakeup that occurred while executing `f`, if any.
-            let unparked = thread_notify.unparked.swap(false, Ordering::Acquire);
-            if !unparked {
-                // No wakeup occurred. It may occur now, right before parking,
-                // but in that case the token made available by `unpark()`
-                // is guaranteed to still be available and `park()` is a no-op.
-                thread::park();
-                // When the thread is unparked, `unparked` will have been set
-                // and needs to be unset before the next call to `f` to avoid
-                // a redundant loop iteration.
-                thread_notify.unparked.store(false, Ordering::Release);
-            }
+fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>, P: Fn(), U: Fn() + Send + Sync>(
+    mut f: F,
+    park: P,
+    notify: &Arc<Notify<U>>,
+) -> T {
+    let waker = waker_ref(notify);
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        if let Poll::Ready(t) = f(&mut cx) {
+            return t;
         }
-    })
+        // Consume the wakeup that occurred while executing `f`, if any.
+        let unparked = notify.unparked.swap(false, Ordering::Acquire);
+        if !unparked {
+            // No wakeup occurred. It may occur now, right before parking,
+            // but in that case the token made available by `unpark()`
+            // is guaranteed to still be available and `park()` is a no-op.
+            park();
+            // When the thread is unparked, `unparked` will have been set
+            // and needs to be unset before the next call to `f` to avoid
+            // a redundant loop iteration.
+            notify.unparked.store(false, Ordering::Release);
+        }
+    }
 }
 
-fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
-    let _enter = enter().expect(
-        "cannot execute `LocalPool` executor from within \
-         another executor",
-    );
-
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
-        let waker = waker_ref(thread_notify);
-        let mut cx = Context::from_waker(&waker);
-        f(&mut cx)
-    })
+fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T, U: Fn() + Send + Sync>(
+    mut f: F,
+    notify: &Arc<Notify<U>>,
+) -> T {
+    let waker = waker_ref(notify);
+    let mut cx = Context::from_waker(&waker);
+    f(&mut cx)
 }
 
-impl LocalPool {
+impl<P: Fn() + Clone, U: Fn() + Clone + Send + Sync> LocalPool<P, U> {
     /// Create a new, empty pool of tasks.
-    pub fn new() -> LocalPool {
-        LocalPool {
+    ///
+    /// ```ignore
+    /// use cortex_m::asm;
+    /// use futures::executor::custom_local_pool::LocalPool;
+    ///
+    /// let pool = LocalPool::new(asm::wfe, asm::sev);
+    /// ```
+    pub fn new(park: P, unpark: U) -> Self {
+        Self {
             pool: FuturesUnordered::new(),
             incoming: Default::default(),
+            park,
+            notify: Arc::new(Notify {
+                unpark,
+                unparked: AtomicBool::new(false),
+            }),
         }
     }
 
@@ -134,10 +141,11 @@ impl LocalPool {
 
     /// Run all tasks in the pool to completion.
     ///
-    /// ```
-    /// use futures::executor::LocalPool;
+    /// ```ignore
+    /// use cortex_m::asm;
+    /// use futures::executor::custom_local_pool::LocalPool;
     ///
-    /// let mut pool = LocalPool::new();
+    /// let pool = LocalPool::new(asm::wfe, asm::sev);
     ///
     /// // ... spawn some initial tasks using `spawn.spawn()` or `spawn.spawn_local()`
     ///
@@ -148,15 +156,18 @@ impl LocalPool {
     /// The function will block the calling thread until *all* tasks in the pool
     /// are complete, including any spawned while running existing tasks.
     pub fn run(&mut self) {
-        run_executor(|cx| self.poll_pool(cx))
+        let park = self.park.clone();
+        let notify = self.notify.clone();
+        run_executor(|cx| self.poll_pool(cx), park, &notify)
     }
 
     /// Runs all the tasks in the pool until the given future completes.
     ///
-    /// ```
-    /// use futures::executor::LocalPool;
+    /// ```ignore
+    /// use cortex_m::asm;
+    /// use futures::executor::custom_local_pool::LocalPool;
     ///
-    /// let mut pool = LocalPool::new();
+    /// let pool = LocalPool::new(asm::wfe, asm::sev);
     /// # let my_app  = async {};
     ///
     /// // run tasks in the pool until `my_app` completes
@@ -169,31 +180,39 @@ impl LocalPool {
     /// one of the pool's run or poll methods. While the function is running,
     /// however, all tasks in the pool will try to make progress.
     pub fn run_until<F: Future>(&mut self, future: F) -> F::Output {
+        let park = self.park.clone();
+        let notify = self.notify.clone();
+
         pin_mut!(future);
 
-        run_executor(|cx| {
-            {
-                // if our main task is done, so are we
-                let result = future.as_mut().poll(cx);
-                if let Poll::Ready(output) = result {
-                    return Poll::Ready(output);
+        run_executor(
+            |cx| {
+                {
+                    // if our main task is done, so are we
+                    let result = future.as_mut().poll(cx);
+                    if let Poll::Ready(output) = result {
+                        return Poll::Ready(output);
+                    }
                 }
-            }
 
-            let _ = self.poll_pool(cx);
-            Poll::Pending
-        })
+                let _ = self.poll_pool(cx);
+                Poll::Pending
+            },
+            park,
+            &notify,
+        )
     }
 
     /// Runs all tasks and returns after completing one future or until no more progress
     /// can be made. Returns `true` if one future was completed, `false` otherwise.
     ///
     /// ```
-    /// use futures::executor::LocalPool;
+    /// use cortex_m::asm;
+    /// use futures::executor::custom_local_pool::LocalPool;
     /// use futures::task::LocalSpawnExt;
     /// use futures::future::{ready, pending};
     ///
-    /// let mut pool = LocalPool::new();
+    /// let pool = LocalPool::new(asm::wfe, asm::sev);
     /// let spawner = pool.spawner();
     ///
     /// spawner.spawn_local(ready(())).unwrap();
@@ -214,34 +233,40 @@ impl LocalPool {
     /// further use of one of the pool's run or poll methods.
     /// Though only one task will be completed, progress may be made on multiple tasks.
     pub fn try_run_one(&mut self) -> bool {
-        poll_executor(|ctx| {
-            loop {
-                let ret = self.poll_pool_once(ctx);
+        let notify = self.notify.clone();
 
-                // return if we have executed a future
-                if let Poll::Ready(Some(_)) = ret {
-                    return true;
-                }
+        poll_executor(
+            |ctx| {
+                loop {
+                    let ret = self.poll_pool_once(ctx);
 
-                // if there are no new incoming futures
-                // then there is no feature that can make progress
-                // and we can return without having completed a single future
-                if self.incoming.borrow().is_empty() {
-                    return false;
+                    // return if we have executed a future
+                    if let Poll::Ready(Some(_)) = ret {
+                        return true;
+                    }
+
+                    // if there are no new incoming futures
+                    // then there is no feature that can make progress
+                    // and we can return without having completed a single future
+                    if self.incoming.borrow().is_empty() {
+                        return false;
+                    }
                 }
-            }
-        })
+            },
+            &notify,
+        )
     }
 
     /// Runs all tasks in the pool and returns if no more progress can be made
     /// on any task.
     ///
-    /// ```
-    /// use futures::executor::LocalPool;
+    /// ```ignore
+    /// use cortex_m::asm;
+    /// use futures::executor::custom_local_pool::LocalPool;
     /// use futures::task::LocalSpawnExt;
     /// use futures::future::{ready, pending};
     ///
-    /// let mut pool = LocalPool::new();
+    /// let pool = LocalPool::new(asm::wfe, asm::sev);
     /// let spawner = pool.spawner();
     ///
     /// spawner.spawn_local(ready(())).unwrap();
@@ -259,9 +284,14 @@ impl LocalPool {
     /// of the pool's run or poll methods. While the function is running, all tasks
     /// in the pool will try to make progress.
     pub fn run_until_stalled(&mut self) {
-        poll_executor(|ctx| {
-            let _ = self.poll_pool(ctx);
-        });
+        let notify = self.notify.clone();
+
+        poll_executor(
+            |ctx| {
+                let _ = self.poll_pool(ctx);
+            },
+            &notify,
+        );
     }
 
     // Make maximal progress on the entire pool of spawned task, returning `Ready`
@@ -298,64 +328,70 @@ impl LocalPool {
         // try to execute the next ready future
         self.pool.poll_next_unpin(cx)
     }
-}
 
-impl Default for LocalPool {
-    fn default() -> Self {
-        Self::new()
+    /// Run a future to completion on the current thread.
+    ///
+    /// This function will block the caller until the given future has completed.
+    ///
+    /// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
+    /// spawned tasks.
+    pub fn block_on<F: Future>(self: &mut Self, f: F) -> F::Output {
+        let park = self.park.clone();
+        let notify = self.notify.clone();
+
+        pin_mut!(f);
+        run_executor(|cx| f.as_mut().poll(cx), park, &notify)
     }
-}
 
-/// Run a future to completion on the current thread.
-///
-/// This function will block the caller until the given future has completed.
-///
-/// Use a [`LocalPool`](LocalPool) if you need finer-grained control over
-/// spawned tasks.
-pub fn block_on<F: Future>(f: F) -> F::Output {
-    pin_mut!(f);
-    run_executor(|cx| f.as_mut().poll(cx))
-}
-
-/// Turn a stream into a blocking iterator.
-///
-/// When `next` is called on the resulting `BlockingStream`, the caller
-/// will be blocked until the next element of the `Stream` becomes available.
-pub fn block_on_stream<S: Stream + Unpin>(stream: S) -> BlockingStream<S> {
-    BlockingStream { stream }
+    /// Turn a stream into a blocking iterator.
+    ///
+    /// When `next` is called on the resulting `BlockingStream`, the caller
+    /// will be blocked until the next element of the `Stream` becomes available.
+    pub fn block_on_stream<S: Stream + Unpin>(
+        self: &mut Self,
+        stream: S,
+    ) -> BlockingStream<'_, S, P, U> {
+        BlockingStream { pool: self, stream }
+    }
 }
 
 /// An iterator which blocks on values from a stream until they become available.
 #[derive(Debug)]
-pub struct BlockingStream<S: Stream + Unpin> {
+pub struct BlockingStream<'a, S: Stream + Unpin, P: Fn(), U: Fn()> {
+    pool: &'a mut LocalPool<P, U>,
     stream: S,
 }
 
-impl<S: Stream + Unpin> Deref for BlockingStream<S> {
+impl<S: Stream + Unpin, P: Fn(), U: Fn()> Deref for BlockingStream<'_, S, P, U> {
     type Target = S;
     fn deref(&self) -> &Self::Target {
         &self.stream
     }
 }
 
-impl<S: Stream + Unpin> DerefMut for BlockingStream<S> {
+impl<S: Stream + Unpin, P: Fn(), U: Fn()> DerefMut for BlockingStream<'_, S, P, U> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.stream
     }
 }
 
-impl<S: Stream + Unpin> BlockingStream<S> {
+impl<S: Stream + Unpin, P: Fn(), U: Fn()> BlockingStream<'_, S, P, U> {
     /// Convert this `BlockingStream` into the inner `Stream` type.
     pub fn into_inner(self) -> S {
         self.stream
     }
 }
 
-impl<S: Stream + Unpin> Iterator for BlockingStream<S> {
+impl<S, P, U> Iterator for BlockingStream<'_, S, P, U>
+where
+    S: Stream + Unpin,
+    P: Fn() + Clone,
+    U: Fn() + Clone + Send + Sync,
+{
     type Item = S::Item;
 
     fn next(&mut self) -> Option<Self::Item> {
-        LocalPool::new().run_until(self.stream.next())
+        self.pool.run_until(self.stream.next())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -14,6 +14,9 @@
 
 #![doc(html_root_url = "https://docs.rs/futures-executor/0.3.5")]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
@@ -33,3 +36,6 @@ pub use crate::thread_pool::{ThreadPool, ThreadPoolBuilder};
 mod enter;
 #[cfg(feature = "std")]
 pub use crate::enter::{enter, Enter, EnterError};
+
+#[cfg(feature = "alloc")]
+pub mod custom_local_pool;

--- a/futures-executor/tests/custom_local_pool.rs
+++ b/futures-executor/tests/custom_local_pool.rs
@@ -1,0 +1,387 @@
+use futures::channel::oneshot;
+use futures::executor::LocalPool;
+use futures::future::{self, Future, lazy, poll_fn};
+use futures::task::{Context, Poll, Spawn, LocalSpawn, Waker};
+use std::cell::{Cell, RefCell};
+use std::pin::Pin;
+use std::rc::Rc;
+use std::thread;
+use std::time::Duration;
+use std::sync::Arc;
+use std::sync::atomic::{Ordering, AtomicBool};
+
+struct Pending(Rc<()>);
+
+impl Future for Pending {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+        Poll::Pending
+    }
+}
+
+fn pending() -> Pending {
+    Pending(Rc::new(()))
+}
+
+#[test]
+fn run_until_single_future() {
+    let mut cnt = 0;
+
+    {
+        let mut pool = LocalPool::new();
+        let fut = lazy(|_| {
+            cnt += 1;
+        });
+        pool.run_until(fut);
+    }
+
+    assert_eq!(cnt, 1);
+}
+
+#[test]
+fn run_until_ignores_spawned() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
+    pool.run_until(lazy(|_| ()));
+}
+
+#[test]
+fn run_until_executes_spawned() {
+    let (tx, rx) = oneshot::channel();
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+        tx.send(()).unwrap();
+    })).into()).unwrap();
+    pool.run_until(rx).unwrap();
+}
+
+#[test]
+fn run_returns_if_empty() {
+    let mut pool = LocalPool::new();
+    pool.run();
+    pool.run();
+}
+
+#[test]
+fn run_executes_spawned() {
+    let cnt = Rc::new(Cell::new(0));
+    let cnt2 = cnt.clone();
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    let spawn2 = pool.spawner();
+
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+        spawn2.spawn_local_obj(Box::pin(lazy(move |_| {
+            cnt2.set(cnt2.get() + 1);
+        })).into()).unwrap();
+    })).into()).unwrap();
+
+    pool.run();
+
+    assert_eq!(cnt.get(), 1);
+}
+
+
+#[test]
+fn run_spawn_many() {
+    const ITER: usize = 200;
+
+    let cnt = Rc::new(Cell::new(0));
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    for _ in 0..ITER {
+        let cnt = cnt.clone();
+        spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+            cnt.set(cnt.get() + 1);
+        })).into()).unwrap();
+    }
+
+    pool.run();
+
+    assert_eq!(cnt.get(), ITER);
+}
+
+#[test]
+fn try_run_one_returns_if_empty() {
+    let mut pool = LocalPool::new();
+    assert!(!pool.try_run_one());
+}
+
+#[test]
+fn try_run_one_executes_one_ready() {
+    const ITER: usize = 200;
+
+    let cnt = Rc::new(Cell::new(0));
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    for _ in 0..ITER {
+        spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
+
+        let cnt = cnt.clone();
+        spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+            cnt.set(cnt.get() + 1);
+        })).into()).unwrap();
+
+        spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
+    }
+
+    for i in 0..ITER {
+        assert_eq!(cnt.get(), i);
+        assert!(pool.try_run_one());
+        assert_eq!(cnt.get(), i + 1);
+    }
+    assert!(!pool.try_run_one());
+}
+
+#[test]
+fn try_run_one_returns_on_no_progress() {
+    const ITER: usize = 10;
+
+    let cnt = Rc::new(Cell::new(0));
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    let waker: Rc<Cell<Option<Waker>>> = Rc::new(Cell::new(None));
+    {
+        let cnt = cnt.clone();
+        let waker = waker.clone();
+        spawn.spawn_local_obj(Box::pin(poll_fn(move |ctx| {
+            cnt.set(cnt.get() + 1);
+            waker.set(Some(ctx.waker().clone()));
+            if cnt.get() == ITER {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })).into()).unwrap();
+    }
+
+    for i in 0..ITER - 1 {
+        assert_eq!(cnt.get(), i);
+        assert!(!pool.try_run_one());
+        assert_eq!(cnt.get(), i + 1);
+        let w = waker.take();
+        assert!(w.is_some());
+        w.unwrap().wake();
+    }
+    assert!(pool.try_run_one());
+    assert_eq!(cnt.get(), ITER);
+}
+
+#[test]
+fn try_run_one_runs_sub_futures() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    let cnt = Rc::new(Cell::new(0));
+
+    let inner_spawner = spawn.clone();
+    let cnt1 = cnt.clone();
+    spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
+        cnt1.set(cnt1.get() + 1);
+        
+        let cnt2 = cnt1.clone();
+        inner_spawner.spawn_local_obj(Box::pin(lazy(move |_|{
+            cnt2.set(cnt2.get() + 1)
+        })).into()).unwrap();
+
+        Poll::Pending
+    })).into()).unwrap();
+
+    pool.try_run_one();
+    assert_eq!(cnt.get(), 2);
+}
+
+#[test]
+fn run_until_stalled_returns_if_empty() {
+    let mut pool = LocalPool::new();
+    pool.run_until_stalled();
+    pool.run_until_stalled();
+}
+
+#[test]
+fn run_until_stalled_returns_multiple_times() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    let cnt = Rc::new(Cell::new(0));
+
+    let cnt1 = cnt.clone();
+    spawn.spawn_local_obj(Box::pin(lazy(move |_|{ cnt1.set(cnt1.get() + 1) })).into()).unwrap();
+    pool.run_until_stalled();
+    assert_eq!(cnt.get(), 1);
+
+    let cnt2 = cnt.clone();
+    spawn.spawn_local_obj(Box::pin(lazy(move |_|{ cnt2.set(cnt2.get() + 1) })).into()).unwrap();
+    pool.run_until_stalled();
+    assert_eq!(cnt.get(), 2);
+}
+
+#[test]
+fn run_until_stalled_runs_spawned_sub_futures() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+    let cnt = Rc::new(Cell::new(0));
+
+    let inner_spawner = spawn.clone();
+    let cnt1 = cnt.clone();
+    spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
+        cnt1.set(cnt1.get() + 1);
+        
+        let cnt2 = cnt1.clone();
+        inner_spawner.spawn_local_obj(Box::pin(lazy(move |_|{
+            cnt2.set(cnt2.get() + 1)
+        })).into()).unwrap();
+
+        Poll::Pending
+    })).into()).unwrap();
+
+    pool.run_until_stalled();
+    assert_eq!(cnt.get(), 2);
+}
+
+#[test]
+fn run_until_stalled_executes_all_ready() {
+    const ITER: usize = 200;
+    const PER_ITER: usize = 3;
+
+    let cnt = Rc::new(Cell::new(0));
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    for i in 0..ITER {
+        for _ in 0..PER_ITER {
+            spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
+
+            let cnt = cnt.clone();
+            spawn.spawn_local_obj(Box::pin(lazy(move |_| {
+                cnt.set(cnt.get() + 1);
+            })).into()).unwrap();
+
+            // also add some pending tasks to test if they are ignored
+            spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
+        }
+        assert_eq!(cnt.get(), i * PER_ITER);
+        pool.run_until_stalled();
+        assert_eq!(cnt.get(), (i + 1) * PER_ITER);
+    }
+}
+
+#[test]
+#[should_panic]
+fn nesting_run() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    spawn.spawn_obj(Box::pin(lazy(|_| {
+        let mut pool = LocalPool::new();
+        pool.run();
+    })).into()).unwrap();
+
+    pool.run();
+}
+
+#[test]
+#[should_panic]
+fn nesting_run_run_until_stalled() {
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    spawn.spawn_obj(Box::pin(lazy(|_| {
+        let mut pool = LocalPool::new();
+        pool.run_until_stalled();
+    })).into()).unwrap();
+
+    pool.run();
+}
+
+#[test]
+fn tasks_are_scheduled_fairly() {
+    let state = Rc::new(RefCell::new([0, 0]));
+
+    struct Spin {
+        state: Rc<RefCell<[i32; 2]>>,
+        idx: usize,
+    }
+
+    impl Future for Spin {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            let mut state = self.state.borrow_mut();
+
+            if self.idx == 0 {
+                let diff = state[0] - state[1];
+
+                assert!(diff.abs() <= 1);
+
+                if state[0] >= 50 {
+                    return Poll::Ready(());
+                }
+            }
+
+            state[self.idx] += 1;
+
+            if state[self.idx] >= 100 {
+                return Poll::Ready(());
+            }
+
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+
+    let mut pool = LocalPool::new();
+    let spawn = pool.spawner();
+
+    spawn.spawn_local_obj(Box::pin(Spin {
+        state: state.clone(),
+        idx: 0,
+    }).into()).unwrap();
+
+    spawn.spawn_local_obj(Box::pin(Spin {
+        state,
+        idx: 1,
+    }).into()).unwrap();
+
+    pool.run();
+}
+
+// Tests that the use of park/unpark in user-code has no
+// effect on the expected behaviour of the executor.
+#[test]
+fn park_unpark_independence() {
+    let mut done = false;
+
+    let future = future::poll_fn(move |cx| {
+        if done {
+            return Poll::Ready(())
+        }
+        done = true;
+        cx.waker().clone().wake(); // (*)
+        // some user-code that temporarily parks the thread
+        let test = thread::current();
+        let latch = Arc::new(AtomicBool::new(false));
+        let signal = latch.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(10));
+            signal.store(true, Ordering::SeqCst);
+            test.unpark()
+        });
+        while !latch.load(Ordering::Relaxed) {
+            thread::park();
+        }
+        Poll::Pending // Expect to be called again due to (*).
+    });
+
+    futures::executor::block_on(future)
+}
+

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -38,7 +38,7 @@ pin-project = "0.4.20"
 [features]
 default = ["std", "async-await", "executor"]
 std = ["alloc", "futures-core/std", "futures-task/std", "futures-io/std", "futures-sink/std", "futures-util/std", "futures-util/io", "futures-util/channel"]
-alloc = ["futures-core/alloc", "futures-task/alloc", "futures-sink/alloc", "futures-channel/alloc", "futures-util/alloc"]
+alloc = ["futures-core/alloc", "futures-task/alloc", "futures-sink/alloc", "futures-channel/alloc", "futures-executor/alloc", "futures-util/alloc"]
 async-await = ["futures-util/async-await", "futures-util/async-await-macro"]
 compat = ["std", "futures-util/compat"]
 io-compat = ["compat", "futures-util/io-compat"]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -174,7 +174,6 @@ pub mod compat {
     };
 }
 
-#[cfg(feature = "executor")]
 pub mod executor {
     //! Task execution.
     //!
@@ -182,8 +181,9 @@ pub mod executor {
     //! capable of spawning futures as tasks. This module provides several
     //! built-in executors, as well as tools for building your own.
     //!
-    //! This module is only available when the `executor` feature of this
-    //! library is activated, and it is activated by default.
+    //! Except for [`custom_local_pool`], this module is only available when
+    //! the `executor` feature of this library is activated, and it is
+    //! activated by default.
     //!
     //! # Using a thread pool (M:N task scheduling)
     //!
@@ -217,6 +217,7 @@ pub mod executor {
     //! [`block_on`](crate::executor::block_on) for simply running a future to
     //! completion on the current thread.
 
+    #[cfg(feature = "executor")]
     pub use futures_executor::{
         BlockingStream,
         Enter, EnterError,
@@ -224,8 +225,18 @@ pub mod executor {
         block_on, block_on_stream, enter,
     };
 
+    #[cfg(feature = "executor")]
     #[cfg(feature = "thread-pool")]
     pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
+
+    #[cfg(feature = "alloc")]
+    pub mod custom_local_pool {
+        //! `no_std` local task execution.
+        //!
+        //! This module is only available when the `alloc` feature of this library is
+        //! activated, and it is activated by default.
+        pub use futures_executor::custom_local_pool::{BlockingStream, LocalPool, LocalSpawner};
+    }
 }
 
 pub mod future {


### PR DESCRIPTION
Related to #1007.

This is an effort to create a `LocalPool` which can be run on embedded devices without `std`.

While the proof of concept executor from Ferrous Systems relies on a private allocator ([rust-embedded-community/async-on-embedded/async-embedded/src/alloc.rs](https://github.com/rust-embedded-community/async-on-embedded/blob/17aa0f6ef1f1e3639acbce28093c6c30aacaf2c9/async-embedded/src/alloc.rs)), this approach requires a global allocator (like [alloc-cortex-m](https://github.com/rust-embedded/alloc-cortex-m)) and leverages existing abstractions like `FuturesUnordered`.

As we can't park/unpark the current thread without `std`, this approach is generic over the park/unpark functions. The user has to supply them, matching their environment, like this: `LocalPool::new(asm::wfe, asm::sev)`. Using empty functions for testing is possible as well.

This custom local pool is based on `LocalPool`. It was necessary to remove two occurences of `thread_local!`:

1. A waker to for the current thread was saved in thread local storage:
https://github.com/rust-lang/futures-rs/blob/19831dbecd13961fbd4243c1114663e24299c33d/futures-executor/src/local_pool.rs#L53-L58
This waker is now created by the pool, calling the provided function.

2. In `enter`:
https://github.com/rust-lang/futures-rs/blob/19831dbecd13961fbd4243c1114663e24299c33d/futures-executor/src/enter.rs#L4
This is used to avoid nested invoking of the executor. I did remove this and the two respective tests in my first attemt. Do you have an idea for a better solution? 

To view the changes from the `std`-based `LocalPool`, take a look at the second commit and following.
Note: I did not work on documentation and proper integration into `futures` jet. Also I am not sure about the naming of this executor.

Is this in scope of this project, or should I spin this off as another crate? What do you think?