### PR TITLE
Don't double panic in futures-test::test::panic_waker::wake_panic

### DIFF
--- a/futures-test/src/task/panic_waker.rs
+++ b/futures-test/src/task/panic_waker.rs
@@ -9,7 +9,9 @@ unsafe fn clone_panic_waker(_data: *const ()) -> RawWaker {
 unsafe fn noop(_data: *const ()) {}
 
 unsafe fn wake_panic(_data: *const ()) {
-    panic!("should not be woken");
+    if ! std::thread::panicking() {
+        panic!("should not be woken");
+    }
 }
 
 const PANIC_WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(


### PR DESCRIPTION
This function can get called during Drop, so it's important not to panic
if the thread is already panicking. Doing so makes debugging panics much
harder.