### PR TITLE
use only_hack_old_rustc for proc_macro_hack

### DIFF
--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -18,6 +18,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-proc-macro-hack = "0.5.9"
+proc-macro-hack = "0.5.19"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -39,7 +39,7 @@ futures-channel = { path = "../futures-channel", version = "0.3.7", default-feat
 futures-io = { path = "../futures-io", version = "0.3.7", default-features = false, features = ["std"], optional = true }
 futures-sink = { path = "../futures-sink", version = "0.3.7", default-features = false, optional = true }
 futures-macro = { path = "../futures-macro", version = "=0.3.7", default-features = false, optional = true }
-proc-macro-hack = { version = "0.5.9", optional = true }
+proc-macro-hack = { version = "0.5.19", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }

--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -82,11 +82,11 @@ macro_rules! document_join_macro {
 }
 
 #[doc(hidden)]
-#[proc_macro_hack(support_nested)]
+#[proc_macro_hack(support_nested, only_hack_old_rustc)]
 pub use futures_macro::join_internal;
 
 #[doc(hidden)]
-#[proc_macro_hack(support_nested)]
+#[proc_macro_hack(support_nested, only_hack_old_rustc)]
 pub use futures_macro::try_join_internal;
 
 document_join_macro! {

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -310,11 +310,11 @@ macro_rules! document_select_macro {
 
 #[cfg(feature = "std")]
 #[doc(hidden)]
-#[proc_macro_hack(support_nested)]
+#[proc_macro_hack(support_nested, only_hack_old_rustc)]
 pub use futures_macro::select_internal;
 
 #[doc(hidden)]
-#[proc_macro_hack(support_nested)]
+#[proc_macro_hack(support_nested, only_hack_old_rustc)]
 pub use futures_macro::select_biased_internal;
 
 document_select_macro! {

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -221,8 +221,8 @@ fn select_on_non_unpin_expressions() {
     let res = block_on(async {
         let select_res;
         select! {
-            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
-            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
+            value_1 = make_non_unpin_fut().fuse() => select_res = value_1,
+            value_2 = make_non_unpin_fut().fuse() => select_res = value_2,
         };
         select_res
     });
@@ -243,9 +243,9 @@ fn select_on_non_unpin_expressions_with_default() {
     let res = block_on(async {
         let select_res;
         select! {
-            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
-            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
-            default => { select_res = 7 },
+            value_1 = make_non_unpin_fut().fuse() => select_res = value_1,
+            value_2 = make_non_unpin_fut().fuse() => select_res = value_2,
+            default => select_res = 7,
         };
         select_res
     });
@@ -265,8 +265,8 @@ fn select_on_non_unpin_size() {
     let fut = async {
         let select_res;
         select! {
-            value_1 = make_non_unpin_fut().fuse() => { select_res = value_1 },
-            value_2 = make_non_unpin_fut().fuse() => { select_res = value_2 },
+            value_1 = make_non_unpin_fut().fuse() => select_res = value_1,
+            value_2 = make_non_unpin_fut().fuse() => select_res = value_2,
         };
         select_res
     };
@@ -282,8 +282,8 @@ fn select_can_be_used_as_expression() {
 
     block_on(async {
         let res = select! {
-            x = future::ready(7) => { x },
-            y = future::ready(3) => { y + 1 },
+            x = future::ready(7) => x,
+            y = future::ready(3) => y + 1,
         };
         assert!(res == 7 || res == 4);
     });
@@ -303,7 +303,7 @@ fn select_with_default_can_be_used_as_expression() {
     block_on(async {
         let res = select! {
             x = poll_fn(poll_always_pending::<i32>).fuse() => x,
-            y = poll_fn(poll_always_pending::<i32>).fuse() => { y + 1 },
+            y = poll_fn(poll_always_pending::<i32>).fuse() => y + 1,
             default => 99,
         };
         assert_eq!(res, 99);
@@ -318,8 +318,8 @@ fn select_with_complete_can_be_used_as_expression() {
 
     block_on(async {
         let res = select! {
-            x = future::pending::<i32>() => { x },
-            y = future::pending::<i32>() => { y + 1 },
+            x = future::pending::<i32>() => x,
+            y = future::pending::<i32>() => y + 1,
             default => 99,
             complete => 237,
         };
@@ -328,6 +328,7 @@ fn select_with_complete_can_be_used_as_expression() {
 }
 
 #[test]
+#[allow(unused_assignments)]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
     use futures::select;
     use futures::executor::block_on;
@@ -339,8 +340,8 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
     block_on(async {
         let mut value = 234;
         select! {
-            x = require_mutable(&mut value).fuse() => { },
-            y = async_noop().fuse() => {
+            _ = require_mutable(&mut value).fuse() => { },
+            _ = async_noop().fuse() => {
                 value += 5;
             },
         }
@@ -348,6 +349,7 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
 }
 
 #[test]
+#[allow(unused_assignments)]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
     use futures::select;
     use futures::executor::block_on;
@@ -359,8 +361,8 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
     block_on(async {
         let mut value = 234;
         select! {
-            x = require_mutable(&mut value).fuse() => { },
-            y = async_noop().fuse() => {
+            _ = require_mutable(&mut value).fuse() => { },
+            _ = async_noop().fuse() => {
                 value += 5;
             },
             default => {


### PR DESCRIPTION
Uses https://github.com/dtolnay/proc-macro-hack/pull/66 to fix https://github.com/rust-lang/rust/issues/78234.

Fixes: #2026
Fixes: #2097