### PR TITLE
Mention FuturesOrdered as alternative to join_all

### DIFF
--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -56,8 +56,10 @@ where
 ///
 /// This is purposefully a very simple API for basic use-cases. In a lot of
 /// cases you will want to use the more powerful
-/// [`FuturesUnordered`][crate::stream::FuturesUnordered] APIs, some
-/// examples of additional functionality that provides:
+/// [`FuturesOrdered`][crate::stream::FuturesOrdered] APIs, or, if order does
+/// not matter, [`FuturesUnordered`][crate::stream::FuturesUnordered].
+///
+/// Some examples for additional functionality provided by these are:
 ///
 ///  * Adding new futures to the set even after it has been started.
 ///


### PR DESCRIPTION
The docs of `futures::future::join_all` say that results are collected “into a destination Vec<T> in the same order as they were provided”, but then go on to suggest `FuturesUnordered` as an alternative to it. `FuturesOrdered` should be mentioned as a proper replacement for keeping the order, while suggesting `FuturesUnordered` as an additional option.