### PR TITLE
Avoid writes without any data in write_all_vectored

### DIFF
--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -124,9 +124,9 @@ pub use self::write_vectored::WriteVectored;
 mod write_all;
 pub use self::write_all::WriteAll;
 
-#[cfg(feature = "write_all_vectored")]
+#[cfg(feature = "write-all-vectored")]
 mod write_all_vectored;
-#[cfg(feature = "write_all_vectored")]
+#[cfg(feature = "write-all-vectored")]
 pub use self::write_all_vectored::WriteAllVectored;
 
 /// An extension trait which adds utility methods to `AsyncRead` types.
@@ -493,9 +493,10 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// ```
     /// # futures::executor::block_on(async {
     /// use futures::io::AsyncWriteExt;
-    /// use std::io::{Cursor, IoSlice};
+    /// use futures_util::io::Cursor;
+    /// use std::io::IoSlice;
     ///
-    /// let mut writer = Cursor::new([0u8; 7]);
+    /// let mut writer = Cursor::new(Vec::new());
     /// let bufs = &mut [
     ///     IoSlice::new(&[1]),
     ///     IoSlice::new(&[2, 3]),
@@ -503,12 +504,12 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// ];
     ///
     /// writer.write_all_vectored(bufs).await?;
-    /// // Note: the contents of `bufs` is now undefined, see the Notes section.
+    /// // Note: the contents of `bufs` is now unspecified, see the Notes section.
     ///
-    /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 5, 6, 0]);
+    /// assert_eq!(writer.into_inner(), &[1, 2, 3, 4, 5, 6]);
     /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
-    #[cfg(feature = "write_all_vectored")]
+    #[cfg(feature = "write-all-vectored")]
     fn write_all_vectored<'a>(
         &'a mut self,
         bufs: &'a mut [IoSlice<'a>],

--- a/futures-util/src/io/write_all_vectored.rs
+++ b/futures-util/src/io/write_all_vectored.rs
@@ -19,7 +19,7 @@ impl<W: ?Sized + Unpin> Unpin for WriteAllVectored<'_, W> {}
 
 impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAllVectored<'a, W> {
     pub(super) fn new(writer: &'a mut W, bufs: &'a mut [IoSlice<'a>]) -> Self {
-        WriteAllVectored { writer, bufs }
+        WriteAllVectored { writer, bufs: IoSlice::advance(bufs, 0) }
     }
 }
 
@@ -171,6 +171,7 @@ mod tests {
         #[rustfmt::skip] // Becomes unreadable otherwise.
         let tests: Vec<(_, &'static [u8])> = vec![
             (vec![], &[]),
+            (vec![IoSlice::new(&[]), IoSlice::new(&[])], &[]),
             (vec![IoSlice::new(&[1])], &[1]),
             (vec![IoSlice::new(&[1, 2])], &[1, 2]),
             (vec![IoSlice::new(&[1, 2, 3])], &[1, 2, 3]),


### PR DESCRIPTION
Previously, when non-empty sequence of empty IoSlices have been provided
to write_all_vectored, the buffers would be written as is with
write_vectored, and subsequently the return value of Ok(0) would be
misinterpreted as an error.

Avoid writes without any data by advancing the buffers first. This is
analogous to behaviour of write_all which makes no attempt to write if
there is no data.

Includes #2181.

