### PR TITLE
Fix UB due to missing 'static on task::waker

### DIFF
--- a/futures-task/src/waker.rs
+++ b/futures-task/src/waker.rs
@@ -18,7 +18,7 @@ pub(super) fn waker_vtable<W: ArcWake>() -> &'static RawWakerVTable {
 /// [`ArcWake.wake()`](ArcWake::wake) if awoken.
 pub fn waker<W>(wake: Arc<W>) -> Waker
 where
-    W: ArcWake,
+    W: ArcWake + 'static,
 {
     let ptr = Arc::into_raw(wake) as *const ();
 


### PR DESCRIPTION
The `futures::task::waker` function currently allows you to transmute an `Arc<T>` into a `Waker`, even if `T` is not `'static`. This can cause an use-after-free.

```rust
use std::sync::Arc;
use futures::task::{waker, ArcWake};

struct MyRef<'a> {
    a: &'a str,
}

impl<'a> ArcWake for MyRef<'a> {
    fn wake_by_ref(arc_self: &Arc<Self>) {
        println!("{}", arc_self.a);
    }
}

fn main() {
    let string = "Hello World!".to_string();
    let waker = waker(Arc::new(MyRef { a: &string }));
    drop(string);
    waker.wake(); // This causes an use-after-free of the string.
}
```
[playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=7285f2d4210708a36e509b656236a712)