### PR TITLE
Release 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.7 - 2020-10-23
+* Fixed unsoundness in `MappedMutexGuard` (#2240)
+* Re-exported `TakeUntil` (#2235)
+* futures-test: Prevent double panic in `panic_waker` (#2236)
+
 # 0.3.6 - 2020-10-06
 * Fixed UB due to missing 'static on `task::waker` (#2206)
 * Added `AsyncBufReadExt::fill_buf` (#2225)

--- a/examples/functional/Cargo.toml
+++ b/examples/functional/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures-example-functional"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.6"
+documentation = "https://docs.rs/futures/0.3.7"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.6", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.7", features = ["thread-pool"] }

--- a/examples/imperative/Cargo.toml
+++ b/examples/imperative/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures-example-imperative"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.6"
+documentation = "https://docs.rs/futures/0.3.7"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.6", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.7", features = ["thread-pool"] }

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-channel"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-channel/0.3.6"
+documentation = "https://docs.rs/futures-channel/0.3.7"
 description = """
 Channels for asynchronous communication using futures-rs.
 """
@@ -24,12 +24,12 @@ unstable = ["futures-core/unstable"]
 cfg-target-has-atomic = ["futures-core/cfg-target-has-atomic"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.6", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.6", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.7", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.7", default-features = false, optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.6", default-features = true }
-futures-test = { path = "../futures-test", version = "0.3.6", default-features = true }
+futures = { path = "../futures", version = "0.3.7", default-features = true }
+futures-test = { path = "../futures-test", version = "0.3.7", default-features = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -22,7 +22,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-channel/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-channel/0.3.7")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-core"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-core/0.3.6"
+documentation = "https://docs.rs/futures-core/0.3.7"
 description = """
 The core traits and types in for the `futures` library.
 """
@@ -25,7 +25,7 @@ cfg-target-has-atomic = []
 [dependencies]
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.6" }
+futures = { path = "../futures", version = "0.3.7" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-core/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-core/0.3.7")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-executor"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-executor/0.3.6"
+documentation = "https://docs.rs/futures-executor/0.3.7"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """
@@ -17,13 +17,13 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.6", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.6", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.6", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.7", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.7", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.7", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.6" }
+futures = { path = "../futures", version = "0.3.7" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -17,7 +17,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-executor/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-executor/0.3.7")]
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-io"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-io/0.3.6"
+documentation = "https://docs.rs/futures-io/0.3.7"
 description = """
 The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library.
 """

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -24,7 +24,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-io/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-io/0.3.7")]
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-macro"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-macro/0.3.6"
+documentation = "https://docs.rs/futures-macro/0.3.7"
 description = """
 The futures-rs procedural macro implementations.
 """

--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -13,7 +13,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-join-macro/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-join-macro/0.3.7")]
 
 // Since https://github.com/rust-lang/cargo/pull/7700 `proc_macro` is part of the prelude for
 // proc-macro crates, but to support older compilers we still need this explicit `extern crate`.

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-sink"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-sink/0.3.6"
+documentation = "https://docs.rs/futures-sink/0.3.7"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-sink/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-sink/0.3.7")]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-task"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-task/0.3.6"
+documentation = "https://docs.rs/futures-task/0.3.7"
 description = """
 Tools for working with tasks.
 """
@@ -26,7 +26,7 @@ cfg-target-has-atomic = []
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.6" }
+futures = { path = "../futures", version = "0.3.7" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-task/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-task/0.3.7")]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]
 compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
 name = "futures-test"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-test/0.3.6"
+documentation = "https://docs.rs/futures-test/0.3.7"
 description = """
 Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.6", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.6", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.6", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.6", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.6", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.6", path = "../futures-sink", default-features = false }
+futures-core = { version = "0.3.7", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.7", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.7", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.7", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.7", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.7", path = "../futures-sink", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 pin-project = "1.0.1"
 
 [dev-dependencies]
-futures = { version = "0.3.6", path = "../futures", default-features = false, features = ["std", "executor"] }
+futures = { version = "0.3.7", path = "../futures", default-features = false, features = ["std", "executor"] }
 
 [features]
 default = ["std"]

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -12,7 +12,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-test/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-test/0.3.7")]
 
 #[cfg(not(feature = "std"))]
 compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-util"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-util/0.3.6"
+documentation = "https://docs.rs/futures-util/0.3.7"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """
@@ -33,12 +33,12 @@ read-initializer = ["io", "futures-io/read-initializer", "futures-io/unstable"]
 write-all-vectored = ["io"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.6", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.6", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.6", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.6", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.6", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.6", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.7", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.7", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.7", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.7", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.7", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.7", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.9", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }
@@ -49,8 +49,8 @@ pin-utils = "0.1.0"
 pin-project = "1.0.1"
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.6", features = ["async-await", "thread-pool"] }
-futures-test = { path = "../futures-test", version = "0.3.6" }
+futures = { path = "../futures", version = "0.3.7", features = ["async-await", "thread-pool"] }
+futures-test = { path = "../futures-test", version = "0.3.7" }
 tokio = "0.1.11"
 
 [package.metadata.docs.rs]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures-util/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures-util/0.3.7")]
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures"
 edition = "2018"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.6"
+documentation = "https://docs.rs/futures/0.3.7"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -19,18 +19,18 @@ categories = ["asynchronous"]
 travis-ci = { repository = "rust-lang/futures-rs" }
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.6", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.6", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.6", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.6", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.6", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.6", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.6", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.7", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.7", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.7", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.7", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.7", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.7", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.7", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 pin-utils = "0.1.0"
-futures-executor = { path = "../futures-executor", version = "0.3.6", features = ["thread-pool"] }
-futures-test = { path = "../futures-test", version = "0.3.6" }
+futures-executor = { path = "../futures-executor", version = "0.3.7", features = ["thread-pool"] }
+futures-test = { path = "../futures-test", version = "0.3.7" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
 pin-project = "1.0.1"

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -95,7 +95,7 @@
 
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
-#![doc(html_root_url = "https://docs.rs/futures/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/futures/0.3.7")]
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 


### PR DESCRIPTION
Changes:

* Fixed unsoundness in `MappedMutexGuard` (#2240)
* Re-exported `TakeUntil` (#2235)
* futures-test: Prevent double panic in `panic_waker` (#2236)