### PR TITLE
extend example for join!/try_join!

### DIFF
--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -22,8 +22,13 @@ macro_rules! document_join_macro {
         ///
         /// let a = async { 1 };
         /// let b = async { 2 };
-        ///
+        /// let c = async { 3 };
+        /// let d = async { 4 };
+        /// let e = async { 5 };
+        /// 
+        /// // `join!` is variadic
         /// assert_eq!(join!(a, b), (1, 2));
+        /// assert_eq!(join!(c, d, e), (3, 4, 5));
         /// # });
         /// ```
         $join
@@ -48,9 +53,14 @@ macro_rules! document_join_macro {
         /// use futures::try_join;
         ///
         /// let a = async { Ok::<i32, i32>(1) };
-        /// let b = async { Ok::<u64, i32>(2) };
+        /// let b = async { Ok::<i32, i32>(2) };
+        /// let c = async { Ok::<i32, i32>(3) };
+        /// let d = async { Ok::<i32, i32>(4) };
+        /// let e = async { Ok::<i32, i32>(5) };
         ///
+        /// // `try_join!` is variadic
         /// assert_eq!(try_join!(a, b), Ok((1, 2)));
+        /// assert_eq!(try_join!(c, d, e), Ok((3, 4, 5)));
         /// # });
         /// ```
         ///

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -22,12 +22,12 @@ macro_rules! document_join_macro {
         ///
         /// let a = async { 1 };
         /// let b = async { 2 };
+        /// assert_eq!(join!(a, b), (1, 2));
+        ///
+        /// // `join!` is variadic
         /// let c = async { 3 };
         /// let d = async { 4 };
         /// let e = async { 5 };
-        /// 
-        /// // `join!` is variadic
-        /// assert_eq!(join!(a, b), (1, 2));
         /// assert_eq!(join!(c, d, e), (3, 4, 5));
         /// # });
         /// ```

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -24,7 +24,7 @@ macro_rules! document_join_macro {
         /// let b = async { 2 };
         /// assert_eq!(join!(a, b), (1, 2));
         ///
-        /// // `join!` is variadic
+        /// // `join!` is variadic, so you can pass any number of futures
         /// let c = async { 3 };
         /// let d = async { 4 };
         /// let e = async { 5 };
@@ -56,7 +56,7 @@ macro_rules! document_join_macro {
         /// let b = async { Ok::<i32, i32>(2) };
         /// assert_eq!(try_join!(a, b), Ok((1, 2)));
         ///
-        /// // `try_join!` is variadic
+        /// // `try_join!` is variadic, so you can pass any number of futures
         /// let c = async { Ok::<i32, i32>(3) };
         /// let d = async { Ok::<i32, i32>(4) };
         /// let e = async { Ok::<i32, i32>(5) };

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -54,12 +54,12 @@ macro_rules! document_join_macro {
         ///
         /// let a = async { Ok::<i32, i32>(1) };
         /// let b = async { Ok::<i32, i32>(2) };
+        /// assert_eq!(try_join!(a, b), Ok((1, 2)));
+        ///
+        /// // `try_join!` is variadic
         /// let c = async { Ok::<i32, i32>(3) };
         /// let d = async { Ok::<i32, i32>(4) };
         /// let e = async { Ok::<i32, i32>(5) };
-        ///
-        /// // `try_join!` is variadic
-        /// assert_eq!(try_join!(a, b), Ok((1, 2)));
         /// assert_eq!(try_join!(c, d, e), Ok((3, 4, 5)));
         /// # });
         /// ```


### PR DESCRIPTION
Hello :crab: , this PR makes the following change.
* Update examples for `join!`/`try_join!` to make explicit that these macros are variadic.

closes #2120 

Thank you for reviewing this PR :+1: 