### PR TITLE
Add Shared::ready method to create a shared future that is immediately ready.

### DIFF
--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -95,6 +95,22 @@ impl<Fut: Future> Shared<Fut> {
             waker_key: NULL_WAKER_KEY,
         }
     }
+
+    /// Creates a [`Shared`] that is immediately ready with a value.
+    pub fn ready(output: Fut::Output) -> Shared<Fut> {
+        let inner = Inner {
+            future_or_output: UnsafeCell::new(FutureOrOutput::Output(output)),
+            notifier: Arc::new(Notifier {
+                state: AtomicUsize::new(COMPLETE),
+                wakers: Mutex::new(None)
+            })
+        };
+
+        Shared {
+            inner: Some(Arc::new(inner)),
+            waker_key: NULL_WAKER_KEY
+        }
+    }
 }
 
 impl<Fut> Shared<Fut>

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -214,6 +214,20 @@ fn dont_do_unnecessary_clones_on_output() {
 }
 
 #[test]
+fn ready() {
+    use futures::executor::block_on;
+    use futures::future::{FutureExt, Shared};
+
+    let mut futs = Vec::new();
+    futs.push(futures::future::ready(0).shared());
+    futs.push(Shared::ready(1));
+
+    assert_eq!(futs[1].peek(), Some(&1));
+
+    assert_eq!(block_on(futures::future::join_all(futs)), &[0, 1]);
+}
+
+#[test]
 fn shared_future_that_wakes_itself_until_pending_is_returned() {
     use futures::executor::block_on;
     use futures::future::FutureExt;


### PR DESCRIPTION
Importantly, this affects the behavior of peek _without_ requiring an async context. Otherwise within an async context one can simply clone and await a shared future to achieve the same effect (though perhaps less efficiently).