### PR TITLE
Prepare 0.1.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.1.29"
+version = "0.1.30"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/futures01/Cargo.toml
+++ b/futures01/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures01"
-version = "0.1.29"
+version = "0.1.30"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang-nursery/futures-rs"
@@ -16,7 +16,7 @@ the `futures` crate.
 
 [dependencies.futures]
 path = ".."
-version = "0.1.29"
+version = "0.1.30"
 default-features = false
 
 [features]


### PR DESCRIPTION
This includes a bug fix (#1864) and compatibility fixes with tokio 0.2 (#2122, #2154).

r? @cramertj 