### PR TITLE
Add TryStreamExt::try_buffered

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -55,7 +55,7 @@ pub use self::try_stream::IntoAsyncRead;
 
 #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]
-pub use self::try_stream::{TryBufferUnordered, TryForEachConcurrent};
+pub use self::try_stream::{TryBufferUnordered, TryBuffered, TryForEachConcurrent};
 
 // Primitive streams
 

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -779,7 +779,7 @@ pub trait TryStreamExt: TryStream {
         assert_future::<Result<Self::Ok, Self::Error>, _>(TryConcat::new(self))
     }
 
-    /// Attempt to execute several futures from a stream concurrently.
+    /// Attempt to execute several futures from a stream concurrently (unordered).
     ///
     /// This stream's `Ok` type must be a [`TryFuture`](futures_core::future::TryFuture) with an `Error` type
     /// that matches the stream's `Error` type.
@@ -872,7 +872,6 @@ pub trait TryStreamExt: TryStream {
     /// use futures::channel::oneshot;
     /// use futures::future::lazy;
     /// use futures::stream::{self, StreamExt, TryStreamExt};
-    /// use futures::task::Poll;
     ///
     /// let (send_one, recv_one) = oneshot::channel();
     /// let (send_two, recv_two) = oneshot::channel();
@@ -882,10 +881,10 @@ pub trait TryStreamExt: TryStream {
     ///
     ///     let mut buffered = stream_of_futures.try_buffered(10);
     ///
-    ///     assert_eq!(buffered.try_poll_next_unpin(cx), Poll::Pending);
+    ///     assert!(buffered.try_poll_next_unpin(cx).is_pending());
     ///
     ///     send_two.send(2i32)?;
-    ///     assert_eq!(buffered.try_poll_next_unpin(cx), Poll::Pending);
+    ///     assert!(buffered.try_poll_next_unpin(cx).is_pending());
     ///     Ok::<_, i32>(buffered)
     /// }).await?;
     ///

--- a/futures-util/src/stream/try_stream/try_buffered.rs
+++ b/futures-util/src/stream/try_stream/try_buffered.rs
@@ -1,0 +1,89 @@
+use crate::stream::{Fuse, FuturesOrdered, StreamExt, IntoStream};
+use crate::future::{IntoFuture, TryFutureExt};
+use futures_core::future::TryFuture;
+use futures_core::stream::{Stream, TryStream};
+use futures_core::task::{Context, Poll};
+#[cfg(feature = "sink")]
+use futures_sink::Sink;
+use pin_project::pin_project;
+use core::pin::Pin;
+
+/// Stream for the [`try_buffered`](super::TryStreamExt::try_buffered) method.
+#[pin_project]
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct TryBuffered<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture,
+{
+    #[pin]
+    stream: Fuse<IntoStream<St>>,
+    in_progress_queue: FuturesOrdered<IntoFuture<St::Ok>>,
+    max: usize,
+}
+
+impl<St> TryBuffered<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture,
+{
+    pub(super) fn new(stream: St, n: usize) -> TryBuffered<St> {
+        TryBuffered {
+            stream: IntoStream::new(stream).fuse(),
+            in_progress_queue: FuturesOrdered::new(),
+            max: n,
+        }
+    }
+
+    delegate_access_inner!(stream, St, (. .));
+}
+
+impl<St> Stream for TryBuffered<St>
+where
+    St: TryStream,
+    St::Ok: TryFuture<Error = St::Error>,
+{
+    type Item = Result<<St::Ok as TryFuture>::Ok, St::Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        // First up, try to spawn off as many futures as possible by filling up
+        // our queue of futures. Propagate errors from the stream immediately.
+        while this.in_progress_queue.len() < *this.max {
+            match this.stream.as_mut().poll_next(cx)? {
+                Poll::Ready(Some(fut)) => this.in_progress_queue.push(fut.into_future()),
+                Poll::Ready(None) | Poll::Pending => break,
+            }
+        }
+
+        // Attempt to pull the next value from the in_progress_queue
+        match this.in_progress_queue.poll_next_unpin(cx) {
+            x @ Poll::Pending | x @ Poll::Ready(Some(_)) => return x,
+            Poll::Ready(None) => {}
+        }
+
+        // If more values are still coming from the stream, we're not done yet
+        if this.stream.is_done() {
+            Poll::Ready(None)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+#[cfg(feature = "sink")]
+impl<S, Item, E> Sink<Item> for TryBuffered<S>
+where
+    S: TryStream + Sink<Item, Error = E>,
+    S::Ok: TryFuture<Error = E>,
+{
+    type Error = E;
+
+    delegate_sink!(stream, Item);
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -498,7 +498,7 @@ pub mod stream {
     #[cfg(feature = "alloc")]
     pub use futures_util::stream::{
         // For TryStreamExt:
-        TryBufferUnordered, TryForEachConcurrent,
+        TryBufferUnordered, TryBuffered, TryForEachConcurrent,
     };
 
     #[cfg(feature = "std")]


### PR DESCRIPTION
A copy of TryBufferUnordered, with the underlying FuturesUnordered swapped out for a FuturesOrdered.