### PR TITLE
Fix clippy::needless_lifetimes warning

### DIFF
--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -70,7 +70,7 @@ impl<Fut> ArcWake for Task<Fut> {
 
 impl<Fut> Task<Fut> {
     /// Returns a waker reference for this task without cloning the Arc.
-    pub(super) fn waker_ref<'a>(this: &'a Arc<Task<Fut>>) -> WakerRef<'a> {
+    pub(super) fn waker_ref(this: &Arc<Task<Fut>>) -> WakerRef<'_> {
         waker_ref(this)
     }
 

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -32,7 +32,7 @@ fn join_all_iter_lifetime() {
     use std::future::Future;
     // In futures-rs version 0.1, this function would fail to typecheck due to an overly
     // conservative type parameterization of `JoinAll`.
-    fn sizes<'a>(bufs: Vec<&'a [u8]>) -> Box<dyn Future<Output = Vec<usize>> + Unpin> {
+    fn sizes(bufs: Vec<&[u8]>) -> Box<dyn Future<Output = Vec<usize>> + Unpin> {
         let iter = bufs.into_iter().map(|b| ready::<usize>(b.len()));
         Box::new(join_all(iter))
     }

--- a/futures/tests/try_join_all.rs
+++ b/futures/tests/try_join_all.rs
@@ -37,7 +37,7 @@ fn try_join_all_iter_lifetime() {
 
     // In futures-rs version 0.1, this function would fail to typecheck due to an overly
     // conservative type parameterization of `TryJoinAll`.
-    fn sizes<'a>(bufs: Vec<&'a [u8]>) -> Box<dyn Future<Output = Result<Vec<usize>, ()>> + Unpin> {
+    fn sizes(bufs: Vec<&[u8]>) -> Box<dyn Future<Output = Result<Vec<usize>, ()>> + Unpin> {
         let iter = bufs.into_iter().map(|b| ok::<usize, ()>(b.len()));
         Box::new(try_join_all(iter))
     }


### PR DESCRIPTION
I'm surprised that `single_use_lifetimes` lint doesn't detect this.
