### PR TITLE
impl Clone for stream::{Empty, Pending, Repeat}

### DIFF
--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -38,3 +38,9 @@ impl<T> Stream for Empty<T> {
         (0, Some(0))
     }
 }
+
+impl<T> Clone for Empty<T> {
+    fn clone(&self) -> Self {
+        empty()
+    }
+}

--- a/futures-util/src/stream/pending.rs
+++ b/futures-util/src/stream/pending.rs
@@ -36,3 +36,9 @@ impl<T> Stream for Pending<T> {
         (0, Some(0))
     }
 }
+
+impl<T> Clone for Pending<T> {
+    fn clone(&self) -> Self {
+        pending()
+    }
+}

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -3,7 +3,7 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 
 /// Stream for the [`repeat`] function.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Repeat<T> {
     item: T,


### PR DESCRIPTION
I'm not clear about if it needs to [implement `Clone` for almost combinator as std iterator does](https://grep.app/search?q=Clone&filter[repo][0]=rust-lang/rust&filter[path][0]=library/core/src/iter/adapters/&filter[lang][0]=Rust), but I think it makes sense for these streams to implement `Clone`.