### PR TITLE
Use Self keyword instead of concrete type name

### DIFF
--- a/futures-channel/src/lock.rs
+++ b/futures-channel/src/lock.rs
@@ -36,8 +36,8 @@ unsafe impl<T: Send> Sync for Lock<T> {}
 
 impl<T> Lock<T> {
     /// Creates a new lock around the given value.
-    pub(crate) fn new(t: T) -> Lock<T> {
-        Lock {
+    pub(crate) fn new(t: T) -> Self {
+        Self {
             locked: AtomicBool::new(false),
             data: UnsafeCell::new(t),
         }

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -334,7 +334,7 @@ struct SenderTask {
 
 impl SenderTask {
     fn new() -> Self {
-        SenderTask {
+        Self {
             task: None,
             is_parked: false,
         }
@@ -665,7 +665,7 @@ impl<T> BoundedSenderInner<T> {
     /// Returns whether the sender send to this receiver.
     fn is_connected_to(&self, receiver: &Arc<BoundedInner<T>>) -> bool {
         Arc::ptr_eq(&self.inner, &receiver)
-    } 
+    }
 
     /// Returns pointer to the Arc containing sender
     ///
@@ -896,19 +896,19 @@ impl<T> UnboundedSender<T> {
 }
 
 impl<T> Clone for Sender<T> {
-    fn clone(&self) -> Sender<T> {
-        Sender(self.0.clone())
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 
 impl<T> Clone for UnboundedSender<T> {
-    fn clone(&self) -> UnboundedSender<T> {
-        UnboundedSender(self.0.clone())
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 
 impl<T> Clone for UnboundedSenderInner<T> {
-    fn clone(&self) -> UnboundedSenderInner<T> {
+    fn clone(&self) -> Self {
         // Since this atomic op isn't actually guarding any memory and we don't
         // care about any orderings besides the ordering on the single atomic
         // variable, a relaxed ordering is acceptable.
@@ -928,7 +928,7 @@ impl<T> Clone for UnboundedSenderInner<T> {
             // The ABA problem doesn't matter here. We only care that the
             // number of senders never exceeds the maximum.
             if actual == curr {
-                return UnboundedSenderInner {
+                return Self {
                     inner: self.inner.clone(),
                 };
             }
@@ -939,7 +939,7 @@ impl<T> Clone for UnboundedSenderInner<T> {
 }
 
 impl<T> Clone for BoundedSenderInner<T> {
-    fn clone(&self) -> BoundedSenderInner<T> {
+    fn clone(&self) -> Self {
         // Since this atomic op isn't actually guarding any memory and we don't
         // care about any orderings besides the ordering on the single atomic
         // variable, a relaxed ordering is acceptable.
@@ -959,7 +959,7 @@ impl<T> Clone for BoundedSenderInner<T> {
             // The ABA problem doesn't matter here. We only care that the
             // number of senders never exceeds the maximum.
             if actual == curr {
-                return BoundedSenderInner {
+                return Self {
                     inner: self.inner.clone(),
                     sender_task: Arc::new(Mutex::new(SenderTask::new())),
                     maybe_parked: false,

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -63,7 +63,7 @@ pub(super) enum PopResult<T> {
 
 #[derive(Debug)]
 struct Node<T> {
-    next: AtomicPtr<Node<T>>,
+    next: AtomicPtr<Self>,
     value: Option<T>,
 }
 
@@ -80,8 +80,8 @@ unsafe impl<T: Send> Send for Queue<T> { }
 unsafe impl<T: Send> Sync for Queue<T> { }
 
 impl<T> Node<T> {
-    unsafe fn new(v: Option<T>) -> *mut Node<T> {
-        Box::into_raw(Box::new(Node {
+    unsafe fn new(v: Option<T>) -> *mut Self {
+        Box::into_raw(Box::new(Self {
             next: AtomicPtr::new(ptr::null_mut()),
             value: v,
         }))
@@ -91,9 +91,9 @@ impl<T> Node<T> {
 impl<T> Queue<T> {
     /// Creates a new queue that is safe to share among multiple producers and
     /// one consumer.
-    pub(super) fn new() -> Queue<T> {
+    pub(super) fn new() -> Self {
         let stub = unsafe { Node::new(None) };
-        Queue {
+        Self {
             head: AtomicPtr::new(stub),
             tail: UnsafeCell::new(stub),
         }

--- a/futures-channel/src/mpsc/sink_impl.rs
+++ b/futures-channel/src/mpsc/sink_impl.rs
@@ -49,14 +49,14 @@ impl<T> Sink<T> for UnboundedSender<T> {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        UnboundedSender::poll_ready(&*self, cx)
+        Self::poll_ready(&*self, cx)
     }
 
     fn start_send(
         mut self: Pin<&mut Self>,
         msg: T,
     ) -> Result<(), Self::Error> {
-        UnboundedSender::start_send(&mut *self, msg)
+        Self::start_send(&mut *self, msg)
     }
 
     fn poll_flush(

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -116,8 +116,8 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 }
 
 impl<T> Inner<T> {
-    fn new() -> Inner<T> {
-        Inner {
+    fn new() -> Self {
+        Self {
             complete: AtomicBool::new(false),
             data: Lock::new(None),
             rx_task: Lock::new(None),
@@ -366,7 +366,7 @@ impl<T> Sender<T> {
     /// [`Receiver`](Receiver) half has hung up.
     ///
     /// This is a utility wrapping [`poll_canceled`](Sender::poll_canceled)
-    /// to expose a [`Future`](core::future::Future). 
+    /// to expose a [`Future`](core::future::Future).
     pub fn cancellation(&mut self) -> Cancellation<'_, T> {
         Cancellation { inner: self }
     }

--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -79,7 +79,7 @@ impl<F, T, E> TryFuture for F
     type Error = E;
 
     #[inline]
-    fn try_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+    fn try_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.poll(cx)
     }
 }

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -53,7 +53,7 @@ use core::task::Waker;
 ///
 /// impl Flag {
 ///     pub fn new() -> Self {
-///         Flag(Arc::new(Inner {
+///         Self(Arc::new(Inner {
 ///             waker: AtomicWaker::new(),
 ///             set: AtomicBool::new(false),
 ///         }))
@@ -202,7 +202,7 @@ impl AtomicWaker {
         trait AssertSync: Sync {}
         impl AssertSync for Waker {}
 
-        AtomicWaker {
+        Self {
             state: AtomicUsize::new(WAITING),
             waker: UnsafeCell::new(None),
         }
@@ -398,7 +398,7 @@ impl AtomicWaker {
 
 impl Default for AtomicWaker {
     fn default() -> Self {
-        AtomicWaker::new()
+        Self::new()
     }
 }
 

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -118,8 +118,8 @@ fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
 
 impl LocalPool {
     /// Create a new, empty pool of tasks.
-    pub fn new() -> LocalPool {
-        LocalPool {
+    pub fn new() -> Self {
+        Self {
             pool: FuturesUnordered::new(),
             incoming: Default::default(),
         }

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -80,7 +80,7 @@ impl ThreadPool {
     /// See documentation for the methods in
     /// [`ThreadPoolBuilder`](ThreadPoolBuilder) for details on the default
     /// configuration.
-    pub fn new() -> Result<ThreadPool, io::Error> {
+    pub fn new() -> Result<Self, io::Error> {
         ThreadPoolBuilder::new().create()
     }
 
@@ -168,9 +168,9 @@ impl PoolState {
 }
 
 impl Clone for ThreadPool {
-    fn clone(&self) -> ThreadPool {
+    fn clone(&self) -> Self {
         self.state.cnt.fetch_add(1, Ordering::Relaxed);
-        ThreadPool { state: self.state.clone() }
+        Self { state: self.state.clone() }
     }
 }
 
@@ -313,7 +313,7 @@ impl Task {
     /// Actually run the task (invoking `poll` on the future) on the current
     /// thread.
     fn run(self) {
-        let Task { mut future, wake_handle, mut exec } = self;
+        let Self { mut future, wake_handle, mut exec } = self;
         let waker = waker_ref(&wake_handle);
         let mut cx = Context::from_waker(&waker);
 
@@ -328,7 +328,7 @@ impl Task {
                     Poll::Pending => {}
                     Poll::Ready(()) => return wake_handle.mutex.complete(),
                 }
-                let task = Task {
+                let task = Self {
                     future,
                     wake_handle: wake_handle.clone(),
                     exec,

--- a/futures-executor/src/unpark_mutex.rs
+++ b/futures-executor/src/unpark_mutex.rs
@@ -43,8 +43,8 @@ const REPOLL: usize = 2;        // --> POLLING
 const COMPLETE: usize = 3;      // No transitions out
 
 impl<D> UnparkMutex<D> {
-    pub(crate) fn new() -> UnparkMutex<D> {
-        UnparkMutex {
+    pub(crate) fn new() -> Self {
+        Self {
             status: AtomicUsize::new(WAITING),
             inner: UnsafeCell::new(None),
         }

--- a/futures-macro/src/join.rs
+++ b/futures-macro/src/join.rs
@@ -13,7 +13,7 @@ struct Join {
 
 impl Parse for Join {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let mut join = Join::default();
+        let mut join = Self::default();
 
         while !input.is_empty() {
             join.fut_exprs.push(input.parse::<Expr>()?);

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -27,7 +27,7 @@ enum CaseKind {
 
 impl Parse for Select {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
-        let mut select = Select {
+        let mut select = Self {
             complete: None,
             default: None,
             normal_fut_exprs: vec![],

--- a/futures-task/src/future_obj.rs
+++ b/futures-task/src/future_obj.rs
@@ -42,8 +42,8 @@ unsafe fn remove_drop_lifetime<'a, T>(ptr: unsafe fn (*mut (dyn Future<Output = 
 impl<'a, T> LocalFutureObj<'a, T> {
     /// Create a `LocalFutureObj` from a custom trait object representation.
     #[inline]
-    pub fn new<F: UnsafeFutureObj<'a, T> + 'a>(f: F) -> LocalFutureObj<'a, T> {
-        LocalFutureObj {
+    pub fn new<F: UnsafeFutureObj<'a, T> + 'a>(f: F) -> Self {
+        Self {
             future: unsafe { remove_future_lifetime(f.into_raw()) },
             drop_fn: unsafe { remove_drop_lifetime(F::drop) },
             _marker: PhantomData,
@@ -72,7 +72,7 @@ impl<T> fmt::Debug for LocalFutureObj<'_, T> {
 
 impl<'a, T> From<FutureObj<'a, T>> for LocalFutureObj<'a, T> {
     #[inline]
-    fn from(f: FutureObj<'a, T>) -> LocalFutureObj<'a, T> {
+    fn from(f: FutureObj<'a, T>) -> Self {
         f.0
     }
 }
@@ -113,8 +113,8 @@ unsafe impl<T> Send for FutureObj<'_, T> {}
 impl<'a, T> FutureObj<'a, T> {
     /// Create a `FutureObj` from a custom trait object representation.
     #[inline]
-    pub fn new<F: UnsafeFutureObj<'a, T> + Send>(f: F) -> FutureObj<'a, T> {
-        FutureObj(LocalFutureObj::new(f))
+    pub fn new<F: UnsafeFutureObj<'a, T> + Send>(f: F) -> Self {
+        Self(LocalFutureObj::new(f))
     }
 }
 
@@ -296,49 +296,49 @@ mod if_alloc {
 
     impl<'a, F: Future<Output = ()> + Send + 'a> From<Box<F>> for FutureObj<'a, ()> {
         fn from(boxed: Box<F>) -> Self {
-            FutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a> From<Box<dyn Future<Output = ()> + Send + 'a>> for FutureObj<'a, ()> {
         fn from(boxed: Box<dyn Future<Output = ()> + Send + 'a>) -> Self {
-            FutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a, F: Future<Output = ()> + Send + 'a> From<Pin<Box<F>>> for FutureObj<'a, ()> {
         fn from(boxed: Pin<Box<F>>) -> Self {
-            FutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a> From<Pin<Box<dyn Future<Output = ()> + Send + 'a>>> for FutureObj<'a, ()> {
         fn from(boxed: Pin<Box<dyn Future<Output = ()> + Send + 'a>>) -> Self {
-            FutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a, F: Future<Output = ()> + 'a> From<Box<F>> for LocalFutureObj<'a, ()> {
         fn from(boxed: Box<F>) -> Self {
-            LocalFutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a> From<Box<dyn Future<Output = ()> + 'a>> for LocalFutureObj<'a, ()> {
         fn from(boxed: Box<dyn Future<Output = ()> + 'a>) -> Self {
-            LocalFutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a, F: Future<Output = ()> + 'a> From<Pin<Box<F>>> for LocalFutureObj<'a, ()> {
         fn from(boxed: Pin<Box<F>>) -> Self {
-            LocalFutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 
     impl<'a> From<Pin<Box<dyn Future<Output = ()> + 'a>>> for LocalFutureObj<'a, ()> {
         fn from(boxed: Pin<Box<dyn Future<Output = ()> + 'a>>) -> Self {
-            LocalFutureObj::new(boxed)
+            Self::new(boxed)
         }
     }
 }

--- a/futures-task/src/waker_ref.rs
+++ b/futures-task/src/waker_ref.rs
@@ -22,7 +22,7 @@ impl<'a> WakerRef<'a> {
         // copy the underlying (raw) waker without calling a clone,
         // as we won't call Waker::drop either.
         let waker = ManuallyDrop::new(unsafe { core::ptr::read(waker) });
-        WakerRef {
+        Self {
             waker,
             _marker: PhantomData,
         }
@@ -35,7 +35,7 @@ impl<'a> WakerRef<'a> {
     /// by the caller), and the [`Waker`] doesn't need to or must not be
     /// destroyed.
     pub fn new_unowned(waker: ManuallyDrop<Waker>) -> Self {
-        WakerRef {
+        Self {
             waker,
             _marker: PhantomData,
         }

--- a/futures-test/src/assert_unmoved.rs
+++ b/futures-test/src/assert_unmoved.rs
@@ -24,7 +24,7 @@ use std::thread::panicking;
 pub struct AssertUnmoved<T> {
     #[pin]
     inner: T,
-    this_ptr: *const AssertUnmoved<T>,
+    this_ptr: *const Self,
 }
 
 // Safety: having a raw pointer in a struct makes it `!Send`, however the

--- a/futures-test/src/io/limited.rs
+++ b/futures-test/src/io/limited.rs
@@ -21,8 +21,8 @@ pub struct Limited<Io> {
 }
 
 impl<Io> Limited<Io> {
-    pub(crate) fn new(io: Io, limit: usize) -> Limited<Io> {
-        Limited { io, limit }
+    pub(crate) fn new(io: Io, limit: usize) -> Self {
+        Self { io, limit }
     }
 
     /// Acquires a reference to the underlying I/O object that this adaptor is

--- a/futures-test/src/track_closed.rs
+++ b/futures-test/src/track_closed.rs
@@ -20,8 +20,8 @@ pub struct TrackClosed<T> {
 }
 
 impl<T> TrackClosed<T> {
-    pub(crate) fn new(inner: T) -> TrackClosed<T> {
-        TrackClosed {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
             inner,
             closed: false,
         }

--- a/futures-util/benches_disabled/bilock.rs
+++ b/futures-util/benches_disabled/bilock.rs
@@ -29,8 +29,8 @@ struct LockStream {
 }
 
 impl LockStream {
-    fn new(lock: BiLock<u32>) -> LockStream {
-        LockStream {
+    fn new(lock: BiLock<u32>) -> Self {
+        Self {
             lock: lock.lock()
         }
     }

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -32,8 +32,8 @@ impl<T> Unpin for Compat01As03<T> {}
 impl<T> Compat01As03<T> {
     /// Wraps a futures 0.1 Future, Stream, AsyncRead, or AsyncWrite
     /// object in a futures 0.3-compatible wrapper.
-    pub fn new(object: T) -> Compat01As03<T> {
-        Compat01As03 {
+    pub fn new(object: T) -> Self {
+        Self {
             inner: spawn01(object),
         }
     }
@@ -197,8 +197,8 @@ impl<S, SinkItem> Unpin for Compat01As03Sink<S, SinkItem> {}
 #[cfg(feature = "sink")]
 impl<S, SinkItem> Compat01As03Sink<S, SinkItem> {
     /// Wraps a futures 0.1 Sink object in a futures 0.3-compatible wrapper.
-    pub fn new(inner: S) -> Compat01As03Sink<S, SinkItem> {
-        Compat01As03Sink {
+    pub fn new(inner: S) -> Self {
+        Self {
             inner: spawn01(inner),
             buffer: None,
             close_started: false
@@ -344,10 +344,10 @@ struct NotifyWaker(task03::Waker);
 struct WakerToHandle<'a>(&'a task03::Waker);
 
 impl From<WakerToHandle<'_>> for NotifyHandle01 {
-    fn from(handle: WakerToHandle<'_>) -> NotifyHandle01 {
+    fn from(handle: WakerToHandle<'_>) -> Self {
         let ptr = Box::new(NotifyWaker(handle.0.clone()));
 
-        unsafe { NotifyHandle01::new(Box::into_raw(ptr)) }
+        unsafe { Self::new(Box::into_raw(ptr)) }
     }
 }
 

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -54,8 +54,8 @@ impl<T> Compat<T> {
     /// For types which implement appropriate futures `0.3`
     /// traits, the result will be a type which implements
     /// the corresponding futures 0.1 type.
-    pub fn new(inner: T) -> Compat<T> {
-        Compat { inner }
+    pub fn new(inner: T) -> Self {
+        Self { inner }
     }
 
     /// Get a reference to 0.3 Future, Stream, AsyncRead, or AsyncWrite object
@@ -80,7 +80,7 @@ impl<T> Compat<T> {
 impl<T, Item> CompatSink<T, Item> {
     /// Creates a new [`CompatSink`].
     pub fn new(inner: T) -> Self {
-        CompatSink {
+        Self {
             inner,
             _phantom: PhantomData,
         }
@@ -174,8 +174,8 @@ where
 struct Current(task01::Task);
 
 impl Current {
-    fn new() -> Current {
-        Current(task01::current())
+    fn new() -> Self {
+        Self(task01::current())
     }
 
     fn as_waker(&self) -> WakerRef<'_> {

--- a/futures-util/src/fns.rs
+++ b/futures-util/src/fns.rs
@@ -75,7 +75,7 @@ pub struct OkFn<E>(PhantomData<fn(E)>);
 
 impl<E> Default for OkFn<E> {
     fn default() -> Self {
-        OkFn(PhantomData)
+        Self(PhantomData)
     }
 }
 
@@ -344,7 +344,7 @@ pub struct IntoFn<T>(PhantomData<fn() -> T>);
 
 impl<T> Default for IntoFn<T> {
     fn default() -> Self {
-        IntoFn(PhantomData)
+        Self(PhantomData)
     }
 }
 impl<A, T> FnOnce1<A> for IntoFn<T> where A: Into<T> {

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -38,7 +38,7 @@ impl<Fut> Abortable<Fut> where Fut: Future {
     /// # });
     /// ```
     pub fn new(future: Fut, reg: AbortRegistration) -> Self {
-        Abortable {
+        Self {
             future,
             inner: reg.inner,
         }
@@ -84,7 +84,7 @@ impl AbortHandle {
         });
 
         (
-            AbortHandle {
+            Self {
                 inner: inner.clone(),
             },
             AbortRegistration {

--- a/futures-util/src/future/future/catch_unwind.rs
+++ b/futures-util/src/future/future/catch_unwind.rs
@@ -13,8 +13,8 @@ use pin_project::pin_project;
 pub struct CatchUnwind<Fut>(#[pin] Fut);
 
 impl<Fut> CatchUnwind<Fut> where Fut: Future + UnwindSafe {
-    pub(super) fn new(future: Fut) -> CatchUnwind<Fut> {
-        CatchUnwind(future)
+    pub(super) fn new(future: Fut) -> Self {
+        Self(future)
     }
 }
 

--- a/futures-util/src/future/future/flatten.rs
+++ b/futures-util/src/future/future/flatten.rs
@@ -16,7 +16,7 @@ pub enum Flatten<Fut1, Fut2> {
 
 impl<Fut1, Fut2> Flatten<Fut1, Fut2> {
     pub(crate) fn new(future: Fut1) -> Self {
-        Flatten::First(future)
+        Self::First(future)
     }
 }
 
@@ -26,7 +26,7 @@ impl<Fut> FusedFuture for Flatten<Fut, Fut::Output>
 {
     fn is_terminated(&self) -> bool {
         match self {
-            Flatten::Empty => true,
+            Self::Empty => true,
             _ => false,
         }
     }
@@ -43,11 +43,11 @@ impl<Fut> Future for Flatten<Fut, Fut::Output>
             match self.as_mut().project() {
                 FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
-                    self.set(Flatten::Second(f));
+                    self.set(Self::Second(f));
                 },
                 FlattenProj::Second(f) => {
                     let output = ready!(f.poll(cx));
-                    self.set(Flatten::Empty);
+                    self.set(Self::Empty);
                     break output;
                 },
                 FlattenProj::Empty => panic!("Flatten polled after completion"),
@@ -62,7 +62,7 @@ impl<Fut> FusedStream for Flatten<Fut, Fut::Output>
 {
     fn is_terminated(&self) -> bool {
         match self {
-            Flatten::Empty => true,
+            Self::Empty => true,
             _ => false,
         }
     }
@@ -79,12 +79,12 @@ impl<Fut> Stream for Flatten<Fut, Fut::Output>
             match self.as_mut().project() {
                 FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
-                    self.set(Flatten::Second(f));
+                    self.set(Self::Second(f));
                 },
                 FlattenProj::Second(f) => {
                     let output = ready!(f.poll_next(cx));
                     if output.is_none() {
-                        self.set(Flatten::Empty);
+                        self.set(Self::Empty);
                     }
                     break output;
                 },
@@ -111,7 +111,7 @@ where
             match self.as_mut().project() {
                 FlattenProj::First(f) => {
                     let f = ready!(f.poll(cx));
-                    self.set(Flatten::Second(f));
+                    self.set(Self::Second(f));
                 },
                 FlattenProj::Second(f) => {
                     break ready!(f.poll_ready(cx));
@@ -146,7 +146,7 @@ where
             _ => Poll::Ready(Ok(())),
         };
         if res.is_ready() {
-            self.set(Flatten::Empty);
+            self.set(Self::Empty);
         }
         res
     }

--- a/futures-util/src/future/future/fuse.rs
+++ b/futures-util/src/future/future/fuse.rs
@@ -10,8 +10,8 @@ use pin_project::pin_project;
 pub struct Fuse<Fut>(#[pin] Option<Fut>);
 
 impl<Fut> Fuse<Fut> {
-    pub(super) fn new(f: Fut) -> Fuse<Fut> {
-        Fuse(Some(f))
+    pub(super) fn new(f: Fut) -> Self {
+        Self(Some(f))
     }
 }
 
@@ -61,8 +61,8 @@ impl<Fut: Future> Fuse<Fut> {
     /// }
     /// # });
     /// ```
-    pub fn terminated() -> Fuse<Fut> {
-        Fuse(None)
+    pub fn terminated() -> Self {
+        Self(None)
     }
 }
 

--- a/futures-util/src/future/future/map.rs
+++ b/futures-util/src/future/future/map.rs
@@ -20,8 +20,8 @@ pub enum Map<Fut, F> {
 
 impl<Fut, F> Map<Fut, F> {
     /// Creates a new Map.
-    pub(crate) fn new(future: Fut, f: F) -> Map<Fut, F> {
-        Map::Incomplete { future, f }
+    pub(crate) fn new(future: Fut, f: F) -> Self {
+        Self::Incomplete { future, f }
     }
 }
 
@@ -31,8 +31,8 @@ impl<Fut, F, T> FusedFuture for Map<Fut, F>
 {
     fn is_terminated(&self) -> bool {
         match self {
-            Map::Incomplete { .. } => false,
-            Map::Complete => true,
+            Self::Incomplete { .. } => false,
+            Self::Complete => true,
         }
     }
 }
@@ -47,7 +47,7 @@ impl<Fut, F, T> Future for Map<Fut, F>
         match self.as_mut().project() {
             MapProj::Incomplete { future, .. } => {
                 let output = ready!(future.poll(cx));
-                match self.project_replace(Map::Complete) {
+                match self.project_replace(Self::Complete) {
                     MapProjOwn::Incomplete { f, .. } => Poll::Ready(f.call_once(output)),
                     MapProjOwn::Complete => unreachable!(),
                 }

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -81,7 +81,7 @@ const POISONED: usize = 3;
 const NULL_WAKER_KEY: usize = usize::max_value();
 
 impl<Fut: Future> Shared<Fut> {
-    pub(super) fn new(future: Fut) -> Shared<Fut> {
+    pub(super) fn new(future: Fut) -> Self {
         let inner = Inner {
             future_or_output: UnsafeCell::new(FutureOrOutput::Future(future)),
             notifier: Arc::new(Notifier {
@@ -90,7 +90,7 @@ impl<Fut: Future> Shared<Fut> {
             }),
         };
 
-        Shared {
+        Self {
             inner: Some(Arc::new(inner)),
             waker_key: NULL_WAKER_KEY,
         }
@@ -297,7 +297,7 @@ where
     Fut: Future,
 {
     fn clone(&self) -> Self {
-        Shared {
+        Self {
             inner: self.inner.clone(),
             waker_key: NULL_WAKER_KEY,
         }

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -36,8 +36,8 @@ macro_rules! generate {
         }
 
         impl<$($Fut: Future),*> $Join<$($Fut),*> {
-            fn new($($Fut: $Fut),*) -> $Join<$($Fut),*> {
-                $Join {
+            fn new($($Fut: $Fut),*) -> Self {
+                Self {
                     $($Fut: maybe_done($Fut)),*
                 }
             }

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -59,10 +59,10 @@ impl<Fut: Future> MaybeDone<Fut> {
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Output> {
         match &*self {
-            MaybeDone::Done(_) => {}
-            MaybeDone::Future(_) | MaybeDone::Gone => return None,
+            Self::Done(_) => {}
+            Self::Future(_) | Self::Gone => return None,
         }
-        match self.project_replace(MaybeDone::Gone) {
+        match self.project_replace(Self::Gone) {
             MaybeDoneProjOwn::Done(output) => Some(output),
             _ => unreachable!(),
         }
@@ -72,8 +72,8 @@ impl<Fut: Future> MaybeDone<Fut> {
 impl<Fut: Future> FusedFuture for MaybeDone<Fut> {
     fn is_terminated(&self) -> bool {
         match self {
-            MaybeDone::Future(_) => false,
-            MaybeDone::Done(_) | MaybeDone::Gone => true,
+            Self::Future(_) => false,
+            Self::Done(_) | Self::Gone => true,
         }
     }
 }
@@ -85,7 +85,7 @@ impl<Fut: Future> Future for MaybeDone<Fut> {
         match self.as_mut().project() {
             MaybeDoneProj::Future(f) => {
                 let res = ready!(f.poll(cx));
-                self.set(MaybeDone::Done(res));
+                self.set(Self::Done(res));
             }
             MaybeDoneProj::Done(_) => {}
             MaybeDoneProj::Gone => panic!("MaybeDone polled after value taken"),

--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -52,6 +52,6 @@ impl<F: FusedFuture> FusedFuture for OptionFuture<F> {
 
 impl<T> From<Option<T>> for OptionFuture<T> {
     fn from(option: Option<T>) -> Self {
-        OptionFuture(option)
+        Self(option)
     }
 }

--- a/futures-util/src/future/try_future/into_future.rs
+++ b/futures-util/src/future/try_future/into_future.rs
@@ -11,8 +11,8 @@ pub struct IntoFuture<Fut>(#[pin] Fut);
 
 impl<Fut> IntoFuture<Fut> {
     #[inline]
-    pub(crate) fn new(future: Fut) -> IntoFuture<Fut> {
-        IntoFuture(future)
+    pub(crate) fn new(future: Fut) -> Self {
+        Self(future)
     }
 }
 

--- a/futures-util/src/future/try_future/try_flatten_err.rs
+++ b/futures-util/src/future/try_future/try_flatten_err.rs
@@ -13,7 +13,7 @@ pub enum TryFlattenErr<Fut1, Fut2> {
 
 impl<Fut1, Fut2> TryFlattenErr<Fut1, Fut2> {
     pub(crate) fn new(future: Fut1) -> Self {
-        TryFlattenErr::First(future)
+        Self::First(future)
     }
 }
 
@@ -23,7 +23,7 @@ impl<Fut> FusedFuture for TryFlattenErr<Fut, Fut::Error>
 {
     fn is_terminated(&self) -> bool {
         match self {
-            TryFlattenErr::Empty => true,
+            Self::Empty => true,
             _ => false,
         }
     }
@@ -40,16 +40,16 @@ impl<Fut> Future for TryFlattenErr<Fut, Fut::Error>
             match self.as_mut().project() {
                 TryFlattenErrProj::First(f) => {
                     match ready!(f.try_poll(cx)) {
-                        Err(f) => self.set(TryFlattenErr::Second(f)),
+                        Err(f) => self.set(Self::Second(f)),
                         Ok(e) => {
-                            self.set(TryFlattenErr::Empty);
+                            self.set(Self::Empty);
                             break Ok(e);
                         }
                     }
                 },
                 TryFlattenErrProj::Second(f) => {
                     let output = ready!(f.try_poll(cx));
-                    self.set(TryFlattenErr::Empty);
+                    self.set(Self::Empty);
                     break output;
                 },
                 TryFlattenErrProj::Empty => panic!("TryFlattenErr polled after completion"),

--- a/futures-util/src/future/try_join.rs
+++ b/futures-util/src/future/try_join.rs
@@ -46,8 +46,8 @@ macro_rules! generate {
                 $Fut: TryFuture<Error=Fut1::Error>
             ),*
         {
-            fn new(Fut1: Fut1, $($Fut: $Fut),*) -> $Join<Fut1, $($Fut),*> {
-                $Join {
+            fn new(Fut1: Fut1, $($Fut: $Fut),*) -> Self {
+                Self {
                     Fut1: try_maybe_done(Fut1),
                     $($Fut: try_maybe_done($Fut)),*
                 }

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -44,10 +44,10 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Ok> {
         match &*self {
-            TryMaybeDone::Done(_) => {},
-            TryMaybeDone::Future(_) | TryMaybeDone::Gone => return None,
+            Self::Done(_) => {},
+            Self::Future(_) | Self::Gone => return None,
         }
-        match self.project_replace(TryMaybeDone::Gone) {
+        match self.project_replace(Self::Gone) {
             TryMaybeDoneProjOwn::Done(output) => Some(output),
             _ => unreachable!()
         }
@@ -57,8 +57,8 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
 impl<Fut: TryFuture> FusedFuture for TryMaybeDone<Fut> {
     fn is_terminated(&self) -> bool {
         match self {
-            TryMaybeDone::Future(_) => false,
-            TryMaybeDone::Done(_) | TryMaybeDone::Gone => true,
+            Self::Future(_) => false,
+            Self::Done(_) | Self::Gone => true,
         }
     }
 }
@@ -70,9 +70,9 @@ impl<Fut: TryFuture> Future for TryMaybeDone<Fut> {
         match self.as_mut().project() {
             TryMaybeDoneProj::Future(f) => {
                 match ready!(f.try_poll(cx)) {
-                    Ok(res) => self.set(TryMaybeDone::Done(res)),
+                    Ok(res) => self.set(Self::Done(res)),
                     Err(e) => {
-                        self.set(TryMaybeDone::Gone);
+                        self.set(Self::Gone);
                         return Poll::Ready(Err(e));
                     }
                 }

--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -41,7 +41,7 @@ macro_rules! try_with_interrupt {
 impl<T> AllowStdIo<T> {
     /// Creates a new `AllowStdIo` from an existing IO object.
     pub fn new(io: T) -> Self {
-        AllowStdIo(io)
+        Self(io)
     }
 
     /// Returns a reference to the contained IO object.

--- a/futures-util/src/io/close.rs
+++ b/futures-util/src/io/close.rs
@@ -15,7 +15,7 @@ impl<W: ?Sized + Unpin> Unpin for Close<'_, W> {}
 
 impl<'a, W: AsyncWrite + ?Sized + Unpin> Close<'a, W> {
     pub(super) fn new(writer: &'a mut W) -> Self {
-        Close { writer }
+        Self { writer }
     }
 }
 

--- a/futures-util/src/io/cursor.rs
+++ b/futures-util/src/io/cursor.rs
@@ -42,8 +42,8 @@ impl<T> Cursor<T> {
     /// # fn force_inference(_: &Cursor<Vec<u8>>) {}
     /// # force_inference(&buff);
     /// ```
-    pub fn new(inner: T) -> Cursor<T> {
-        Cursor {
+    pub fn new(inner: T) -> Self {
+        Self {
             inner: io::Cursor::new(inner),
         }
     }

--- a/futures-util/src/io/fill_buf.rs
+++ b/futures-util/src/io/fill_buf.rs
@@ -15,7 +15,7 @@ impl<R: ?Sized> Unpin for FillBuf<'_, R> {}
 
 impl<'a, R: AsyncBufRead + ?Sized + Unpin> FillBuf<'a, R> {
     pub(super) fn new(reader: &'a mut R) -> Self {
-        FillBuf { reader: Some(reader) }
+        Self { reader: Some(reader) }
     }
 }
 

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -15,7 +15,7 @@ impl<W: ?Sized + Unpin> Unpin for Flush<'_, W> {}
 
 impl<'a, W: AsyncWrite + ?Sized + Unpin> Flush<'a, W> {
     pub(super) fn new(writer: &'a mut W) -> Self {
-        Flush { writer }
+        Self { writer }
     }
 }
 

--- a/futures-util/src/io/into_sink.rs
+++ b/futures-util/src/io/into_sink.rs
@@ -26,7 +26,7 @@ pub struct IntoSink<W, Item> {
 
 impl<W: AsyncWrite, Item: AsRef<[u8]>> IntoSink<W, Item> {
     pub(super) fn new(writer: W) -> Self {
-        IntoSink { writer, buffer: None }
+        Self { writer, buffer: None }
     }
 
     /// If we have an outstanding block in `buffer` attempt to push it into the writer, does _not_

--- a/futures-util/src/io/read.rs
+++ b/futures-util/src/io/read.rs
@@ -16,7 +16,7 @@ impl<R: ?Sized + Unpin> Unpin for Read<'_, R> {}
 
 impl<'a, R: AsyncRead + ?Sized + Unpin> Read<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
-        Read { reader, buf }
+        Self { reader, buf }
     }
 }
 

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -17,7 +17,7 @@ impl<R: ?Sized + Unpin> Unpin for ReadExact<'_, R> {}
 
 impl<'a, R: AsyncRead + ?Sized + Unpin> ReadExact<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut [u8]) -> Self {
-        ReadExact { reader, buf }
+        Self { reader, buf }
     }
 }
 

--- a/futures-util/src/io/write_all.rs
+++ b/futures-util/src/io/write_all.rs
@@ -17,7 +17,7 @@ impl<W: ?Sized + Unpin> Unpin for WriteAll<'_, W> {}
 
 impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAll<'a, W> {
     pub(super) fn new(writer: &'a mut W, buf: &'a [u8]) -> Self {
-        WriteAll { writer, buf }
+        Self { writer, buf }
     }
 }
 

--- a/futures-util/src/io/write_all_vectored.rs
+++ b/futures-util/src/io/write_all_vectored.rs
@@ -19,7 +19,7 @@ impl<W: ?Sized + Unpin> Unpin for WriteAllVectored<'_, W> {}
 
 impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAllVectored<'a, W> {
     pub(super) fn new(writer: &'a mut W, bufs: &'a mut [IoSlice<'a>]) -> Self {
-        WriteAllVectored { writer, bufs: IoSlice::advance(bufs, 0) }
+        Self { writer, bufs: IoSlice::advance(bufs, 0) }
     }
 }
 

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -60,13 +60,13 @@ impl<T> BiLock<T> {
     /// will only be available through `Pin<&mut T>` (not `&mut T`) unless `T` is `Unpin`.
     /// Similarly, reuniting the lock and extracting the inner value is only
     /// possible when `T` is `Unpin`.
-    pub fn new(t: T) -> (BiLock<T>, BiLock<T>) {
+    pub fn new(t: T) -> (Self, Self) {
         let arc = Arc::new(Inner {
             state: AtomicUsize::new(0),
             value: Some(UnsafeCell::new(t)),
         });
 
-        (BiLock { arc: arc.clone() }, BiLock { arc })
+        (Self { arc: arc.clone() }, Self { arc })
     }
 
     /// Attempt to acquire this lock, returning `Pending` if it can't be

--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -40,8 +40,8 @@ impl<T> From<T> for Mutex<T> {
 }
 
 impl<T: Default> Default for Mutex<T> {
-    fn default() -> Mutex<T> {
-        Mutex::new(Default::default())
+    fn default() -> Self {
+        Self::new(Default::default())
     }
 }
 
@@ -53,15 +53,15 @@ enum Waiter {
 impl Waiter {
     fn register(&mut self, waker: &Waker) {
         match self {
-            Waiter::Waiting(w) if waker.will_wake(w) => {},
-            _ => *self = Waiter::Waiting(waker.clone()),
+            Self::Waiting(w) if waker.will_wake(w) => {},
+            _ => *self = Self::Waiting(waker.clone()),
         }
     }
 
     fn wake(&mut self) {
-        match mem::replace(self, Waiter::Woken) {
-            Waiter::Waiting(waker) => waker.wake(),
-            Waiter::Woken => {},
+        match mem::replace(self, Self::Woken) {
+            Self::Waiting(waker) => waker.wake(),
+            Self::Woken => {},
         }
     }
 }
@@ -72,8 +72,8 @@ const HAS_WAITERS: usize = 1 << 1;
 
 impl<T> Mutex<T> {
     /// Creates a new futures-aware mutex.
-    pub fn new(t: T) -> Mutex<T> {
-        Mutex {
+    pub fn new(t: T) -> Self {
+        Self {
             state: AtomicUsize::new(0),
             waiters: StdMutex::new(Slab::new()),
             value: UnsafeCell::new(t),

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -20,7 +20,7 @@ pub struct Buffer<Si, Item> {
 
 impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
     pub(super) fn new(sink: Si, capacity: usize) -> Self {
-        Buffer {
+        Self {
             sink,
             buf: VecDeque::with_capacity(capacity),
             capacity,

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -19,7 +19,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Close<'_, Si, Item> {}
 /// The sink itself is returned after closeing is complete.
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Close<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si) -> Self {
-        Close {
+        Self {
             sink,
             _phantom: PhantomData,
         }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -17,7 +17,7 @@ impl<Si, E, Item> SinkErrInto<Si, Item, E>
           Si::Error: Into<E>,
 {
     pub(super) fn new(sink: Si) -> Self {
-        SinkErrInto {
+        Self {
             sink: SinkExt::sink_map_err(sink, Into::into),
         }
     }

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -18,8 +18,8 @@ pub struct Fanout<Si1, Si2> {
 }
 
 impl<Si1, Si2> Fanout<Si1, Si2> {
-    pub(super) fn new(sink1: Si1, sink2: Si2) -> Fanout<Si1, Si2> {
-        Fanout { sink1, sink2 }
+    pub(super) fn new(sink1: Si1, sink2: Si2) -> Self {
+        Self { sink1, sink2 }
     }
 
     /// Get a shared reference to the inner sinks.

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -23,7 +23,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Flush<'_, Si, Item> {}
 /// all current requests are processed.
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Flush<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si) -> Self {
-        Flush {
+        Self {
             sink,
             _phantom: PhantomData,
         }

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -15,8 +15,8 @@ pub struct SinkMapErr<Si, F> {
 }
 
 impl<Si, F> SinkMapErr<Si, F> {
-    pub(super) fn new(sink: Si, f: F) -> SinkMapErr<Si, F> {
-        SinkMapErr { sink, f: Some(f) }
+    pub(super) fn new(sink: Si, f: F) -> Self {
+        Self { sink, f: Some(f) }
     }
 
     delegate_access_inner!(sink, Si, ());

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -16,7 +16,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Send<'_, Si, Item> {}
 
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Send<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si, item: Item) -> Self {
-        Send {
+        Self {
             sink,
             item: Some(item),
         }

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -49,8 +49,8 @@ where
     pub(super) fn new(
         sink: &'a mut Si,
         stream: &'a mut St,
-    ) -> SendAll<'a, Si, St> {
-        SendAll {
+    ) -> Self {
+        Self {
             sink,
             stream: stream.fuse(),
             buffered: None,

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -42,7 +42,7 @@ where Si: Sink<Item>,
             Fut: Future<Output = Result<Item, E>>,
             E: From<Si::Error>,
     {
-        With {
+        Self {
             state: None,
             sink,
             f,

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -41,7 +41,7 @@ where
     St: Stream<Item = Result<Item, Si::Error>>,
 {
     pub(super) fn new(sink: Si, f: F) -> Self {
-        WithFlatMap {
+        Self {
             sink,
             f,
             stream: None,

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -104,8 +104,8 @@ impl<Fut: Future> FuturesOrdered<Fut> {
     ///
     /// The returned `FuturesOrdered` does not contain any futures and, in this
     /// state, `FuturesOrdered::poll_next` will return `Poll::Ready(None)`.
-    pub fn new() -> FuturesOrdered<Fut> {
-        FuturesOrdered {
+    pub fn new() -> Self {
+        Self {
             in_progress_queue: FuturesUnordered::new(),
             queued_outputs: BinaryHeap::new(),
             next_incoming_index: 0,
@@ -144,8 +144,8 @@ impl<Fut: Future> FuturesOrdered<Fut> {
 }
 
 impl<Fut: Future> Default for FuturesOrdered<Fut> {
-    fn default() -> FuturesOrdered<Fut> {
-        FuturesOrdered::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -198,7 +198,7 @@ impl<Fut: Future> FromIterator<Fut> for FuturesOrdered<Fut> {
     where
         T: IntoIterator<Item = Fut>,
     {
-        let acc = FuturesOrdered::new();
+        let acc = Self::new();
         iter.into_iter().fold(acc, |mut acc, item| { acc.push(item); acc })
     }
 }

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -122,8 +122,8 @@ impl LocalSpawn for FuturesUnordered<LocalFutureObj<'_, ()>> {
 // run queue if it isn't inserted already.
 
 impl<Fut> Default for FuturesUnordered<Fut> {
-    fn default() -> FuturesUnordered<Fut> {
-        FuturesUnordered::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -133,7 +133,7 @@ impl<Fut> FuturesUnordered<Fut> {
     /// The returned [`FuturesUnordered`] does not contain any futures.
     /// In this state, [`FuturesUnordered::poll_next`](Stream::poll_next) will
     /// return [`Poll::Ready(None)`](Poll::Ready).
-    pub fn new() -> FuturesUnordered<Fut> {
+    pub fn new() -> Self {
         let stub = Arc::new(Task {
             future: UnsafeCell::new(None),
             next_all: AtomicPtr::new(ptr::null_mut()),
@@ -151,7 +151,7 @@ impl<Fut> FuturesUnordered<Fut> {
             stub,
         });
 
-        FuturesUnordered {
+        Self {
             head_all: AtomicPtr::new(ptr::null_mut()),
             ready_to_run_queue,
             is_terminated: AtomicBool::new(false),
@@ -610,7 +610,7 @@ impl<Fut> FromIterator<Fut> for FuturesUnordered<Fut> {
     where
         I: IntoIterator<Item = Fut>,
     {
-        let acc = FuturesUnordered::new();
+        let acc = Self::new();
         iter.into_iter().fold(acc, |acc, item| { acc.push(item); acc })
     }
 }

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -70,7 +70,7 @@ impl<Fut> ArcWake for Task<Fut> {
 
 impl<Fut> Task<Fut> {
     /// Returns a waker reference for this task without cloning the Arc.
-    pub(super) fn waker_ref(this: &Arc<Task<Fut>>) -> WakerRef<'_> {
+    pub(super) fn waker_ref(this: &Arc<Self>) -> WakerRef<'_> {
         waker_ref(this)
     }
 

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -37,8 +37,8 @@ impl<St: Stream + Unpin> SelectAll<St> {
     ///
     /// The returned `SelectAll` does not contain any streams and, in this
     /// state, `SelectAll::poll` will return `Poll::Ready(None)`.
-    pub fn new() -> SelectAll<St> {
-        SelectAll { inner: FuturesUnordered::new() }
+    pub fn new() -> Self {
+        Self { inner: FuturesUnordered::new() }
     }
 
     /// Returns the number of streams contained in the set.
@@ -65,8 +65,8 @@ impl<St: Stream + Unpin> SelectAll<St> {
 }
 
 impl<St: Stream + Unpin> Default for SelectAll<St> {
-    fn default() -> SelectAll<St> {
-        SelectAll::new()
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/futures-util/src/stream/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/stream/buffer_unordered.rs
@@ -40,12 +40,12 @@ where
     St: Stream,
     St::Item: Future,
 {
-    pub(super) fn new(stream: St, n: usize) -> BufferUnordered<St>
+    pub(super) fn new(stream: St, n: usize) -> Self
     where
         St: Stream,
         St::Item: Future,
     {
-        BufferUnordered {
+        Self {
             stream: super::Fuse::new(stream),
             in_progress_queue: FuturesUnordered::new(),
             max: n,

--- a/futures-util/src/stream/stream/buffered.rs
+++ b/futures-util/src/stream/stream/buffered.rs
@@ -41,8 +41,8 @@ where
     St: Stream,
     St::Item: Future,
 {
-    pub(super) fn new(stream: St, n: usize) -> Buffered<St> {
-        Buffered {
+    pub(super) fn new(stream: St, n: usize) -> Self {
+        Self {
             stream: super::Fuse::new(stream),
             in_progress_queue: FuturesOrdered::new(),
             max: n,

--- a/futures-util/src/stream/stream/catch_unwind.rs
+++ b/futures-util/src/stream/stream/catch_unwind.rs
@@ -16,8 +16,8 @@ pub struct CatchUnwind<St> {
 }
 
 impl<St: Stream + UnwindSafe> CatchUnwind<St> {
-    pub(super) fn new(stream: St) -> CatchUnwind<St> {
-        CatchUnwind { stream, caught_unwind: false }
+    pub(super) fn new(stream: St) -> Self {
+        Self { stream, caught_unwind: false }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -19,8 +19,8 @@ impl<St1, St2> Chain<St1, St2>
 where St1: Stream,
       St2: Stream<Item = St1::Item>,
 {
-    pub(super) fn new(stream1: St1, stream2: St2) -> Chain<St1, St2> {
-        Chain {
+    pub(super) fn new(stream1: St1, stream2: St2) -> Self {
+        Self {
             first: Some(stream1),
             second: stream2,
         }

--- a/futures-util/src/stream/stream/chunks.rs
+++ b/futures-util/src/stream/stream/chunks.rs
@@ -20,10 +20,10 @@ pub struct Chunks<St: Stream> {
 }
 
 impl<St: Stream> Chunks<St> where St: Stream {
-    pub(super) fn new(stream: St, capacity: usize) -> Chunks<St> {
+    pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 
-        Chunks {
+        Self {
             stream: super::Fuse::new(stream),
             items: Vec::with_capacity(capacity),
             cap: capacity,

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -20,8 +20,8 @@ impl<St: Stream, C: Default> Collect<St, C> {
         mem::replace(self.project().collection, Default::default())
     }
 
-    pub(super) fn new(stream: St) -> Collect<St, C> {
-        Collect {
+    pub(super) fn new(stream: St) -> Self {
+        Self {
             stream,
             collection: Default::default(),
         }

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -19,8 +19,8 @@ where St: Stream,
       St::Item: Extend<<St::Item as IntoIterator>::Item> +
                 IntoIterator + Default,
 {
-    pub(super) fn new(stream: St) -> Concat<St> {
-        Concat {
+    pub(super) fn new(stream: St) -> Self {
+        Self {
             stream,
             accum: None,
         }

--- a/futures-util/src/stream/stream/enumerate.rs
+++ b/futures-util/src/stream/stream/enumerate.rs
@@ -16,8 +16,8 @@ pub struct Enumerate<St> {
 }
 
 impl<St: Stream> Enumerate<St> {
-    pub(super) fn new(stream: St) -> Enumerate<St> {
-        Enumerate {
+    pub(super) fn new(stream: St) -> Self {
+        Self {
             stream,
             count: 0,
         }

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -43,8 +43,8 @@ where St: Stream,
       F: for<'a> FnMut1<&'a St::Item, Output=Fut>,
       Fut: Future<Output = bool>,
 {
-    pub(super) fn new(stream: St, f: F) -> Filter<St, Fut, F> {
-        Filter {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -37,8 +37,8 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
           F: FnMut(St::Item) -> Fut,
           Fut: Future,
 {
-    pub(super) fn new(stream: St, f: F) -> FilterMap<St, Fut, F> {
-        FilterMap { stream, f, pending: None }
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f, pending: None }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -37,8 +37,8 @@ where St: Stream,
       F: FnMut(T, St::Item) -> Fut,
       Fut: Future<Output = T>,
 {
-    pub(super) fn new(stream: St, f: F, t: T) -> Fold<St, Fut, T, F> {
-        Fold {
+    pub(super) fn new(stream: St, f: F, t: T) -> Self {
+        Self {
             stream,
             f,
             accum: Some(t),

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -34,8 +34,8 @@ where St: Stream,
       F: FnMut(St::Item) -> Fut,
       Fut: Future<Output = ()>,
 {
-    pub(super) fn new(stream: St, f: F) -> ForEach<St, Fut, F> {
-        ForEach {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             future: None,

--- a/futures-util/src/stream/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/stream/for_each_concurrent.rs
@@ -38,8 +38,8 @@ where St: Stream,
       F: FnMut(St::Item) -> Fut,
       Fut: Future<Output = ()>,
 {
-    pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> ForEachConcurrent<St, Fut, F> {
-        ForEachConcurrent {
+    pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> Self {
+        Self {
             stream: Some(stream),
             // Note: `limit` = 0 gets ignored.
             limit: limit.and_then(NonZeroUsize::new),

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -20,7 +20,7 @@ pub struct Forward<St, Si, Item> {
 
 impl<St, Si, Item> Forward<St, Si, Item> {
     pub(crate) fn new(stream: St, sink: Si) -> Self {
-        Forward {
+        Self {
             sink: Some(sink),
             stream: Fuse::new(stream),
             buffered_item: None,

--- a/futures-util/src/stream/stream/fuse.rs
+++ b/futures-util/src/stream/stream/fuse.rs
@@ -16,8 +16,8 @@ pub struct Fuse<St> {
 }
 
 impl<St> Fuse<St> {
-    pub(super) fn new(stream: St) -> Fuse<St> {
-        Fuse { stream, done: false }
+    pub(super) fn new(stream: St) -> Self {
+        Self { stream, done: false }
     }
 
     /// Returns whether the underlying stream has finished or not.

--- a/futures-util/src/stream/stream/into_future.rs
+++ b/futures-util/src/stream/stream/into_future.rs
@@ -12,8 +12,8 @@ pub struct StreamFuture<St> {
 }
 
 impl<St: Stream + Unpin> StreamFuture<St> {
-    pub(super) fn new(stream: St) -> StreamFuture<St> {
-        StreamFuture { stream: Some(stream) }
+    pub(super) fn new(stream: St) -> Self {
+        Self { stream: Some(stream) }
     }
 
     /// Acquires a reference to the underlying stream that this combinator is

--- a/futures-util/src/stream/stream/map.rs
+++ b/futures-util/src/stream/stream/map.rs
@@ -29,8 +29,8 @@ where
 }
 
 impl<St, F> Map<St, F> {
-    pub(crate) fn new(stream: St, f: F) -> Map<St, F> {
-        Map { stream, f }
+    pub(crate) fn new(stream: St, f: F) -> Self {
+        Self { stream, f }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/stream/next.rs
+++ b/futures-util/src/stream/stream/next.rs
@@ -15,7 +15,7 @@ impl<St: ?Sized + Unpin> Unpin for Next<'_, St> {}
 
 impl<'a, St: ?Sized + Stream + Unpin> Next<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
-        Next { stream }
+        Self { stream }
     }
 }
 

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -23,8 +23,8 @@ pub struct Peekable<St: Stream> {
 }
 
 impl<St: Stream> Peekable<St> {
-    pub(super) fn new(stream: St) -> Peekable<St> {
-        Peekable {
+    pub(super) fn new(stream: St) -> Self {
+        Self {
             stream: stream.fuse(),
             peeked: None,
         }

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -20,10 +20,10 @@ pub struct ReadyChunks<St: Stream> {
 }
 
 impl<St: Stream> ReadyChunks<St> where St: Stream {
-    pub(super) fn new(stream: St, capacity: usize) -> ReadyChunks<St> {
+    pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 
-        ReadyChunks {
+        Self {
             stream: super::Fuse::new(stream),
             items: Vec::with_capacity(capacity),
             cap: capacity,

--- a/futures-util/src/stream/stream/scan.rs
+++ b/futures-util/src/stream/stream/scan.rs
@@ -53,8 +53,8 @@ where
     F: FnMut(&mut S, St::Item) -> Fut,
     Fut: Future<Output = Option<B>>,
 {
-    pub(super) fn new(stream: St, initial_state: S, f: F) -> Scan<St, S, Fut, F> {
-        Scan {
+    pub(super) fn new(stream: St, initial_state: S, f: F) -> Self {
+        Self {
             stream,
             state_f: Some(StateFn {
                 state: initial_state,

--- a/futures-util/src/stream/stream/select_next_some.rs
+++ b/futures-util/src/stream/stream/select_next_some.rs
@@ -14,7 +14,7 @@ pub struct SelectNextSome<'a, St: ?Sized> {
 
 impl<'a, St: ?Sized> SelectNextSome<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
-        SelectNextSome { stream }
+        Self { stream }
     }
 }
 

--- a/futures-util/src/stream/stream/skip.rs
+++ b/futures-util/src/stream/stream/skip.rs
@@ -16,8 +16,8 @@ pub struct Skip<St> {
 }
 
 impl<St: Stream> Skip<St> {
-    pub(super) fn new(stream: St, n: usize) -> Skip<St> {
-        Skip {
+    pub(super) fn new(stream: St, n: usize) -> Self {
+        Self {
             stream,
             remaining: n,
         }

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -41,8 +41,8 @@ impl<St, Fut, F> SkipWhile<St, Fut, F>
           F: FnMut(&St::Item) -> Fut,
           Fut: Future<Output = bool>,
 {
-    pub(super) fn new(stream: St, f: F) -> SkipWhile<St, Fut, F> {
-        SkipWhile {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures-util/src/stream/stream/take.rs
+++ b/futures-util/src/stream/stream/take.rs
@@ -17,8 +17,8 @@ pub struct Take<St> {
 }
 
 impl<St: Stream> Take<St> {
-    pub(super) fn new(stream: St, n: usize) -> Take<St> {
-        Take {
+    pub(super) fn new(stream: St, n: usize) -> Self {
+        Self {
             stream,
             remaining: n,
         }

--- a/futures-util/src/stream/stream/take_until.rs
+++ b/futures-util/src/stream/stream/take_until.rs
@@ -44,8 +44,8 @@ where
     St: Stream,
     Fut: Future,
 {
-    pub(super) fn new(stream: St, fut: Fut) -> TakeUntil<St, Fut> {
-        TakeUntil {
+    pub(super) fn new(stream: St, fut: Fut) -> Self {
+        Self {
             stream,
             fut: Some(fut),
             fut_result: None,

--- a/futures-util/src/stream/stream/take_while.rs
+++ b/futures-util/src/stream/stream/take_while.rs
@@ -41,8 +41,8 @@ impl<St, Fut, F> TakeWhile<St, Fut, F>
           F: FnMut(&St::Item) -> Fut,
           Fut: Future<Output = bool>,
 {
-    pub(super) fn new(stream: St, f: F) -> TakeWhile<St, Fut, F> {
-        TakeWhile {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures-util/src/stream/stream/then.rs
+++ b/futures-util/src/stream/stream/then.rs
@@ -35,8 +35,8 @@ impl<St, Fut, F> Then<St, Fut, F>
     where St: Stream,
           F: FnMut(St::Item) -> Fut,
 {
-    pub(super) fn new(stream: St, f: F) -> Then<St, Fut, F> {
-        Then {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             future: None,
             f,

--- a/futures-util/src/stream/stream/zip.rs
+++ b/futures-util/src/stream/stream/zip.rs
@@ -19,8 +19,8 @@ pub struct Zip<St1: Stream, St2: Stream> {
 }
 
 impl<St1: Stream, St2: Stream> Zip<St1, St2> {
-    pub(super) fn new(stream1: St1, stream2: St2) -> Zip<St1, St2> {
-        Zip {
+    pub(super) fn new(stream1: St1, stream2: St2) -> Self {
+        Self {
             stream1: stream1.fuse(),
             stream2: stream2.fuse(),
             queued1: None,

--- a/futures-util/src/stream/try_stream/into_async_read.rs
+++ b/futures-util/src/stream/try_stream/into_async_read.rs
@@ -39,7 +39,7 @@ where
     St::Ok: AsRef<[u8]>,
 {
     pub(super) fn new(stream: St) -> Self {
-        IntoAsyncRead {
+        Self {
             stream,
             state: ReadState::PendingChunk,
         }

--- a/futures-util/src/stream/try_stream/into_stream.rs
+++ b/futures-util/src/stream/try_stream/into_stream.rs
@@ -17,7 +17,7 @@ pub struct IntoStream<St> {
 impl<St> IntoStream<St> {
     #[inline]
     pub(super) fn new(stream: St) -> Self {
-        IntoStream { stream }
+        Self { stream }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_buffer_unordered.rs
@@ -27,7 +27,7 @@ impl<St> TryBufferUnordered<St>
           St::Ok: TryFuture,
 {
     pub(super) fn new(stream: St, n: usize) -> Self {
-        TryBufferUnordered {
+        Self {
             stream: IntoStream::new(stream).fuse(),
             in_progress_queue: FuturesUnordered::new(),
             max: n,

--- a/futures-util/src/stream/try_stream/try_buffered.rs
+++ b/futures-util/src/stream/try_stream/try_buffered.rs
@@ -28,8 +28,8 @@ where
     St: TryStream,
     St::Ok: TryFuture,
 {
-    pub(super) fn new(stream: St, n: usize) -> TryBuffered<St> {
-        TryBuffered {
+    pub(super) fn new(stream: St, n: usize) -> Self {
+        Self {
             stream: IntoStream::new(stream).fuse(),
             in_progress_queue: FuturesOrdered::new(),
             max: n,

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -16,8 +16,8 @@ pub struct TryCollect<St, C> {
 }
 
 impl<St: TryStream, C: Default> TryCollect<St, C> {
-    pub(super) fn new(s: St) -> TryCollect<St, C> {
-        TryCollect {
+    pub(super) fn new(s: St) -> Self {
+        Self {
             stream: s,
             items: Default::default(),
         }

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -19,8 +19,8 @@ where
     St: TryStream,
     St::Ok: Extend<<St::Ok as IntoIterator>::Item> + IntoIterator + Default,
 {
-    pub(super) fn new(stream: St) -> TryConcat<St> {
-        TryConcat {
+    pub(super) fn new(stream: St) -> Self {
+        Self {
             stream,
             accum: None,
         }

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -41,7 +41,7 @@ impl<St, Fut, F> TryFilter<St, Fut, F>
     where St: TryStream
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        TryFilter {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -34,7 +34,7 @@ where
 
 impl<St, Fut, F> TryFilterMap<St, Fut, F> {
     pub(super) fn new(stream: St, f: F) -> Self {
-        TryFilterMap { stream, f, pending: None }
+        Self { stream, f, pending: None }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -37,8 +37,8 @@ where St: TryStream,
       F: FnMut(T, St::Ok) -> Fut,
       Fut: TryFuture<Ok = T, Error = St::Error>,
 {
-    pub(super) fn new(stream: St, f: F, t: T) -> TryFold<St, Fut, T, F> {
-        TryFold {
+    pub(super) fn new(stream: St, f: F, t: T) -> Self {
+        Self {
             stream,
             f,
             accum: Some(t),

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -34,8 +34,8 @@ where St: TryStream,
       F: FnMut(St::Ok) -> Fut,
       Fut: TryFuture<Ok = (), Error = St::Error>,
 {
-    pub(super) fn new(stream: St, f: F) -> TryForEach<St, Fut, F> {
-        TryForEach {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             future: None,

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -50,8 +50,8 @@ where St: TryStream,
       F: FnMut(St::Ok) -> Fut,
       Fut: Future<Output = Result<(), St::Error>>,
 {
-    pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> TryForEachConcurrent<St, Fut, F> {
-        TryForEachConcurrent {
+    pub(super) fn new(stream: St, limit: Option<usize>, f: F) -> Self {
+        Self {
             stream: Some(stream),
             // Note: `limit` = 0 gets ignored.
             limit: limit.and_then(NonZeroUsize::new),

--- a/futures-util/src/stream/try_stream/try_next.rs
+++ b/futures-util/src/stream/try_stream/try_next.rs
@@ -15,7 +15,7 @@ impl<St: ?Sized + Unpin> Unpin for TryNext<'_, St> {}
 
 impl<'a, St: ?Sized + TryStream + Unpin> TryNext<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
-        TryNext { stream }
+        Self { stream }
     }
 }
 

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -42,8 +42,8 @@ impl<St, Fut, F> TrySkipWhile<St, Fut, F>
           F: FnMut(&St::Ok) -> Fut,
           Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
-    pub(super) fn new(stream: St, f: F) -> TrySkipWhile<St, Fut, F> {
-        TrySkipWhile {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -46,8 +46,8 @@ where
     F: FnMut(&St::Ok) -> Fut,
     Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
-    pub(super) fn new(stream: St, f: F) -> TryTakeWhile<St, Fut, F> {
-        TryTakeWhile {
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self {
             stream,
             f,
             pending_fut: None,

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -7,8 +7,8 @@ mod countingwaker {
     }
 
     impl CountingWaker {
-        fn new() -> CountingWaker {
-            CountingWaker {
+        fn new() -> Self {
+            Self {
                 nr_wake: Mutex::new(0),
             }
         }

--- a/futures/tests/io_read.rs
+++ b/futures/tests/io_read.rs
@@ -10,7 +10,7 @@ mod mock_reader {
 
     impl MockReader {
         pub fn new(fun: impl FnMut(&mut [u8]) -> Poll<io::Result<usize>> + 'static) -> Self {
-            MockReader { fun: Box::new(fun) }
+            Self { fun: Box::new(fun) }
         }
     }
 

--- a/futures/tests/io_write.rs
+++ b/futures/tests/io_write.rs
@@ -10,7 +10,7 @@ mod mock_writer {
 
     impl MockWriter {
         pub fn new(fun: impl FnMut(&[u8]) -> Poll<io::Result<usize>> + 'static) -> Self {
-            MockWriter { fun: Box::new(fun) }
+            Self { fun: Box::new(fun) }
         }
     }
 

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -7,7 +7,7 @@ mod count_clone {
     impl Clone for CountClone {
         fn clone(&self) -> Self {
             self.0.set(self.0.get() + 1);
-            CountClone(self.0.clone())
+            Self(self.0.clone())
         }
     }
 }

--- a/futures/tests_disabled/stream.rs
+++ b/futures/tests_disabled/stream.rs
@@ -66,8 +66,8 @@ fn map_err() {
 struct FromErrTest(u32);
 
 impl From<u32> for FromErrTest {
-    fn from(i: u32) -> FromErrTest {
-        FromErrTest(i)
+    fn from(i: u32) -> Self {
+        Self(i)
     }
 }
 


### PR DESCRIPTION
In most cases, `Self` is shorter than concrete type name + generics. Also even if longer than concrete type name, this helps reduce diffs in future renaming.

(There is `clippy::use_self` lint that catches this, but unfortunately, it's so buggy that it wasn't very useful 😅 )

Related: #2001