### PR TITLE
Remove outdated comment

### DIFF
--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -20,8 +20,6 @@ pub fn once<Fut: Future>(future: Fut) -> Once<Fut> {
 }
 
 /// A stream which emits single element and then EOF.
-///
-/// This stream will never block and is always ready.
 #[pin_project]
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]


### PR DESCRIPTION
Small doc fix: this is no longer accurate since `once` was changed to take a future instead of an item in #885 / #826.