### PR TITLE
0.1: Allow deprecated warnings

### DIFF
--- a/futures-cpupool/src/lib.rs
+++ b/futures-cpupool/src/lib.rs
@@ -36,6 +36,7 @@
 
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![allow(bare_trait_objects, unknown_lints)]
 
 extern crate futures;
 extern crate num_cpus;

--- a/futures-cpupool/tests/smoke.rs
+++ b/futures-cpupool/tests/smoke.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 extern crate futures_cpupool;
 

--- a/src/future/shared.rs
+++ b/src/future/shared.rs
@@ -288,6 +288,7 @@ impl<E> fmt::Display for SharedError<E>
 impl<E> error::Error for SharedError<E>
     where E: error::Error,
 {
+    #[allow(deprecated)]
     fn description(&self) -> &str {
         self.error.description()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,7 @@
 
 #![no_std]
 #![deny(missing_docs, missing_debug_implementations)]
+#![allow(bare_trait_objects, unknown_lints)]
 #![doc(html_root_url = "https://docs.rs/futures/0.1")]
 
 #[macro_use]

--- a/src/task_impl/std/mod.rs
+++ b/src/task_impl/std/mod.rs
@@ -5,7 +5,9 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
-use std::sync::{Arc, Mutex, Condvar, Once, ONCE_INIT};
+use std::sync::{Arc, Mutex, Condvar, Once};
+#[allow(deprecated)]
+use std::sync::ONCE_INIT;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use {Future, Stream, Sink, Poll, Async, StartSend, AsyncSink};
@@ -32,6 +34,7 @@ pub fn is_in_task() -> bool {
     CURRENT_TASK.with(|task| !task.get().is_null())
 }
 
+#[allow(deprecated)]
 static INIT: Once = ONCE_INIT;
 
 pub fn get_ptr() -> Option<*mut u8> {

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::sync::mpsc::{channel, TryRecvError};

--- a/tests/bilock.rs
+++ b/tests/bilock.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::thread;

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::sync::atomic::*;

--- a/tests/futures_ordered.rs
+++ b/tests/futures_ordered.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::any::Any;

--- a/tests/futures_unordered.rs
+++ b/tests/futures_unordered.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::any::Any;

--- a/tests/mpsc.rs
+++ b/tests/mpsc.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "use_std")]
+#![allow(bare_trait_objects, unknown_lints)]
 
 #[macro_use]
 extern crate futures;

--- a/tests/recurse.rs
+++ b/tests/recurse.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::sync::mpsc::channel;

--- a/tests/shared.rs
+++ b/tests/shared.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 mod support;

--- a/tests/sink.rs
+++ b/tests/sink.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 extern crate futures;
 
 use std::mem;
@@ -372,7 +374,7 @@ fn fanout_backpressure() {
 
     let sink = StartSendFut::new(sink, 0).wait().unwrap();
     let sink = StartSendFut::new(sink, 1).wait().unwrap();
- 
+
     let flag = Flag::new();
     let mut task = executor::spawn(sink.send(2));
     assert!(!flag.get());

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,3 +1,5 @@
+#![allow(bare_trait_objects, unknown_lints)]
+
 #[macro_use]
 extern crate futures;
 

--- a/tests/support/local_executor.rs
+++ b/tests/support/local_executor.rs
@@ -4,6 +4,8 @@
 //! futures-aware inter-thread communications, and is not intended to be used to
 //! manage I/O. For futures that do I/O you'll likely want to use `tokio-core`.
 
+#![allow(bare_trait_objects, unknown_lints)]
+
 use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex, mpsc};
 

--- a/tests/unsync.rs
+++ b/tests/unsync.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "use_std")]
+#![allow(bare_trait_objects, unknown_lints)]
 
 extern crate futures;
 


### PR DESCRIPTION
They are warnings about deprecated items or syntax, but alternatives are not available in 0.1's msrv.