### PR TITLE
futures: Require all stable features in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,16 @@ matrix:
     # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
     - name: cargo build --features async-await (minimum required version)
       rust: 1.39.0
+      install:
+        # cargo does not support for --features/--no-default-features with workspace, so use cargo-hack instead.
+        # Refs: cargo#3620, cargo#4106, cargo#4463, cargo#4753, cargo#5015, cargo#5364, cargo#6195
+        - if ! cargo hack -V 2>/dev/null; then
+            cargo install cargo-hack;
+          fi
       script:
-        - cargo run --manifest-path ci/remove-dev-dependencies/Cargo.toml */Cargo.toml
         # async-await feature is activated by default.
-        - cargo build --workspace
+        - cargo hack build --workspace --no-dev-deps
+        - cargo build --tests --features default,thread-pool,io-compat --manifest-path futures/Cargo.toml
 
     - name: cargo +stable build
       rust: stable

--- a/futures/tests/_require_features.rs
+++ b/futures/tests/_require_features.rs
@@ -1,0 +1,8 @@
+#[cfg(not(all(
+    feature = "std", feature = "alloc", feature = "async-await",
+    feature = "compat", feature = "io-compat",
+    feature = "executor", feature = "thread-pool",
+)))]
+compile_error!("`futures` tests must have all stable features activated: \
+    use `--all-features` or `--features default,thread-pool,io-compat`"
+);

--- a/futures/tests/abortable.rs
+++ b/futures/tests/abortable.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "alloc", feature = "executor"))]
 #[test]
 fn abortable_works() {
     use futures::channel::oneshot;
@@ -12,7 +11,6 @@ fn abortable_works() {
     assert_eq!(Err(Aborted), block_on(abortable_rx));
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))]
 #[test]
 fn abortable_awakens() {
     use futures::channel::oneshot;
@@ -33,7 +31,6 @@ fn abortable_awakens() {
     assert_eq!(Poll::Ready(Err(Aborted)), abortable_rx.poll_unpin(&mut cx));
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))]
 #[test]
 fn abortable_resolves() {
     use futures::channel::oneshot;

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")]
 mod countingwaker {
     use futures::task::{self, ArcWake, Waker};
     use std::sync::{Arc, Mutex};
@@ -60,7 +59,6 @@ mod countingwaker {
     }
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn proper_refcount_on_wake_panic() {
     use futures::task::{self, ArcWake, Waker};

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -1,6 +1,3 @@
-#![recursion_limit="128"]
-
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn poll_and_pending() {
     use futures::{pending, pin_mut, poll};
@@ -15,7 +12,6 @@ fn poll_and_pending() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn join() {
     use futures::{pin_mut, poll, join};
@@ -41,7 +37,6 @@ fn join() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select() {
     use futures::select;
@@ -65,7 +60,6 @@ fn select() {
     assert!(ran);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor", feature = "async-await"))]
 #[test]
 fn select_biased() {
     use futures::channel::oneshot;
@@ -89,7 +83,6 @@ fn select_biased() {
     assert!(ran);
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_streams() {
     use futures::select;
@@ -139,7 +132,6 @@ fn select_streams() {
     assert!(ran);
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_can_move_uncompleted_futures() {
     use futures::select;
@@ -171,7 +163,6 @@ fn select_can_move_uncompleted_futures() {
     assert!(ran);
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_nested() {
     use futures::select;
@@ -192,7 +183,6 @@ fn select_nested() {
     assert_eq!(res, 3);
 }
 
-#[cfg(all(feature = "async-await", feature = "std"))]
 #[test]
 fn select_size() {
     use futures::select;
@@ -217,7 +207,6 @@ fn select_size() {
     assert_eq!(::std::mem::size_of_val(&fut), 40);
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_on_non_unpin_expressions() {
     use futures::select;
@@ -240,7 +229,6 @@ fn select_on_non_unpin_expressions() {
     assert_eq!(res, 5);
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_on_non_unpin_expressions_with_default() {
     use futures::select;
@@ -264,7 +252,6 @@ fn select_on_non_unpin_expressions_with_default() {
     assert_eq!(res, 5);
 }
 
-#[cfg(all(feature = "async-await", feature = "std"))]
 #[test]
 fn select_on_non_unpin_size() {
     use futures::select;
@@ -287,7 +274,6 @@ fn select_on_non_unpin_size() {
     assert_eq!(32, std::mem::size_of_val(&fut));
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_can_be_used_as_expression() {
     use futures::select;
@@ -303,7 +289,6 @@ fn select_can_be_used_as_expression() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_with_default_can_be_used_as_expression() {
     use futures::select;
@@ -325,7 +310,6 @@ fn select_with_default_can_be_used_as_expression() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_with_complete_can_be_used_as_expression() {
     use futures::select;
@@ -343,7 +327,6 @@ fn select_with_complete_can_be_used_as_expression() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
     use futures::select;
@@ -364,7 +347,6 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
     });
 }
 
-#[cfg(all(feature = "async-await", feature = "std", feature = "executor"))]
 #[test]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
     use futures::select;
@@ -388,7 +370,6 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
     });
 }
 
-#[cfg(feature = "async-await")]
 #[test]
 fn join_size() {
     use futures::join;
@@ -408,7 +389,6 @@ fn join_size() {
     assert_eq!(::std::mem::size_of_val(&fut), 28);
 }
 
-#[cfg(feature = "async-await")]
 #[test]
 fn try_join_size() {
     use futures::try_join;
@@ -428,7 +408,6 @@ fn try_join_size() {
     assert_eq!(::std::mem::size_of_val(&fut), 28);
 }
 
-#[cfg(feature = "async-await")]
 #[test]
 fn join_doesnt_require_unpin() {
     use futures::join;
@@ -438,7 +417,6 @@ fn join_doesnt_require_unpin() {
     };
 }
 
-#[cfg(feature = "async-await")]
 #[test]
 fn try_join_doesnt_require_unpin() {
     use futures::try_join;

--- a/futures/tests/atomic_waker.rs
+++ b/futures/tests/atomic_waker.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn basic() {
     use std::sync::atomic::AtomicUsize;

--- a/futures/tests/buffer_unordered.rs
+++ b/futures/tests/buffer_unordered.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "alloc", feature = "std", feature = "executor"))]
 #[test]
 #[ignore] // FIXME: https://github.com/rust-lang/futures-rs/issues/1790
 fn works() {

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "compat")]
-
 use tokio::timer::Delay;
 use tokio::runtime::Runtime;
 use std::time::Instant;

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -63,7 +63,6 @@ mod channelled {
         }
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn then_drops_eagerly() {
         use futures::channel::oneshot;
@@ -88,7 +87,6 @@ mod channelled {
         rx2.recv().unwrap();
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn and_then_drops_eagerly() {
         use futures::channel::oneshot;
@@ -113,7 +111,6 @@ mod channelled {
         rx2.recv().unwrap();
     }
 
-    #[cfg(feature = "alloc")]
     #[test]
     fn or_else_drops_eagerly() {
         use futures::channel::oneshot;

--- a/futures/tests/eventual.rs
+++ b/futures/tests/eventual.rs
@@ -1,4 +1,3 @@
-#![cfg(all(feature = "executor", feature = "thread-pool"))]
 use futures::channel::oneshot;
 use futures::executor::ThreadPool;
 use futures::future::{self, ok, Future, FutureExt, TryFutureExt};

--- a/futures/tests/future_try_flatten_stream.rs
+++ b/futures/tests/future_try_flatten_stream.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn successful_future() {
     use futures::executor::block_on_stream;
@@ -16,7 +15,6 @@ fn successful_future() {
     assert_eq!(None, iter.next());
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn failed_future() {
     use core::marker::PhantomData;

--- a/futures/tests/futures_ordered.rs
+++ b/futures/tests/futures_ordered.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "alloc", feature="executor"))]
 #[test]
 fn works_1() {
     use futures::channel::oneshot;
@@ -25,7 +24,6 @@ fn works_1() {
     assert_eq!(None, iter.next());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn works_2() {
     use futures::channel::oneshot;
@@ -51,7 +49,6 @@ fn works_2() {
     assert!(stream.poll_next_unpin(&mut cx).is_ready());
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn from_iterator() {
     use futures::executor::block_on;
@@ -67,7 +64,6 @@ fn from_iterator() {
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1,2,3]);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn queue_never_unblocked() {
     use futures::channel::oneshot;

--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")]
 #[test]
 fn is_terminated() {
     use futures::future;
@@ -31,7 +30,6 @@ fn is_terminated() {
     assert_eq!(tasks.is_terminated(), true);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))]
 #[test]
 fn works_1() {
     use futures::channel::oneshot;
@@ -58,7 +56,6 @@ fn works_1() {
     assert_eq!(None, iter.next());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn works_2() {
     use futures::channel::oneshot;
@@ -88,7 +85,6 @@ fn works_2() {
     assert_eq!(stream.poll_next_unpin(&mut cx), Poll::Ready(None));
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn from_iterator() {
     use futures::executor::block_on;
@@ -106,7 +102,6 @@ fn from_iterator() {
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn finished_future() {
     use std::marker::Unpin;
@@ -138,7 +133,6 @@ fn finished_future() {
     assert!(stream.poll_next_unpin(cx).is_pending());
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))]
 #[test]
 fn iter_mut_cancel() {
     use futures::channel::oneshot;
@@ -169,7 +163,6 @@ fn iter_mut_cancel() {
     assert_eq!(iter.next(), None);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn iter_mut_len() {
     use futures::future;
@@ -194,7 +187,6 @@ fn iter_mut_len() {
     assert!(iter_mut.next().is_none());
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn iter_cancel() {
     use std::marker::Unpin;
@@ -249,7 +241,6 @@ fn iter_cancel() {
     assert_eq!(iter.next(), None);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn iter_len() {
     use futures::future;
@@ -274,7 +265,6 @@ fn iter_len() {
     assert!(iter.next().is_none());
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn futures_not_moved_after_poll() {
     use futures::future;
@@ -292,7 +282,6 @@ fn futures_not_moved_after_poll() {
     assert_stream_done!(stream);
 }
 
-#[cfg(feature = "alloc")]
 #[test]
 fn len_valid_during_out_of_order_completion() {
     use futures::channel::oneshot;

--- a/futures/tests/inspect.rs
+++ b/futures/tests/inspect.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn smoke() {
     use futures::executor::block_on;

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "std", feature = "executor"))]
 macro_rules! run_fill_buf {
     ($reader:expr) => {{
         use futures_test::task::noop_context;
@@ -14,7 +13,6 @@ macro_rules! run_fill_buf {
     }};
 }
 
-#[cfg(any(feature = "std", feature = "executor"))]
 mod util {
     use futures::future::Future;
     pub fn run<F: Future + Unpin>(mut f: F) -> F::Output {
@@ -31,7 +29,6 @@ mod util {
     }
 }
 
-#[cfg(feature = "std")]
 mod maybe_pending {
     use futures::task::{Context,Poll};
     use std::{cmp,io};
@@ -85,7 +82,6 @@ mod maybe_pending {
     }
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn test_buffered_reader() {
     use futures::executor::block_on;
@@ -126,7 +122,6 @@ fn test_buffered_reader() {
     assert_eq!(block_on(reader.read(&mut buf)).unwrap(), 0);
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn test_buffered_reader_seek() {
     use futures::executor::block_on;
@@ -147,7 +142,6 @@ fn test_buffered_reader_seek() {
     assert_eq!(block_on(reader.seek(SeekFrom::Current(-2))).ok(), Some(3));
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn test_buffered_reader_seek_underflow() {
     use futures::executor::block_on;
@@ -198,7 +192,6 @@ fn test_buffered_reader_seek_underflow() {
     assert_eq!(reader.get_ref().get_ref().pos, expected);
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn test_short_reads() {
     use futures::executor::block_on;
@@ -232,7 +225,6 @@ fn test_short_reads() {
     assert_eq!(block_on(reader.read(&mut buf)).unwrap(), 0);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending() {
     use futures::io::{AsyncReadExt, BufReader};
@@ -274,7 +266,6 @@ fn maybe_pending() {
     assert_eq!(run(reader.read(&mut buf)).unwrap(), 0);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending_buf_read() {
     use futures::io::{AsyncBufReadExt, BufReader};
@@ -298,7 +289,6 @@ fn maybe_pending_buf_read() {
 }
 
 // https://github.com/rust-lang/futures-rs/pull/1573#discussion_r281162309
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending_seek() {
     use futures::io::{AsyncBufRead, AsyncSeek, AsyncSeekExt, AsyncRead, BufReader,

--- a/futures/tests/io_buf_writer.rs
+++ b/futures/tests/io_buf_writer.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")]
 mod maybe_pending {
     use futures::io::AsyncWrite;
     use futures::task::{Context, Poll};
@@ -41,7 +40,6 @@ mod maybe_pending {
     }
 }
 
-#[cfg(any(feature = "std", feature = "executor"))]
 mod util {
     use futures::future::Future;
 
@@ -59,7 +57,6 @@ mod util {
     }
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn buf_writer() {
     use futures::executor::block_on;
@@ -105,7 +102,6 @@ fn buf_writer() {
     assert_eq!(*writer.get_ref(), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn buf_writer_inner_flushes() {
     use futures::executor::block_on;
@@ -119,7 +115,6 @@ fn buf_writer_inner_flushes() {
     assert_eq!(w, [0, 1]);
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn buf_writer_seek() {
     use futures::executor::block_on;
@@ -138,7 +133,6 @@ fn buf_writer_seek() {
     assert_eq!(&w.into_inner().into_inner()[..], &[0, 1, 8, 9, 4, 5, 6, 7]);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending_buf_writer() {
     use futures::io::{AsyncWriteExt, BufWriter};
@@ -186,7 +180,6 @@ fn maybe_pending_buf_writer() {
     assert_eq!(&writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending_buf_writer_inner_flushes() {
     use futures::io::{AsyncWriteExt, BufWriter};
@@ -202,7 +195,6 @@ fn maybe_pending_buf_writer_inner_flushes() {
     assert_eq!(w, [0, 1]);
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending_buf_writer_seek() {
     use futures::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter, Cursor, SeekFrom};

--- a/futures/tests/io_cursor.rs
+++ b/futures/tests/io_cursor.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "std", feature = "executor"))]
 #[test]
 fn cursor_asyncwrite_vec() {
     use assert_matches::assert_matches;
@@ -17,7 +16,6 @@ fn cursor_asyncwrite_vec() {
     assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5, 6, 6, 7]);
 }
 
-#[cfg(all(feature = "std", feature = "executor"))]
 #[test]
 fn cursor_asyncwrite_box() {
     use assert_matches::assert_matches;

--- a/futures/tests/io_lines.rs
+++ b/futures/tests/io_lines.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "std", feature = "executor"))]
 mod util {
     use futures::future::Future;
 
@@ -16,7 +15,6 @@ mod util {
     }
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn lines() {
     use futures::executor::block_on;
@@ -41,7 +39,6 @@ fn lines() {
     assert!(block_on(s.next()).is_none());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending() {
     use futures::stream::{self, StreamExt, TryStreamExt};

--- a/futures/tests/io_read.rs
+++ b/futures/tests/io_read.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")]
 mod mock_reader {
     use futures::io::AsyncRead;
     use std::io;
@@ -28,7 +27,6 @@ mod mock_reader {
 
 /// Verifies that the default implementation of `poll_read_vectored`
 /// calls `poll_read` with an empty slice if no buffers are provided.
-#[cfg(feature = "std")]
 #[test]
 fn read_vectored_no_buffers() {
     use futures::io::AsyncRead;
@@ -53,7 +51,6 @@ fn read_vectored_no_buffers() {
 
 /// Verifies that the default implementation of `poll_read_vectored`
 /// calls `poll_read` with the first non-empty buffer.
-#[cfg(feature = "std")]
 #[test]
 fn read_vectored_first_non_empty() {
     use futures::io::AsyncRead;
@@ -72,7 +69,7 @@ fn read_vectored_first_non_empty() {
     let cx = &mut panic_context();
     let mut buf = [0; 4];
     let bufs = &mut [
-        io::IoSliceMut::new(&mut []), 
+        io::IoSliceMut::new(&mut []),
         io::IoSliceMut::new(&mut []),
         io::IoSliceMut::new(&mut buf),
     ];
@@ -82,4 +79,3 @@ fn read_vectored_first_non_empty() {
     assert_eq!(res, Poll::Ready(Ok(4)));
     assert_eq!(buf, b"four"[..]);
 }
-

--- a/futures/tests/io_read_exact.rs
+++ b/futures/tests/io_read_exact.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn read_exact() {
     use futures::executor::block_on;

--- a/futures/tests/io_read_line.rs
+++ b/futures/tests/io_read_line.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn read_line() {
     use futures::executor::block_on;
@@ -21,7 +20,6 @@ fn read_line() {
     assert_eq!(v, "");
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending() {
     use futures::future::Future;

--- a/futures/tests/io_read_to_string.rs
+++ b/futures/tests/io_read_to_string.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "std", feature = "executor"))]
 #[test]
 fn read_to_string() {
     use futures::executor::block_on;
@@ -19,7 +18,6 @@ fn read_to_string() {
     assert!(block_on(c.read_to_string(&mut v)).is_err());
 }
 
-#[cfg(feature = "std")]
 #[test]
 fn interleave_pending() {
     use futures::future::Future;

--- a/futures/tests/io_read_until.rs
+++ b/futures/tests/io_read_until.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn read_until() {
     use futures::executor::block_on;
@@ -21,8 +20,6 @@ fn read_until() {
     assert_eq!(v, []);
 }
 
-
-#[cfg(feature = "std")]
 #[test]
 fn maybe_pending() {
     use futures::future::Future;

--- a/futures/tests/io_window.rs
+++ b/futures/tests/io_window.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "std")]
 #![allow(clippy::reversed_empty_ranges)] // This is intentional.
 
 use futures::io::Window;

--- a/futures/tests/io_write.rs
+++ b/futures/tests/io_write.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")]
 mod mock_writer {
     use futures::io::AsyncWrite;
     use std::io;
@@ -36,7 +35,6 @@ mod mock_writer {
 
 /// Verifies that the default implementation of `poll_write_vectored`
 /// calls `poll_write` with an empty slice if no buffers are provided.
-#[cfg(feature = "std")]
 #[test]
 fn write_vectored_no_buffers() {
     use futures::io::AsyncWrite;
@@ -61,7 +59,6 @@ fn write_vectored_no_buffers() {
 
 /// Verifies that the default implementation of `poll_write_vectored`
 /// calls `poll_write` with the first non-empty buffer.
-#[cfg(feature = "std")]
 #[test]
 fn write_vectored_first_non_empty() {
     use futures::io::AsyncWrite;
@@ -78,7 +75,7 @@ fn write_vectored_first_non_empty() {
     });
     let cx = &mut panic_context();
     let bufs = &mut [
-        io::IoSlice::new(&[]), 
+        io::IoSlice::new(&[]),
         io::IoSlice::new(&[]),
         io::IoSlice::new(b"four")
     ];
@@ -87,4 +84,3 @@ fn write_vectored_first_non_empty() {
     let res = res.map_err(|e| e.kind());
     assert_eq!(res, Poll::Ready(Ok(4)));
 }
-

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 mod util {
     use std::future::Future;
     use std::fmt::Debug;
@@ -15,7 +14,6 @@ mod util {
     }
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn collect_collects() {
     use futures_util::future::{join_all,ready};
@@ -28,7 +26,6 @@ fn collect_collects() {
     // TODO: needs more tests
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn join_all_iter_lifetime() {
     use futures_util::future::{join_all,ready};
@@ -43,7 +40,6 @@ fn join_all_iter_lifetime() {
     util::assert_done(|| sizes(vec![&[1,2,3], &[], &[0]]), vec![3 as usize, 0, 1]);
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn join_all_from_iter() {
     use futures_util::future::{JoinAll,ready};

--- a/futures/tests/macro_comma_support.rs
+++ b/futures/tests/macro_comma_support.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn ready() {
     use futures::{
@@ -14,7 +13,6 @@ fn ready() {
     }))
 }
 
-#[cfg(all(feature = "executor", feature = "async-await"))]
 #[test]
 fn poll() {
     use futures::{
@@ -28,7 +26,6 @@ fn poll() {
     })
 }
 
-#[cfg(all(feature = "executor", feature = "async-await"))]
 #[test]
 fn join() {
     use futures::{
@@ -43,7 +40,6 @@ fn join() {
     })
 }
 
-#[cfg(all(feature = "executor", feature = "async-await"))]
 #[test]
 fn try_join() {
     use futures::{

--- a/futures/tests/mutex.rs
+++ b/futures/tests/mutex.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "alloc", feature = "std"))]
 #[test]
 fn mutex_acquire_uncontested() {
     use futures::future::FutureExt;
@@ -11,7 +10,6 @@ fn mutex_acquire_uncontested() {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "std"))]
 #[test]
 fn mutex_wakes_waiters() {
     use futures::future::FutureExt;
@@ -35,7 +33,6 @@ fn mutex_wakes_waiters() {
     assert!(waiter.poll_unpin(&mut panic_context()).is_ready());
 }
 
-#[cfg(feature = "thread-pool")]
 #[test]
 fn mutex_contested() {
     use futures::channel::mpsc;

--- a/futures/tests/object_safety.rs
+++ b/futures/tests/object_safety.rs
@@ -28,7 +28,6 @@ fn sink() {
     assert_is_object_safe::<&dyn Sink<(), Error = ()>>();
 }
 
-#[cfg(feature = "std")] // futures::io
 #[test]
 fn io() {
     // `AsyncReadExt`, `AsyncWriteExt`, `AsyncSeekExt` and `AsyncBufReadExt` are not object safe.

--- a/futures/tests/oneshot.rs
+++ b/futures/tests/oneshot.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_send1() {
     use futures::channel::oneshot;
@@ -16,7 +15,6 @@ fn oneshot_send1() {
     t.join().unwrap();
 }
 
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_send2() {
     use futures::channel::oneshot;
@@ -33,7 +31,6 @@ fn oneshot_send2() {
     assert_eq!(1, rx2.recv().unwrap());
 }
 
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_send3() {
     use futures::channel::oneshot;
@@ -50,7 +47,6 @@ fn oneshot_send3() {
     assert_eq!(1, rx2.recv().unwrap());
 }
 
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_drop_tx1() {
     use futures::channel::oneshot;
@@ -67,7 +63,6 @@ fn oneshot_drop_tx1() {
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());
 }
 
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_drop_tx2() {
     use futures::channel::oneshot;
@@ -86,7 +81,6 @@ fn oneshot_drop_tx2() {
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());
 }
 
-#[cfg(feature = "alloc")] // channel
 #[test]
 fn oneshot_drop_rx() {
     use futures::channel::oneshot;

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")] // FuturesUnordered
 mod assert_send_sync {
     use futures::stream::FuturesUnordered;
 
@@ -6,7 +5,6 @@ mod assert_send_sync {
     impl AssertSendSync for FuturesUnordered<()> {}
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn basic_usage() {
     use futures::channel::oneshot;
@@ -41,7 +39,6 @@ fn basic_usage() {
     }));
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn resolving_errors() {
     use futures::channel::oneshot;
@@ -76,7 +73,6 @@ fn resolving_errors() {
     }));
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn dropping_ready_queue() {
     use futures::channel::oneshot;
@@ -110,7 +106,6 @@ fn dropping_ready_queue() {
     }));
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn stress() {
     use futures::channel::oneshot;
@@ -160,7 +155,6 @@ fn stress() {
     }
 }
 
-#[cfg(feature = "executor")] // executor
 #[test]
 fn panicking_future_dropped() {
     use futures::executor::block_on;

--- a/futures/tests/recurse.rs
+++ b/futures/tests/recurse.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn lots() {
     use futures::executor::block_on;

--- a/futures/tests/select_all.rs
+++ b/futures/tests/select_all.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn smoke() {
     use futures::executor::block_on;

--- a/futures/tests/select_ok.rs
+++ b/futures/tests/select_ok.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn ignore_err() {
     use futures::executor::block_on;
@@ -22,7 +21,6 @@ fn ignore_err() {
     assert!(v.is_empty());
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn last_err() {
     use futures::executor::block_on;

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -12,7 +12,6 @@ mod count_clone {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 fn send_shared_oneshot_and_wait_on_multiple_threads(threads_number: u32) {
     use futures::channel::oneshot;
     use futures::executor::block_on;
@@ -37,25 +36,21 @@ fn send_shared_oneshot_and_wait_on_multiple_threads(threads_number: u32) {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn one_thread() {
     send_shared_oneshot_and_wait_on_multiple_threads(1);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn two_threads() {
     send_shared_oneshot_and_wait_on_multiple_threads(2);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn many_threads() {
     send_shared_oneshot_and_wait_on_multiple_threads(1000);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn drop_on_one_task_ok() {
     use futures::channel::oneshot;
@@ -89,7 +84,6 @@ fn drop_on_one_task_ok() {
     t2.join().unwrap();
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn drop_in_poll() {
     use futures::executor::block_on;
@@ -112,7 +106,6 @@ fn drop_in_poll() {
     assert_eq!(block_on(future1), 1);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn peek() {
     use futures::channel::oneshot;
@@ -150,7 +143,6 @@ fn peek() {
     }
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn dont_clone_in_single_owner_shared_future() {
     use futures::channel::oneshot;
@@ -171,7 +163,6 @@ fn dont_clone_in_single_owner_shared_future() {
     assert_eq!(block_on(rx).unwrap().0.get(), 0);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn dont_do_unnecessary_clones_on_output() {
     use futures::channel::oneshot;
@@ -194,7 +185,6 @@ fn dont_do_unnecessary_clones_on_output() {
     assert_eq!(block_on(rx).unwrap().0.get(), 2);
 }
 
-#[cfg(all(feature = "alloc", feature = "executor"))] // channel:: + executor::
 #[test]
 fn shared_future_that_wakes_itself_until_pending_is_returned() {
     use futures::executor::block_on;

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)]
 mod sassert_next {
     use futures::stream::{Stream, StreamExt};
     use futures::task::Poll;
@@ -18,7 +17,6 @@ mod sassert_next {
     }
 }
 
-#[allow(dead_code)]
 mod unwrap {
     use futures::task::Poll;
     use std::fmt;
@@ -32,8 +30,6 @@ mod unwrap {
     }
 }
 
-#[allow(dead_code)]
-#[cfg(feature = "alloc")] // ArcWake
 mod flag_cx {
     use futures::task::{self, ArcWake, Context};
     use std::sync::Arc;
@@ -73,7 +69,6 @@ mod flag_cx {
     }
 }
 
-#[allow(dead_code)]
 mod start_send_fut {
     use futures::future::Future;
     use futures::ready;
@@ -105,7 +100,6 @@ mod start_send_fut {
     }
 }
 
-#[allow(dead_code)]
 mod manual_flush {
     use futures::sink::Sink;
     use futures::task::{Context, Poll, Waker};
@@ -166,7 +160,6 @@ mod manual_flush {
     }
 }
 
-#[allow(dead_code)]
 mod allowance {
     use futures::sink::Sink;
     use futures::task::{Context, Poll, Waker};
@@ -245,8 +238,6 @@ mod allowance {
     }
 }
 
-
-#[cfg(feature = "alloc")] // futures_sink::Sink satisfying for .left/right_sink
 #[test]
 fn either_sink() {
     use futures::sink::{Sink, SinkExt};
@@ -262,7 +253,6 @@ fn either_sink() {
     Pin::new(&mut s).start_send(0).unwrap();
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn vec_sink() {
     use futures::executor::block_on;
@@ -277,7 +267,6 @@ fn vec_sink() {
     assert_eq!(v, vec![0, 1]);
 }
 
-#[cfg(feature = "alloc")] //  futures_sink::Sink satisfying for .start_send()
 #[test]
 fn vecdeque_sink() {
     use futures::sink::Sink;
@@ -293,7 +282,6 @@ fn vecdeque_sink() {
     assert_eq!(deque.pop_front(), None);
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn send() {
     use futures::executor::block_on;
@@ -311,7 +299,6 @@ fn send() {
     assert_eq!(v, vec![0, 1, 2]);
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn send_all() {
     use futures::executor::block_on;
@@ -332,7 +319,6 @@ fn send_all() {
 
 // Test that `start_send` on an `mpsc` channel does indeed block when the
 // channel is full
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn mpsc_blocking_start_send() {
     use futures::channel::mpsc;
@@ -365,7 +351,6 @@ fn mpsc_blocking_start_send() {
 
 // test `flush` by using `with` to make the first insertion into a sink block
 // until a oneshot is completed
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn with_flush() {
     use futures::channel::oneshot;
@@ -403,7 +388,6 @@ fn with_flush() {
 }
 
 // test simple use of with to change data
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn with_as_map() {
     use futures::executor::block_on;
@@ -419,7 +403,6 @@ fn with_as_map() {
 }
 
 // test simple use of with_flat_map
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn with_flat_map() {
     use futures::executor::block_on;
@@ -436,7 +419,6 @@ fn with_flat_map() {
 
 // Check that `with` propagates `poll_ready` to the inner sink.
 // Regression test for the issue #1834.
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn with_propagates_poll_ready() {
     use futures::channel::mpsc;
@@ -473,7 +455,6 @@ fn with_propagates_poll_ready() {
 
 // test that the `with` sink doesn't require the underlying sink to flush,
 // but doesn't claim to be flushed until the underlying sink is
-#[cfg(feature = "alloc")] // flag_cx
 #[test]
 fn with_flush_propagate() {
     use futures::future::{self, FutureExt};
@@ -503,7 +484,6 @@ fn with_flush_propagate() {
 }
 
 // test that a buffer is a no-nop around a sink that always accepts sends
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn buffer_noop() {
     use futures::executor::block_on;
@@ -522,8 +502,6 @@ fn buffer_noop() {
 
 // test basic buffer functionality, including both filling up to capacity,
 // and writing out when the underlying sink is ready
-#[cfg(feature = "executor")] // executor::
-#[cfg(feature = "alloc")] // flag_cx
 #[test]
 fn buffer() {
     use futures::executor::block_on;
@@ -552,7 +530,6 @@ fn buffer() {
     })
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn fanout_smoke() {
     use futures::executor::block_on;
@@ -568,8 +545,6 @@ fn fanout_smoke() {
     assert_eq!(sink2, vec![1, 2, 3]);
 }
 
-#[cfg(feature = "executor")] // executor::
-#[cfg(feature = "alloc")] // flag_cx
 #[test]
 fn fanout_backpressure() {
     use futures::channel::mpsc;
@@ -612,7 +587,6 @@ fn fanout_backpressure() {
     })
 }
 
-#[cfg(all(feature = "alloc", feature = "std"))] // channel::mpsc
 #[test]
 fn sink_map_err() {
     use futures::channel::mpsc;
@@ -636,7 +610,6 @@ fn sink_map_err() {
     );
 }
 
-#[cfg(all(feature = "alloc", feature = "std"))] // channel::mpsc
 #[test]
 fn err_into() {
     use futures::channel::mpsc;

--- a/futures/tests/sink_fanout.rs
+++ b/futures/tests/sink_fanout.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "alloc", feature="std", feature="executor"))] // channel::mpsc, executor::
 #[test]
 fn it_works() {
     use futures::channel::mpsc;

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn test_split() {
     use futures::executor::block_on;

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn select() {
     use futures::executor::block_on;
@@ -16,7 +15,6 @@ fn select() {
     select_and_compare(vec![1, 2], vec![4, 5, 6], vec![1, 4, 2, 5, 6]);
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn flat_map() {
     use futures::stream::{self, StreamExt};
@@ -37,7 +35,6 @@ fn flat_map() {
     });
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn scan() {
     use futures::stream::{self, StreamExt};
@@ -56,7 +53,6 @@ fn scan() {
     });
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn take_until() {
     use futures::future::{self, Future};
@@ -136,7 +132,6 @@ fn ready_chunks_panic_on_cap_zero() {
     let _ = rx1.ready_chunks(0);
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn ready_chunks() {
     use futures::channel::mpsc;

--- a/futures/tests/stream_catch_unwind.rs
+++ b/futures/tests/stream_catch_unwind.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")]
 #[test]
 fn panic_in_the_middle_of_the_stream() {
     use futures::executor::block_on_stream;
@@ -15,7 +14,6 @@ fn panic_in_the_middle_of_the_stream() {
     assert!(iter.next().is_none());
 }
 
-#[cfg(feature = "executor")]
 #[test]
 fn no_panic() {
     use futures::executor::block_on_stream;

--- a/futures/tests/stream_into_async_read.rs
+++ b/futures/tests/stream_into_async_read.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")] // io::
 #[test]
 fn test_into_async_read() {
     use core::pin::Pin;
@@ -52,7 +51,6 @@ fn test_into_async_read() {
     assert_read!(reader, &mut buf, 0);
 }
 
-#[cfg(feature = "std")] // io::
 #[test]
 fn test_into_async_bufread() -> std::io::Result<()> {
     use core::pin::Pin;

--- a/futures/tests/stream_peekable.rs
+++ b/futures/tests/stream_peekable.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn peekable() {
     use futures::executor::block_on;

--- a/futures/tests/stream_select_all.rs
+++ b/futures/tests/stream_select_all.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")] // stream::SelectAll
 #[test]
 fn is_terminated() {
     use futures::future::{self, FutureExt};
@@ -29,7 +28,6 @@ fn is_terminated() {
     assert_eq!(tasks.is_terminated(), true);
 }
 
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn issue_1626() {
     use futures::executor::block_on_stream;
@@ -51,8 +49,6 @@ fn issue_1626() {
     assert_eq!(s.next(), None);
 }
 
-#[cfg(all(feature = "alloc", feature = "std"))] // channel::mpsc
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn works_1() {
     use futures::channel::mpsc;

--- a/futures/tests/stream_select_next_some.rs
+++ b/futures/tests/stream_select_next_some.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "alloc")] // stream::FuturesUnordered
 #[test]
 fn is_terminated() {
     use futures::future;
@@ -29,8 +28,6 @@ fn is_terminated() {
     assert_eq!(select_next_some.is_terminated(), true);
 }
 
-#[cfg(all(feature = "async-await", feature = "std"))] // futures::select
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn select() {
     use futures::{future, select};
@@ -62,9 +59,6 @@ fn select() {
 }
 
 // Check that `select!` macro does not fail when importing from `futures_util`.
-#[cfg(feature = "alloc")] // stream::FuturesUnordered
-#[cfg(feature = "async-await")] // futures_util::select turned on
-#[cfg(feature = "executor")] // executor::
 #[test]
 fn futures_util_select() {
     use futures::future;

--- a/futures/tests/try_join.rs
+++ b/futures/tests/try_join.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "executor")] // executor::
-#![cfg(feature = "async-await")] // try_join!
 #![deny(unreachable_code)]
 
 use futures::{try_join, executor::block_on};

--- a/futures/tests/try_join_all.rs
+++ b/futures/tests/try_join_all.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "executor")] // executor::
 mod util {
     use std::future::Future;
     use futures::executor::block_on;
@@ -14,7 +13,6 @@ mod util {
     }
 }
 
-#[cfg(feature = "executor")] // assert_done
 #[test]
 fn collect_collects() {
     use futures_util::future::{err, ok, try_join_all};
@@ -30,7 +28,6 @@ fn collect_collects() {
     // TODO: needs more tests
 }
 
-#[cfg(feature = "executor")] // assert_done
 #[test]
 fn try_join_all_iter_lifetime() {
     use futures_util::future::{ok, try_join_all};
@@ -48,7 +45,6 @@ fn try_join_all_iter_lifetime() {
     assert_done(|| sizes(vec![&[1,2,3], &[], &[0]]), Ok(vec![3 as usize, 0, 1]));
 }
 
-#[cfg(feature = "executor")] // assert_done
 #[test]
 fn try_join_all_from_iter() {
     use futures_util::future::{ok, TryJoinAll};


### PR DESCRIPTION
In projects that have many feature flags and tests, it is hard to maintain the support of the feature flag combination in tests (due to complex cfgs, long test time, etc.), so it is probably better to fail tests if all stable features are not activated.

Related: #2101
Closes: #2098

cc @cramertj @Nemo157 @kentfredric 