### PR TITLE
Remove mut from Sender::start_send()

### DIFF
--- a/futures-channel/src/mpsc/sink_impl.rs
+++ b/futures-channel/src/mpsc/sink_impl.rs
@@ -14,7 +14,7 @@ impl<T> Sink<T> for Sender<T> {
     }
 
     fn start_send(
-        mut self: Pin<&mut Self>,
+        self: Pin<&mut Self>,
         msg: T,
     ) -> Result<(), Self::Error> {
         (*self).start_send(msg)

--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -126,7 +126,7 @@ fn single_receiver_drop_closes_channel_and_drains() {
         let ref_count = Arc::new(0);
         let weak_ref = Arc::downgrade(&ref_count);
 
-        let (mut sender, receiver) = mpsc::channel(1);
+        let (sender, receiver) = mpsc::channel(1);
         sender.try_send(ref_count).expect("failed to send");
 
         // Verify that the sent message is still live.

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -428,7 +428,7 @@ fn stress_poll_ready() {
 #[test]
 fn try_send_1() {
     const N: usize = 3000;
-    let (mut tx, rx) = mpsc::channel(0);
+    let (tx, rx) = mpsc::channel(0);
 
     let t = thread::spawn(move || {
         for i in 0..N {
@@ -477,7 +477,7 @@ fn try_send_2() {
 
 #[test]
 fn try_send_fail() {
-    let (mut tx, rx) = mpsc::channel(0);
+    let (tx, rx) = mpsc::channel(0);
     let mut rx = block_on_stream(rx);
 
     tx.try_send("hello").unwrap();
@@ -496,7 +496,7 @@ fn try_send_fail() {
 
 #[test]
 fn try_send_recv() {
-    let (mut tx, mut rx) = mpsc::channel(1);
+    let (tx, mut rx) = mpsc::channel(1);
     tx.try_send("hello").unwrap();
     tx.try_send("hello").unwrap();
     tx.try_send("hello").unwrap_err(); // should be full


### PR DESCRIPTION
I'm not expecting to see this PR merged - just looking to learn!

`std::sync::mpsc::Sender` and `async_channel::Sender` both have `send` methods that don't require `mut`, but `futures_channel::mpsc::Sender` does. Why exactly? I see the comment on `maybe_parked` says "this is an optimization to avoid having to lock the mutex most of the time". Making a "multi-producer" method `mut` to implement an optimization seems like a steep price. Would `AtomicBool` suffice?