### PR TITLE
Clean up private modules

### DIFF
--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -35,7 +35,6 @@ pub mod task;
 
 // Not public API.
 #[doc(hidden)]
-pub mod core_reexport {
-    #[doc(hidden)]
-    pub use core::*;
+pub mod __private {
+    pub use core::task::Poll;
 }

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -4,8 +4,8 @@
 #[macro_export]
 macro_rules! ready {
     ($e:expr $(,)?) => (match $e {
-        $crate::core_reexport::task::Poll::Ready(t) => t,
-        $crate::core_reexport::task::Poll::Pending =>
-            return $crate::core_reexport::task::Poll::Pending,
+        $crate::__private::Poll::Ready(t) => t,
+        $crate::__private::Poll::Pending =>
+            return $crate::__private::Poll::Pending,
     })
 }

--- a/futures-macro/src/join.rs
+++ b/futures-macro/src/join.rs
@@ -61,12 +61,12 @@ pub(crate) fn join(input: TokenStream) -> TokenStream {
     let poll_futures = future_names.iter().map(|fut| {
         quote! {
             __all_done &= __futures_crate::future::Future::poll(
-                unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }, __cx).is_ready();
+                unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }, __cx).is_ready();
         }
     });
     let take_outputs = future_names.iter().map(|fut| {
         quote! {
-            unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }.take_output().unwrap(),
+            unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }.take_output().unwrap(),
         }
     });
 
@@ -99,17 +99,17 @@ pub(crate) fn try_join(input: TokenStream) -> TokenStream {
     let poll_futures = future_names.iter().map(|fut| {
         quote! {
             if __futures_crate::future::Future::poll(
-                unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }, __cx).is_pending()
+                unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }, __cx).is_pending()
             {
                 __all_done = false;
-            } else if unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }.output_mut().unwrap().is_err() {
+            } else if unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }.output_mut().unwrap().is_err() {
                 // `.err().unwrap()` rather than `.unwrap_err()` so that we don't introduce
                 // a `T: Debug` bound.
                 // Also, for an error type of ! any code after `err().unwrap()` is unreachable.
                 #[allow(unreachable_code)]
                 return __futures_crate::task::Poll::Ready(
-                    __futures_crate::core_reexport::result::Result::Err(
-                        unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }.take_output().unwrap().err().unwrap()
+                    __futures_crate::Err(
+                        unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }.take_output().unwrap().err().unwrap()
                     )
                 );
             }
@@ -121,7 +121,7 @@ pub(crate) fn try_join(input: TokenStream) -> TokenStream {
             // an `E: Debug` bound.
             // Also, for an ok type of ! any code after `ok().unwrap()` is unreachable.
             #[allow(unreachable_code)]
-            unsafe { __futures_crate::core_reexport::pin::Pin::new_unchecked(&mut #fut) }.take_output().unwrap().ok().unwrap(),
+            unsafe { __futures_crate::Pin::new_unchecked(&mut #fut) }.take_output().unwrap().ok().unwrap(),
         }
     });
 
@@ -134,7 +134,7 @@ pub(crate) fn try_join(input: TokenStream) -> TokenStream {
             #( #poll_futures )*
             if __all_done {
                 __futures_crate::task::Poll::Ready(
-                    __futures_crate::core_reexport::result::Result::Ok((
+                    __futures_crate::Ok((
                         #( #take_outputs )*
                     ))
                 )

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -201,12 +201,12 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
             quote! {
                 let mut #variant_name = |__cx: &mut __futures_crate::task::Context<'_>| {
                     let mut #bound_future_name = unsafe {
-                        ::core::pin::Pin::new_unchecked(&mut #bound_future_name)
+                        __futures_crate::Pin::new_unchecked(&mut #bound_future_name)
                     };
                     if __futures_crate::future::FusedFuture::is_terminated(&#bound_future_name) {
-                        None
+                        __futures_crate::None
                     } else {
-                        Some(__futures_crate::future::FutureExt::poll_unpin(
+                        __futures_crate::Some(__futures_crate::future::FutureExt::poll_unpin(
                             &mut #bound_future_name,
                             __cx,
                         ).map(#enum_ident::#variant_name))
@@ -214,7 +214,7 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                 };
                 let #variant_name: &mut dyn FnMut(
                     &mut __futures_crate::task::Context<'_>
-                ) -> Option<__futures_crate::task::Poll<_>> = &mut #variant_name;
+                ) -> __futures_crate::Option<__futures_crate::task::Poll<_>> = &mut #variant_name;
             }
         });
 
@@ -304,14 +304,14 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                 for poller in &mut __select_arr {
                     let poller: &mut &mut dyn FnMut(
                         &mut __futures_crate::task::Context<'_>
-                    ) -> Option<__futures_crate::task::Poll<_>> = poller;
+                    ) -> __futures_crate::Option<__futures_crate::task::Poll<_>> = poller;
                     match poller(__cx) {
-                        Some(x @ __futures_crate::task::Poll::Ready(_)) =>
+                        __futures_crate::Some(x @ __futures_crate::task::Poll::Ready(_)) =>
                             return x,
-                        Some(__futures_crate::task::Poll::Pending) => {
+                        __futures_crate::Some(__futures_crate::task::Poll::Pending) => {
                             __any_polled = true;
                         }
-                        None => {}
+                        __futures_crate::None => {}
                     }
                 }
 

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -27,10 +27,10 @@ pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}
 macro_rules! assert_stream_pending {
     ($stream:expr) => {{
         let mut stream = &mut $stream;
-        $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::Pin::new(stream);
+        $crate::__private::assert::assert_is_unpin_stream(stream);
+        let stream = $crate::__private::Pin::new(stream);
         let mut cx = $crate::task::noop_context();
-        let poll = $crate::futures_core_reexport::stream::Stream::poll_next(
+        let poll = $crate::__private::stream::Stream::poll_next(
             stream, &mut cx,
         );
         if poll.is_ready() {
@@ -63,17 +63,17 @@ macro_rules! assert_stream_pending {
 macro_rules! assert_stream_next {
     ($stream:expr, $item:expr) => {{
         let mut stream = &mut $stream;
-        $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::Pin::new(stream);
+        $crate::__private::assert::assert_is_unpin_stream(stream);
+        let stream = $crate::__private::Pin::new(stream);
         let mut cx = $crate::task::noop_context();
-        match $crate::futures_core_reexport::stream::Stream::poll_next(stream, &mut cx) {
-            $crate::futures_core_reexport::task::Poll::Ready(Some(x)) => {
+        match $crate::__private::stream::Stream::poll_next(stream, &mut cx) {
+            $crate::__private::task::Poll::Ready($crate::__private::Some(x)) => {
                 assert_eq!(x, $item);
             }
-            $crate::futures_core_reexport::task::Poll::Ready(None) => {
+            $crate::__private::task::Poll::Ready($crate::__private::None) => {
                 panic!("assertion failed: expected stream to provide item but stream is at its end");
             }
-            $crate::futures_core_reexport::task::Poll::Pending => {
+            $crate::__private::task::Poll::Pending => {
                 panic!("assertion failed: expected stream to provide item but stream wasn't ready");
             }
         }
@@ -105,15 +105,15 @@ macro_rules! assert_stream_next {
 macro_rules! assert_stream_done {
     ($stream:expr) => {{
         let mut stream = &mut $stream;
-        $crate::assert::assert_is_unpin_stream(stream);
-        let stream = $crate::std_reexport::pin::Pin::new(stream);
+        $crate::__private::assert::assert_is_unpin_stream(stream);
+        let stream = $crate::__private::Pin::new(stream);
         let mut cx = $crate::task::noop_context();
-        match $crate::futures_core_reexport::stream::Stream::poll_next(stream, &mut cx) {
-            $crate::futures_core_reexport::task::Poll::Ready(Some(_)) => {
+        match $crate::__private::stream::Stream::poll_next(stream, &mut cx) {
+            $crate::__private::task::Poll::Ready($crate::__private::Some(_)) => {
                 panic!("assertion failed: expected stream to be done but had more elements");
             }
-            $crate::futures_core_reexport::task::Poll::Ready(None) => {}
-            $crate::futures_core_reexport::task::Poll::Pending => {
+            $crate::__private::task::Poll::Ready($crate::__private::None) => {}
+            $crate::__private::task::Poll::Pending => {
                 panic!("assertion failed: expected stream to be done but was pending");
             }
         }

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -17,18 +17,25 @@
 #[cfg(not(feature = "std"))]
 compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");
 
+// Not public API.
 #[doc(hidden)]
 #[cfg(feature = "std")]
-pub use std as std_reexport;
+pub mod __private {
+    pub use std::{
+        option::Option::{Some, None},
+        pin::Pin,
+        result::Result::{Err, Ok},
+    };
+    pub use futures_core::{future, stream, task};
 
-#[doc(hidden)]
-#[cfg(feature = "std")]
-pub extern crate futures_core as futures_core_reexport;
+    pub mod assert {
+        pub use crate::assert::*;
+    }
+}
 
 #[macro_use]
-#[doc(hidden)]
 #[cfg(feature = "std")]
-pub mod assert;
+mod assert;
 
 #[cfg(feature = "std")]
 pub mod task;

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -38,7 +38,7 @@ futures-task = { path = "../futures-task", version = "0.3.6", default-features =
 futures-channel = { path = "../futures-channel", version = "0.3.6", default-features = false, features = ["std"], optional = true }
 futures-io = { path = "../futures-io", version = "0.3.6", default-features = false, features = ["std"], optional = true }
 futures-sink = { path = "../futures-sink", version = "0.3.6", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "0.3.6", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.6", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.9", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -93,7 +93,7 @@ document_join_macro! {
     #[macro_export]
     macro_rules! join {
         ($($tokens:tt)*) => {{
-            use $crate::__reexport as __futures_crate;
+            use $crate::__private as __futures_crate;
             $crate::join_internal! {
                 $( $tokens )*
             }
@@ -103,7 +103,7 @@ document_join_macro! {
     #[macro_export]
     macro_rules! try_join {
         ($($tokens:tt)*) => {{
-            use $crate::__reexport as __futures_crate;
+            use $crate::__private as __futures_crate;
             $crate::try_join_internal! {
                 $( $tokens )*
             }

--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -3,37 +3,37 @@
 //! This module contains a number of functions and combinators for working
 //! with `async`/`await` code.
 
-use futures_core::future::Future;
-use futures_core::stream::Stream;
-
-#[doc(hidden)]
-pub use futures_core::future::FusedFuture;
-#[doc(hidden)]
-pub use futures_core::stream::FusedStream;
+use futures_core::future::{Future, FusedFuture};
+use futures_core::stream::{Stream, FusedStream};
 
 #[macro_use]
 mod poll;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
 pub use self::poll::*;
 
 #[macro_use]
 mod pending;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
 pub use self::pending::*;
 
 // Primary export is a macro
 #[cfg(feature = "async-await-macro")]
 mod join_mod;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
 #[cfg(feature = "async-await-macro")]
 pub use self::join_mod::*;
 
 // Primary export is a macro
 #[cfg(feature = "async-await-macro")]
 mod select_mod;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
 #[cfg(feature = "async-await-macro")]
 pub use self::select_mod::*;
 
 #[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 mod random;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
 #[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 pub use self::random::*;

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -15,7 +15,7 @@ use futures_core::task::{Context, Poll};
 #[macro_export]
 macro_rules! pending {
     () => {
-        $crate::async_await::pending_once().await
+        $crate::__private::async_await::pending_once().await
     }
 }
 

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -12,7 +12,7 @@ use futures_core::task::{Context, Poll};
 #[macro_export]
 macro_rules! poll {
     ($x:expr $(,)?) => {
-        $crate::async_await::poll($x).await
+        $crate::__private::async_await::poll($x).await
     }
 }
 

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -322,7 +322,7 @@ document_select_macro! {
     #[macro_export]
     macro_rules! select {
         ($($tokens:tt)*) => {{
-            use $crate::__reexport as __futures_crate;
+            use $crate::__private as __futures_crate;
             $crate::select_internal! {
                 $( $tokens )*
             }
@@ -332,7 +332,7 @@ document_select_macro! {
     #[macro_export]
     macro_rules! select_biased {
         ($($tokens:tt)*) => {{
-            use $crate::__reexport as __futures_crate;
+            use $crate::__private as __futures_crate;
             $crate::select_biased_internal! {
                 $( $tokens )*
             }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -41,25 +41,27 @@ extern crate futures_core;
 pub use futures_core::ready;
 pub use pin_utils::pin_mut;
 
-// Not public API.
 #[cfg(feature = "async-await")]
 #[macro_use]
-#[doc(hidden)]
-pub mod async_await;
+mod async_await;
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub use self::async_await::*;
 
 // Not public API.
-#[doc(hidden)]
-pub use futures_core::core_reexport;
-
-// Not public API.
 #[cfg(feature = "async-await")]
 #[doc(hidden)]
-pub mod __reexport {
-    #[doc(hidden)]
+pub mod __private {
     pub use crate::*;
+    pub use core::{
+        option::Option::{self, Some, None},
+        pin::Pin,
+        result::Result::{Err, Ok},
+    };
+
+    pub mod async_await {
+        pub use crate::async_await::*;
+    }
 }
 
 macro_rules! cfg_target_has_atomic {
@@ -74,8 +76,8 @@ macro_rules! delegate_sink {
     ($field:ident, $item:ty) => {
         fn poll_ready(
             self: core::pin::Pin<&mut Self>,
-            cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Result<(), Self::Error>> {
             self.project().$field.poll_ready(cx)
         }
 
@@ -88,15 +90,15 @@ macro_rules! delegate_sink {
 
         fn poll_flush(
             self: core::pin::Pin<&mut Self>,
-            cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Result<(), Self::Error>> {
             self.project().$field.poll_flush(cx)
         }
 
         fn poll_close(
             self: core::pin::Pin<&mut Self>,
-            cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Result<(), Self::Error>> {
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Result<(), Self::Error>> {
             self.project().$field.poll_close(cx)
         }
     }
@@ -106,8 +108,8 @@ macro_rules! delegate_future {
     ($field:ident) => {
         fn poll(
             self: core::pin::Pin<&mut Self>,
-            cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Self::Output> {
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Self::Output> {
             self.project().$field.poll(cx)
         }
     }
@@ -117,8 +119,8 @@ macro_rules! delegate_stream {
     ($field:ident) => {
         fn poll_next(
             self: core::pin::Pin<&mut Self>,
-            cx: &mut $crate::core_reexport::task::Context<'_>,
-        ) -> $crate::core_reexport::task::Poll<Option<Self::Item>> {
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Option<Self::Item>> {
             self.project().$field.poll_next(cx)
         }
         fn size_hint(&self) -> (usize, Option<usize>) {


### PR DESCRIPTION
* Merge into one module per crate.
* Rename to __private. To prevent [someone from accidentally using it](https://github.com/rust-lang-nursery/failure/issues/342)...
* Shortened path to some private items.
* Use '=' requirement to futures-macro to avoid breakage due to private API changes. (This should be done in #2124, but I missed that.)