### PR TITLE
Make Flatten doc point to flatten method

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -48,7 +48,7 @@ pub use self::filter_map::FilterMap;
 mod flatten;
 
 delegate_all!(
-    /// Stream for the [`inspect`](StreamExt::inspect) method.
+    /// Stream for the [`flatten`](StreamExt::flatten) method.
     Flatten<St>(
         flatten::Flatten<St, St::Item>
     ): Debug + Sink + Stream + FusedStream + AccessInner[St, (.)] + New[|x: St| flatten::Flatten::new(x)]


### PR DESCRIPTION
The [doc for `Flatten`](https://docs.rs/futures/0.3.5/futures/stream/struct.Flatten.html) claims to be for the `inspect` method. I believe this is probably a copy/paste oversight. This change replaces the reference to `inspect` with one to `flatten`.