### PR TITLE
feat: Add sink::from_fn

### DIFF
--- a/futures-util/src/sink/from_fn.rs
+++ b/futures-util/src/sink/from_fn.rs
@@ -59,11 +59,13 @@ where
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
-        if let Some(future) = this.future.as_mut().as_pin_mut() {
-            ready!(future.poll(cx))?;
-        }
+        let result = if let Some(future) = this.future.as_mut().as_pin_mut() {
+            ready!(future.poll(cx))
+        } else {
+            Ok(())
+        };
         this.future.set(None);
-        Poll::Ready(Ok(()))
+        Poll::Ready(result)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/futures-util/src/sink/from_fn.rs
+++ b/futures-util/src/sink/from_fn.rs
@@ -1,0 +1,74 @@
+use core::{future::Future, pin::Pin};
+use futures_core::task::{Context, Poll};
+use futures_sink::Sink;
+use pin_project::pin_project;
+
+/// Sink for the [`from_fn`] function.
+#[pin_project]
+#[derive(Debug)]
+#[must_use = "sinks do nothing unless polled"]
+pub struct FromFn<F, R> {
+    function: F,
+    #[pin]
+    future: Option<R>,
+}
+
+/// Create a sink from a function which processes one item at a time.
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::sink::{self, SinkExt};
+///
+/// let from_fn = sink::from_fn(|i: i32| {
+///     async move {
+///         eprintln!("{}", i);
+///         Ok::<_, futures::never::Never>(())
+///     }
+/// });
+/// futures::pin_mut!(from_fn);
+/// from_fn.send(5).await?;
+/// # Ok::<(), futures::never::Never>(()) }).unwrap();
+/// ```
+pub fn from_fn<F, R>(function: F) -> FromFn<F, R> {
+    FromFn {
+        function,
+        future: None,
+    }
+}
+
+impl<F, R, T, E> Sink<T> for FromFn<F, R>
+where
+    F: FnMut(T) -> R,
+    R: Future<Output = Result<(), E>>,
+{
+    type Error = E;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.future.is_some() {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        let mut this = self.project();
+        debug_assert!(this.future.is_none());
+        let future = (this.function)(item);
+        this.future.set(Some(future));
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if let Some(future) = self.project().future.as_pin_mut() {
+            ready!(future.poll(cx))?;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.poll_flush(cx)
+    }
+}

--- a/futures-util/src/sink/from_fn.rs
+++ b/futures-util/src/sink/from_fn.rs
@@ -59,13 +59,13 @@ where
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let mut this = self.project();
-        let result = if let Some(future) = this.future.as_mut().as_pin_mut() {
-            ready!(future.poll(cx))
+        Poll::Ready(if let Some(future) = this.future.as_mut().as_pin_mut() {
+            let result = ready!(future.poll(cx));
+            this.future.set(None);
+            result
         } else {
             Ok(())
-        };
-        this.future.set(None);
-        Poll::Ready(result)
+        })
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -29,6 +29,9 @@ pub use self::fanout::Fanout;
 mod flush;
 pub use self::flush::Flush;
 
+mod from_fn;
+pub use self::from_fn::{FromFn, from_fn};
+
 mod err_into;
 pub use self::err_into::SinkErrInto;
 
@@ -264,7 +267,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     {
         CompatSink::new(self)
     }
-    
+
     /// A convenience method for calling [`Sink::poll_ready`] on [`Unpin`]
     /// sink types.
     fn poll_ready_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -416,7 +416,7 @@ pub mod sink {
     pub use futures_sink::Sink;
 
     pub use futures_util::sink::{
-        Close, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
+        Close, Flush, FromFn, from_fn, Send, SendAll, SinkErrInto, SinkMapErr, With,
         SinkExt, Fanout, Drain, drain,
         WithFlatMap,
     };


### PR DESCRIPTION
Felt the need for this a couple times to mock a sink or inject something
that is sink-like, but doesn't implement sink itself.