### PR TITLE
futures-util: Migrate from pin-project to pin-project-lite

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -46,7 +46,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
-pin-project = "1.0.1"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 futures = { path = "../futures", version = "0.3.8", features = ["async-await", "thread-pool"] }

--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -5,16 +5,17 @@ use core::fmt;
 use core::pin::Pin;
 use core::sync::atomic::{AtomicBool, Ordering};
 use alloc::sync::Arc;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// A future which can be remotely short-circuited using an `AbortHandle`.
-#[pin_project]
-#[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Abortable<Fut> {
-    #[pin]
-    future: Fut,
-    inner: Arc<AbortInner>,
+pin_project! {
+    /// A future which can be remotely short-circuited using an `AbortHandle`.
+    #[derive(Debug, Clone)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Abortable<Fut> {
+        #[pin]
+        future: Fut,
+        inner: Arc<AbortInner>,
+    }
 }
 
 impl<Fut> Abortable<Fut> where Fut: Future {

--- a/futures-util/src/future/future/catch_unwind.rs
+++ b/futures-util/src/future/future/catch_unwind.rs
@@ -4,17 +4,21 @@ use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
 
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`catch_unwind`](super::FutureExt::catch_unwind) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct CatchUnwind<Fut>(#[pin] Fut);
+pin_project! {
+    /// Future for the [`catch_unwind`](super::FutureExt::catch_unwind) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct CatchUnwind<Fut> {
+        #[pin]
+        future: Fut,
+    }
+}
 
 impl<Fut> CatchUnwind<Fut> where Fut: Future + UnwindSafe {
     pub(super) fn new(future: Fut) -> Self {
-        Self(future)
+        Self { future }
     }
 }
 
@@ -24,7 +28,7 @@ impl<Fut> Future for CatchUnwind<Fut>
     type Output = Result<Fut::Output, Box<dyn Any + Send>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let f = self.project().0;
+        let f = self.project().future;
         catch_unwind(AssertUnwindSafe(|| f.poll(cx)))?.map(Ok)
     }
 }

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -17,7 +17,7 @@ use {
         },
         thread,
     },
-    pin_project::pin_project,
+    pin_project_lite::pin_project,
 };
 
 /// The handle to a remote future returned by
@@ -70,16 +70,17 @@ impl<T: 'static> Future for RemoteHandle<T> {
 
 type SendMsg<Fut> = Result<<Fut as Future>::Output, Box<(dyn Any + Send + 'static)>>;
 
-/// A future which sends its output to the corresponding `RemoteHandle`.
-/// Created by [`remote_handle`](crate::future::FutureExt::remote_handle).
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-#[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
-pub struct Remote<Fut: Future> {
-    tx: Option<Sender<SendMsg<Fut>>>,
-    keep_running: Arc<AtomicBool>,
-    #[pin]
-    future: CatchUnwind<AssertUnwindSafe<Fut>>,
+pin_project! {
+    /// A future which sends its output to the corresponding `RemoteHandle`.
+    /// Created by [`remote_handle`](crate::future::FutureExt::remote_handle).
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    #[cfg_attr(docsrs, doc(cfg(feature = "channel")))]
+    pub struct Remote<Fut: Future> {
+        tx: Option<Sender<SendMsg<Fut>>>,
+        keep_running: Arc<AtomicBool>,
+        #[pin]
+        future: CatchUnwind<AssertUnwindSafe<Fut>>,
+    }
 }
 
 impl<Fut: Future + fmt::Debug> fmt::Debug for Remote<Fut> {

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 use super::assert_future;
 
@@ -14,11 +14,12 @@ macro_rules! generate {
         $(#[$doc:meta])*
         ($Join:ident, <$($Fut:ident),*>),
     )*) => ($(
-        $(#[$doc])*
-        #[pin_project]
-        #[must_use = "futures do nothing unless you `.await` or poll them"]
-        pub struct $Join<$($Fut: Future),*> {
-            $(#[pin] $Fut: MaybeDone<$Fut>,)*
+        pin_project! {
+            $(#[$doc])*
+            #[must_use = "futures do nothing unless you `.await` or poll them"]
+            pub struct $Join<$($Fut: Future),*> {
+                $(#[pin] $Fut: MaybeDone<$Fut>,)*
+            }
         }
 
         impl<$($Fut),*> fmt::Debug for $Join<$($Fut),*>

--- a/futures-util/src/future/try_future/try_flatten_err.rs
+++ b/futures-util/src/future/try_future/try_flatten_err.rs
@@ -2,19 +2,21 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-#[pin_project(project = TryFlattenErrProj)]
-#[derive(Debug)]
-pub enum TryFlattenErr<Fut1, Fut2> {
-    First(#[pin] Fut1),
-    Second(#[pin] Fut2),
-    Empty,
+pin_project! {
+    #[project = TryFlattenErrProj]
+    #[derive(Debug)]
+    pub enum TryFlattenErr<Fut1, Fut2> {
+        First { #[pin] f: Fut1 },
+        Second { #[pin] f: Fut2 },
+        Empty,
+    }
 }
 
 impl<Fut1, Fut2> TryFlattenErr<Fut1, Fut2> {
     pub(crate) fn new(future: Fut1) -> Self {
-        Self::First(future)
+        Self::First { f: future }
     }
 }
 
@@ -39,16 +41,16 @@ impl<Fut> Future for TryFlattenErr<Fut, Fut::Error>
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                TryFlattenErrProj::First(f) => {
+                TryFlattenErrProj::First { f } => {
                     match ready!(f.try_poll(cx)) {
-                        Err(f) => self.set(Self::Second(f)),
+                        Err(f) => self.set(Self::Second { f }),
                         Ok(e) => {
                             self.set(Self::Empty);
                             break Ok(e);
                         }
                     }
                 },
-                TryFlattenErrProj::Second(f) => {
+                TryFlattenErrProj::Second { f } => {
                     let output = ready!(f.try_poll(cx));
                     self.set(Self::Empty);
                     break output;

--- a/futures-util/src/future/try_join.rs
+++ b/futures-util/src/future/try_join.rs
@@ -5,19 +5,20 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 macro_rules! generate {
     ($(
         $(#[$doc:meta])*
         ($Join:ident, <Fut1, $($Fut:ident),*>),
     )*) => ($(
-        $(#[$doc])*
-        #[pin_project]
-        #[must_use = "futures do nothing unless you `.await` or poll them"]
-        pub struct $Join<Fut1: TryFuture, $($Fut: TryFuture),*> {
-            #[pin] Fut1: TryMaybeDone<Fut1>,
-            $(#[pin] $Fut: TryMaybeDone<$Fut>,)*
+        pin_project! {
+            $(#[$doc])*
+            #[must_use = "futures do nothing unless you `.await` or poll them"]
+            pub struct $Join<Fut1: TryFuture, $($Fut: TryFuture),*> {
+                #[pin] Fut1: TryMaybeDone<Fut1>,
+                $(#[pin] $Fut: TryMaybeDone<$Fut>,)*
+            }
         }
 
         impl<Fut1, $($Fut),*> fmt::Debug for $Join<Fut1, $($Fut),*>

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -1,19 +1,18 @@
 //! Definition of the TryMaybeDone combinator
 
+use core::mem;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
 
 /// A future that may have completed with an error.
 ///
 /// This is created by the [`try_maybe_done()`] function.
-#[pin_project(project = TryMaybeDoneProj, project_replace = TryMaybeDoneProjOwn)]
 #[derive(Debug)]
 pub enum TryMaybeDone<Fut: TryFuture> {
     /// A not-yet-completed future
-    Future(#[pin] Fut),
+    Future(Fut),
     /// The output of the completed future
     Done(Fut::Ok),
     /// The empty variant after the result of a [`TryMaybeDone`] has been
@@ -34,9 +33,11 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
     /// has not yet been called.
     #[inline]
     pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Ok> {
-        match self.project() {
-            TryMaybeDoneProj::Done(res) => Some(res),
-            _ => None,
+        unsafe {
+            match self.get_unchecked_mut() {
+                TryMaybeDone::Done(res) => Some(res),
+                _ => None,
+            }
         }
     }
 
@@ -48,9 +49,11 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
             Self::Done(_) => {},
             Self::Future(_) | Self::Gone => return None,
         }
-        match self.project_replace(Self::Gone) {
-            TryMaybeDoneProjOwn::Done(output) => Some(output),
-            _ => unreachable!()
+        unsafe {
+            match mem::replace(self.get_unchecked_mut(), Self::Gone) {
+                TryMaybeDone::Done(output) => Some(output),
+                _ => unreachable!()
+            }
         }
     }
 }
@@ -68,18 +71,20 @@ impl<Fut: TryFuture> Future for TryMaybeDone<Fut> {
     type Output = Result<(), Fut::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.as_mut().project() {
-            TryMaybeDoneProj::Future(f) => {
-                match ready!(f.try_poll(cx)) {
-                    Ok(res) => self.set(Self::Done(res)),
-                    Err(e) => {
-                        self.set(Self::Gone);
-                        return Poll::Ready(Err(e));
+        unsafe {
+            match self.as_mut().get_unchecked_mut() {
+                TryMaybeDone::Future(f) => {
+                    match ready!(Pin::new_unchecked(f).try_poll(cx)) {
+                        Ok(res) => self.set(Self::Done(res)),
+                        Err(e) => {
+                            self.set(Self::Gone);
+                            return Poll::Ready(Err(e));
+                        }
                     }
-                }
-            },
-            TryMaybeDoneProj::Done(_) => {},
-            TryMaybeDoneProj::Gone => panic!("TryMaybeDone polled after value taken"),
+                },
+                TryMaybeDone::Done(_) => {},
+                TryMaybeDone::Gone => panic!("TryMaybeDone polled after value taken"),
+            }
         }
         Poll::Ready(Ok(()))
     }

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -3,38 +3,39 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSliceMut, SeekFrom};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::io::{self, Read};
 use std::pin::Pin;
 use std::{cmp, fmt};
 use super::DEFAULT_BUF_SIZE;
 
-/// The `BufReader` struct adds buffering to any reader.
-///
-/// It can be excessively inefficient to work directly with a [`AsyncRead`]
-/// instance. A `BufReader` performs large, infrequent reads on the underlying
-/// [`AsyncRead`] and maintains an in-memory buffer of the results.
-///
-/// `BufReader` can improve the speed of programs that make *small* and
-/// *repeated* read calls to the same file or network socket. It does not
-/// help when reading very large amounts at once, or reading just one or a few
-/// times. It also provides no advantage when reading from a source that is
-/// already in memory, like a `Vec<u8>`.
-///
-/// When the `BufReader` is dropped, the contents of its buffer will be
-/// discarded. Creating multiple instances of a `BufReader` on the same
-/// stream can cause data loss.
-///
-/// [`AsyncRead`]: futures_io::AsyncRead
-///
-// TODO: Examples
-#[pin_project]
-pub struct BufReader<R> {
-    #[pin]
-    inner: R,
-    buffer: Box<[u8]>,
-    pos: usize,
-    cap: usize,
+pin_project! {
+    /// The `BufReader` struct adds buffering to any reader.
+    ///
+    /// It can be excessively inefficient to work directly with a [`AsyncRead`]
+    /// instance. A `BufReader` performs large, infrequent reads on the underlying
+    /// [`AsyncRead`] and maintains an in-memory buffer of the results.
+    ///
+    /// `BufReader` can improve the speed of programs that make *small* and
+    /// *repeated* read calls to the same file or network socket. It does not
+    /// help when reading very large amounts at once, or reading just one or a few
+    /// times. It also provides no advantage when reading from a source that is
+    /// already in memory, like a `Vec<u8>`.
+    ///
+    /// When the `BufReader` is dropped, the contents of its buffer will be
+    /// discarded. Creating multiple instances of a `BufReader` on the same
+    /// stream can cause data loss.
+    ///
+    /// [`AsyncRead`]: futures_io::AsyncRead
+    ///
+    // TODO: Examples
+    pub struct BufReader<R> {
+        #[pin]
+        inner: R,
+        buffer: Box<[u8]>,
+        pos: usize,
+        cap: usize,
+    }
 }
 
 impl<R: AsyncRead> BufReader<R> {

--- a/futures-util/src/io/buf_writer.rs
+++ b/futures-util/src/io/buf_writer.rs
@@ -1,39 +1,40 @@
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSlice, SeekFrom};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::fmt;
 use std::io::{self, Write};
 use std::pin::Pin;
 use super::DEFAULT_BUF_SIZE;
 
-/// Wraps a writer and buffers its output.
-///
-/// It can be excessively inefficient to work directly with something that
-/// implements [`AsyncWrite`]. A `BufWriter` keeps an in-memory buffer of data and
-/// writes it to an underlying writer in large, infrequent batches.
-///
-/// `BufWriter` can improve the speed of programs that make *small* and
-/// *repeated* write calls to the same file or network socket. It does not
-/// help when writing very large amounts at once, or writing just one or a few
-/// times. It also provides no advantage when writing to a destination that is
-/// in memory, like a `Vec<u8>`.
-///
-/// When the `BufWriter` is dropped, the contents of its buffer will be
-/// discarded. Creating multiple instances of a `BufWriter` on the same
-/// stream can cause data loss. If you need to write out the contents of its
-/// buffer, you must manually call flush before the writer is dropped.
-///
-/// [`AsyncWrite`]: futures_io::AsyncWrite
-/// [`flush`]: super::AsyncWriteExt::flush
-///
-// TODO: Examples
-#[pin_project]
-pub struct BufWriter<W> {
-    #[pin]
-    inner: W,
-    buf: Vec<u8>,
-    written: usize,
+pin_project! {
+    /// Wraps a writer and buffers its output.
+    ///
+    /// It can be excessively inefficient to work directly with something that
+    /// implements [`AsyncWrite`]. A `BufWriter` keeps an in-memory buffer of data and
+    /// writes it to an underlying writer in large, infrequent batches.
+    ///
+    /// `BufWriter` can improve the speed of programs that make *small* and
+    /// *repeated* write calls to the same file or network socket. It does not
+    /// help when writing very large amounts at once, or writing just one or a few
+    /// times. It also provides no advantage when writing to a destination that is
+    /// in memory, like a `Vec<u8>`.
+    ///
+    /// When the `BufWriter` is dropped, the contents of its buffer will be
+    /// discarded. Creating multiple instances of a `BufWriter` on the same
+    /// stream can cause data loss. If you need to write out the contents of its
+    /// buffer, you must manually call flush before the writer is dropped.
+    ///
+    /// [`AsyncWrite`]: futures_io::AsyncWrite
+    /// [`flush`]: super::AsyncWriteExt::flush
+    ///
+    // TODO: Examples
+    pub struct BufWriter<W> {
+        #[pin]
+        inner: W,
+        buf: Vec<u8>,
+        written: usize,
+    }
 }
 
 impl<W: AsyncWrite> BufWriter<W> {

--- a/futures-util/src/io/chain.rs
+++ b/futures-util/src/io/chain.rs
@@ -3,20 +3,21 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncBufRead, AsyncRead, IoSliceMut};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::fmt;
 use std::io;
 use std::pin::Pin;
 
-/// Reader for the [`chain`](super::AsyncReadExt::chain) method.
-#[pin_project]
-#[must_use = "readers do nothing unless polled"]
-pub struct Chain<T, U> {
-    #[pin]
-    first: T,
-    #[pin]
-    second: U,
-    done_first: bool,
+pin_project! {
+    /// Reader for the [`chain`](super::AsyncReadExt::chain) method.
+    #[must_use = "readers do nothing unless polled"]
+    pub struct Chain<T, U> {
+        #[pin]
+        first: T,
+        #[pin]
+        second: U,
+        done_first: bool,
+    }
 }
 
 impl<T, U> Chain<T, U>

--- a/futures-util/src/io/copy.rs
+++ b/futures-util/src/io/copy.rs
@@ -4,7 +4,7 @@ use futures_io::{AsyncRead, AsyncWrite};
 use std::io;
 use std::pin::Pin;
 use super::{BufReader, copy_buf, CopyBuf};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 /// Creates a future which copies all the bytes from one object to another.
 ///
@@ -41,13 +41,14 @@ where
     }
 }
 
-/// Future for the [`copy()`] function.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Copy<'a, R, W: ?Sized> {
-    #[pin]
-    inner: CopyBuf<'a, BufReader<R>, W>,
+pin_project! {
+    /// Future for the [`copy()`] function.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Copy<'a, R, W: ?Sized> {
+        #[pin]
+        inner: CopyBuf<'a, BufReader<R>, W>,
+    }
 }
 
 impl<R: AsyncRead, W: AsyncWrite + Unpin + ?Sized> Future for Copy<'_, R, W> {

--- a/futures-util/src/io/copy_buf.rs
+++ b/futures-util/src/io/copy_buf.rs
@@ -4,7 +4,7 @@ use futures_core::task::{Context, Poll};
 use futures_io::{AsyncBufRead, AsyncWrite};
 use std::io;
 use std::pin::Pin;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 /// Creates a future which copies all the bytes from one object to another.
 ///
@@ -43,15 +43,16 @@ where
     }
 }
 
-/// Future for the [`copy_buf()`] function.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct CopyBuf<'a, R, W: ?Sized> {
-    #[pin]
-    reader: R,
-    writer: &'a mut W,
-    amt: u64,
+pin_project! {
+    /// Future for the [`copy_buf()`] function.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct CopyBuf<'a, R, W: ?Sized> {
+        #[pin]
+        reader: R,
+        writer: &'a mut W,
+        amt: u64,
+    }
 }
 
 impl<R, W> Future for CopyBuf<'_, R, W>

--- a/futures-util/src/io/into_sink.rs
+++ b/futures-util/src/io/into_sink.rs
@@ -4,7 +4,7 @@ use futures_io::AsyncWrite;
 use futures_sink::Sink;
 use std::io;
 use std::pin::Pin;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 #[derive(Debug)]
 struct Block<Item> {
@@ -12,17 +12,18 @@ struct Block<Item> {
     bytes: Item,
 }
 
-/// Sink for the [`into_sink`](super::AsyncWriteExt::into_sink) method.
-#[pin_project]
-#[must_use = "sinks do nothing unless polled"]
-#[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
-pub struct IntoSink<W, Item> {
-    #[pin]
-    writer: W,
-    /// An outstanding block for us to push into the underlying writer, along with an offset of how
-    /// far into this block we have written already.
-    buffer: Option<Block<Item>>,
+pin_project! {
+    /// Sink for the [`into_sink`](super::AsyncWriteExt::into_sink) method.
+    #[must_use = "sinks do nothing unless polled"]
+    #[derive(Debug)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
+    pub struct IntoSink<W, Item> {
+        #[pin]
+        writer: W,
+        // An outstanding block for us to push into the underlying writer, along with an offset of how
+        // far into this block we have written already.
+        buffer: Option<Block<Item>>,
+    }
 }
 
 impl<W: AsyncWrite, Item: AsRef<[u8]>> IntoSink<W, Item> {

--- a/futures-util/src/io/lines.rs
+++ b/futures-util/src/io/lines.rs
@@ -6,19 +6,19 @@ use std::io;
 use std::mem;
 use std::pin::Pin;
 use super::read_line::read_line_internal;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`lines`](super::AsyncBufReadExt::lines) method.
-
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Lines<R> {
-    #[pin]
-    reader: R,
-    buf: String,
-    bytes: Vec<u8>,
-    read: usize,
+pin_project! {
+    /// Stream for the [`lines`](super::AsyncBufReadExt::lines) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Lines<R> {
+        #[pin]
+        reader: R,
+        buf: String,
+        bytes: Vec<u8>,
+        read: usize,
+    }
 }
 
 impl<R: AsyncBufRead> Lines<R> {

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -3,19 +3,20 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
 use futures_io::{AsyncRead, AsyncBufRead};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::{cmp, io};
 use std::pin::Pin;
 
-/// Reader for the [`take`](super::AsyncReadExt::take) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "readers do nothing unless you `.await` or poll them"]
-pub struct Take<R> {
-    #[pin]
-    inner: R,
-    // Add '_' to avoid conflicts with `limit` method.
-    limit_: u64,
+pin_project! {
+    /// Reader for the [`take`](super::AsyncReadExt::take) method.
+    #[derive(Debug)]
+    #[must_use = "readers do nothing unless you `.await` or poll them"]
+    pub struct Take<R> {
+        #[pin]
+        inner: R,
+        // Add '_' to avoid conflicts with `limit` method.
+        limit_: u64,
+    }
 }
 
 impl<R: AsyncRead> Take<R> {

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -284,10 +284,11 @@ macro_rules! delegate_all {
         }
     };
     ($(#[$attr:meta])* $name:ident<$($arg:ident),*>($t:ty) : $ftrait:ident $([$($targs:tt)*])* $({$($item:tt)*})* $(where $($bound:tt)*)*) => {
-        #[pin_project::pin_project]
-        #[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
-        $(#[$attr])*
-        pub struct $name< $($arg),* > $(where $($bound)*)* { #[pin] inner:$t }
+        pin_project_lite::pin_project! {
+            #[must_use = "futures/streams/sinks do nothing unless you `.await` or poll them"]
+            $(#[$attr])*
+            pub struct $name< $($arg),* > $(where $($bound)*)* { #[pin] inner: $t }
+        }
 
         impl<$($arg),*> $name< $($arg),* > $(where $($bound)*)* {
             $($($item)*)*

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -2,21 +2,22 @@ use futures_core::ready;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::pin::Pin;
 use alloc::collections::VecDeque;
 
-/// Sink for the [`buffer`](super::SinkExt::buffer) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "sinks do nothing unless polled"]
-pub struct Buffer<Si, Item> {
-    #[pin]
-    sink: Si,
-    buf: VecDeque<Item>,
+pin_project! {
+    /// Sink for the [`buffer`](super::SinkExt::buffer) method.
+    #[derive(Debug)]
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct Buffer<Si, Item> {
+        #[pin]
+        sink: Si,
+        buf: VecDeque<Item>,
 
-    // Track capacity separately from the `VecDeque`, which may be rounded up
-    capacity: usize,
+        // Track capacity separately from the `VecDeque`, which may be rounded up
+        capacity: usize,
+    }
 }
 
 impl<Si: Sink<Item>, Item> Buffer<Si, Item> {

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -1,15 +1,16 @@
 use crate::sink::{SinkExt, SinkMapErr};
 use futures_core::stream::{Stream, FusedStream};
 use futures_sink::{Sink};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink for the [`sink_err_into`](super::SinkExt::sink_err_into) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "sinks do nothing unless polled"]
-pub struct SinkErrInto<Si: Sink<Item>, Item, E> {
-    #[pin]
-    sink: SinkMapErr<Si, fn(Si::Error) -> E>,
+pin_project! {
+    /// Sink for the [`sink_err_into`](super::SinkExt::sink_err_into) method.
+    #[derive(Debug)]
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct SinkErrInto<Si: Sink<Item>, Item, E> {
+        #[pin]
+        sink: SinkMapErr<Si, fn(Si::Error) -> E>,
+    }
 }
 
 impl<Si, E, Item> SinkErrInto<Si, Item, E>

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -2,19 +2,20 @@ use core::fmt::{Debug, Formatter, Result as FmtResult};
 use core::pin::Pin;
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink that clones incoming items and forwards them to two sinks at the same time.
-///
-/// Backpressure from any downstream sink propagates up, which means that this sink
-/// can only process items as fast as its _slowest_ downstream sink.
-#[pin_project]
-#[must_use = "sinks do nothing unless polled"]
-pub struct Fanout<Si1, Si2> {
-    #[pin]
-    sink1: Si1,
-    #[pin]
-    sink2: Si2
+pin_project! {
+    /// Sink that clones incoming items and forwards them to two sinks at the same time.
+    ///
+    /// Backpressure from any downstream sink propagates up, which means that this sink
+    /// can only process items as fast as its _slowest_ downstream sink.
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct Fanout<Si1, Si2> {
+        #[pin]
+        sink1: Si1,
+        #[pin]
+        sink2: Si2
+    }
 }
 
 impl<Si1, Si2> Fanout<Si1, Si2> {

--- a/futures-util/src/sink/map_err.rs
+++ b/futures-util/src/sink/map_err.rs
@@ -2,16 +2,17 @@ use core::pin::Pin;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 use futures_sink::{Sink};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink for the [`sink_map_err`](super::SinkExt::sink_map_err) method.
-#[pin_project]
-#[derive(Debug, Clone)]
-#[must_use = "sinks do nothing unless polled"]
-pub struct SinkMapErr<Si, F> {
-    #[pin]
-    sink: Si,
-    f: Option<F>,
+pin_project! {
+    /// Sink for the [`sink_map_err`](super::SinkExt::sink_map_err) method.
+    #[derive(Debug, Clone)]
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct SinkMapErr<Si, F> {
+        #[pin]
+        sink: Si,
+        f: Option<F>,
+    }
 }
 
 impl<Si, F> SinkMapErr<Si, F> {

--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -2,17 +2,18 @@ use core::{future::Future, pin::Pin};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink for the [`unfold`] function.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "sinks do nothing unless polled"]
-pub struct Unfold<T, F, R> {
-    state: Option<T>,
-    function: F,
-    #[pin]
-    future: Option<R>,
+pin_project! {
+    /// Sink for the [`unfold`] function.
+    #[derive(Debug)]
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct Unfold<T, F, R> {
+        state: Option<T>,
+        function: F,
+        #[pin]
+        future: Option<R>,
+    }
 }
 
 /// Create a sink from a function which processes one item at a time.

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -6,18 +6,19 @@ use futures_core::ready;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink for the [`with`](super::SinkExt::with) method.
-#[pin_project]
-#[must_use = "sinks do nothing unless polled"]
-pub struct With<Si, Item, U, Fut, F> {
-    #[pin]
-    sink: Si,
-    f: F,
-    #[pin]
-    state: Option<Fut>,
-    _phantom: PhantomData<fn(U) -> Item>,
+pin_project! {
+    /// Sink for the [`with`](super::SinkExt::with) method.
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct With<Si, Item, U, Fut, F> {
+        #[pin]
+        sink: Si,
+        f: F,
+        #[pin]
+        state: Option<Fut>,
+        _phantom: PhantomData<fn(U) -> Item>,
+    }
 }
 
 impl<Si, Item, U, Fut, F> fmt::Debug for With<Si, Item, U, Fut, F>

--- a/futures-util/src/sink/with_flat_map.rs
+++ b/futures-util/src/sink/with_flat_map.rs
@@ -5,19 +5,20 @@ use futures_core::ready;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Sink for the [`with_flat_map`](super::SinkExt::with_flat_map) method.
-#[pin_project]
-#[must_use = "sinks do nothing unless polled"]
-pub struct WithFlatMap<Si, Item, U, St, F> {
-    #[pin]
-    sink: Si,
-    f: F,
-    #[pin]
-    stream: Option<St>,
-    buffer: Option<Item>,
-    _marker: PhantomData<fn(U)>,
+pin_project! {
+    /// Sink for the [`with_flat_map`](super::SinkExt::with_flat_map) method.
+    #[must_use = "sinks do nothing unless polled"]
+    pub struct WithFlatMap<Si, Item, U, St, F> {
+        #[pin]
+        sink: Si,
+        f: F,
+        #[pin]
+        stream: Option<St>,
+        buffer: Option<Item>,
+        _marker: PhantomData<fn(U)>,
+    }
 }
 
 impl<Si, Item, U, St, F> fmt::Debug for WithFlatMap<Si, Item, U, St, F>

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -3,7 +3,7 @@ use futures_core::future::Future;
 use futures_core::ready;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 /// Creates a stream of a single element.
 ///
@@ -20,13 +20,14 @@ pub fn once<Fut: Future>(future: Fut) -> Once<Fut> {
     Once::new(future)
 }
 
-/// A stream which emits single element and then EOF.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Once<Fut> {
-    #[pin]
-    future: Option<Fut>
+pin_project! {
+    /// A stream which emits single element and then EOF.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Once<Fut> {
+        #[pin]
+        future: Option<Fut>
+    }
 }
 
 impl<Fut> Once<Fut> {

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -2,18 +2,19 @@ use crate::stream::{StreamExt, Fuse};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`select()`] function.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Select<St1, St2> {
-    #[pin]
-    stream1: Fuse<St1>,
-    #[pin]
-    stream2: Fuse<St2>,
-    flag: bool,
+pin_project! {
+    /// Stream for the [`select()`] function.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Select<St1, St2> {
+        #[pin]
+        stream1: Fuse<St1>,
+        #[pin]
+        stream2: Fuse<St2>,
+        flag: bool,
+    }
 }
 
 /// This function will attempt to pull items from both streams. Each

--- a/futures-util/src/stream/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/stream/buffer_unordered.rs
@@ -4,22 +4,23 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::fmt;
 use core::pin::Pin;
 
-/// Stream for the [`buffer_unordered`](super::StreamExt::buffer_unordered)
-/// method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct BufferUnordered<St>
-where
-    St: Stream,
-{
-    #[pin]
-    stream: Fuse<St>,
-    in_progress_queue: FuturesUnordered<St::Item>,
-    max: usize,
+pin_project! {
+    /// Stream for the [`buffer_unordered`](super::StreamExt::buffer_unordered)
+    /// method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct BufferUnordered<St>
+    where
+        St: Stream,
+    {
+        #[pin]
+        stream: Fuse<St>,
+        in_progress_queue: FuturesUnordered<St::Item>,
+        max: usize,
+    }
 }
 
 impl<St> fmt::Debug for BufferUnordered<St>

--- a/futures-util/src/stream/stream/buffered.rs
+++ b/futures-util/src/stream/stream/buffered.rs
@@ -5,22 +5,23 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::fmt;
 use core::pin::Pin;
 
-/// Stream for the [`buffered`](super::StreamExt::buffered) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Buffered<St>
-where
-    St: Stream,
-    St::Item: Future,
-{
-    #[pin]
-    stream: Fuse<St>,
-    in_progress_queue: FuturesOrdered<St::Item>,
-    max: usize,
+pin_project! {
+    /// Stream for the [`buffered`](super::StreamExt::buffered) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Buffered<St>
+    where
+        St: Stream,
+        St::Item: Future,
+    {
+        #[pin]
+        stream: Fuse<St>,
+        in_progress_queue: FuturesOrdered<St::Item>,
+        max: usize,
+    }
 }
 
 impl<St> fmt::Debug for Buffered<St>

--- a/futures-util/src/stream/stream/catch_unwind.rs
+++ b/futures-util/src/stream/stream/catch_unwind.rs
@@ -1,18 +1,19 @@
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use std::any::Any;
 use std::pin::Pin;
 use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
 
-/// Stream for the [`catch_unwind`](super::StreamExt::catch_unwind) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct CatchUnwind<St> {
-    #[pin]
-    stream: St,
-    caught_unwind: bool,
+pin_project! {
+    /// Stream for the [`catch_unwind`](super::StreamExt::catch_unwind) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct CatchUnwind<St> {
+        #[pin]
+        stream: St,
+        caught_unwind: bool,
+    }
 }
 
 impl<St: Stream + UnwindSafe> CatchUnwind<St> {

--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -2,17 +2,18 @@ use core::pin::Pin;
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`chain`](super::StreamExt::chain) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Chain<St1, St2> {
-    #[pin]
-    first: Option<St1>,
-    #[pin]
-    second: St2,
+pin_project! {
+    /// Stream for the [`chain`](super::StreamExt::chain) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Chain<St1, St2> {
+        #[pin]
+        first: Option<St1>,
+        #[pin]
+        second: St2,
+    }
 }
 
 // All interactions with `Pin<&mut Chain<..>>` happen through these methods

--- a/futures-util/src/stream/stream/chunks.rs
+++ b/futures-util/src/stream/stream/chunks.rs
@@ -4,20 +4,21 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::mem;
 use core::pin::Pin;
 use alloc::vec::Vec;
 
-/// Stream for the [`chunks`](super::StreamExt::chunks) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Chunks<St: Stream> {
-    #[pin]
-    stream: Fuse<St>,
-    items: Vec<St::Item>,
-    cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+pin_project! {
+    /// Stream for the [`chunks`](super::StreamExt::chunks) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Chunks<St: Stream> {
+        #[pin]
+        stream: Fuse<St>,
+        items: Vec<St::Item>,
+        cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    }
 }
 
 impl<St: Stream> Chunks<St> where St: Stream {

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -4,16 +4,17 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`collect`](super::StreamExt::collect) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Collect<St, C> {
-    #[pin]
-    stream: St,
-    collection: C,
+pin_project! {
+    /// Future for the [`collect`](super::StreamExt::collect) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Collect<St, C> {
+        #[pin]
+        stream: St,
+        collection: C,
+    }
 }
 
 impl<St: Stream, C: Default> Collect<St, C> {

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -3,16 +3,17 @@ use futures_core::future::{Future, FusedFuture};
 use futures_core::ready;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`concat`](super::StreamExt::concat) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Concat<St: Stream> {
-    #[pin]
-    stream: St,
-    accum: Option<St::Item>,
+pin_project! {
+    /// Future for the [`concat`](super::StreamExt::concat) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Concat<St: Stream> {
+        #[pin]
+        stream: St,
+        accum: Option<St::Item>,
+    }
 }
 
 impl<St> Concat<St>

--- a/futures-util/src/stream/stream/cycle.rs
+++ b/futures-util/src/stream/stream/cycle.rs
@@ -3,16 +3,17 @@ use core::usize;
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`cycle`](super::StreamExt::cycle) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Cycle<St> {
-    orig: St,
-    #[pin]
-    stream: St,
+pin_project! {
+    /// Stream for the [`cycle`](super::StreamExt::cycle) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Cycle<St> {
+        orig: St,
+        #[pin]
+        stream: St,
+    }
 }
 
 impl<St> Cycle<St>

--- a/futures-util/src/stream/stream/enumerate.rs
+++ b/futures-util/src/stream/stream/enumerate.rs
@@ -4,16 +4,17 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`enumerate`](super::StreamExt::enumerate) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Enumerate<St> {
-    #[pin]
-    stream: St,
-    count: usize,
+pin_project! {
+    /// Stream for the [`enumerate`](super::StreamExt::enumerate) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Enumerate<St> {
+        #[pin]
+        stream: St,
+        count: usize,
+    }
 }
 
 impl<St: Stream> Enumerate<St> {

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -6,21 +6,22 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use crate::fns::FnMut1;
 
-/// Stream for the [`filter`](super::StreamExt::filter) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Filter<St, Fut, F>
-    where St: Stream,
-{
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Item>,
+pin_project! {
+    /// Stream for the [`filter`](super::StreamExt::filter) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Filter<St, Fut, F>
+        where St: Stream,
+    {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Item>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for Filter<St, Fut, F>

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -6,18 +6,19 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use crate::fns::FnMut1;
 
-/// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct FilterMap<St, Fut, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending: Option<Fut>,
+pin_project! {
+    /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct FilterMap<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending: Option<Fut>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for FilterMap<St, Fut, F>

--- a/futures-util/src/stream/stream/flatten.rs
+++ b/futures-util/src/stream/stream/flatten.rs
@@ -4,17 +4,18 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`flatten`](super::StreamExt::flatten) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Flatten<St, U> {
-    #[pin]
-    stream: St,
-    #[pin]
-    next: Option<U>,
+pin_project! {
+    /// Stream for the [`flatten`](super::StreamExt::flatten) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Flatten<St, U> {
+        #[pin]
+        stream: St,
+        #[pin]
+        next: Option<U>,
+    }
 }
 
 impl<St, U> Flatten<St, U> {

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -4,18 +4,19 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`fold`](super::StreamExt::fold) method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Fold<St, Fut, T, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    accum: Option<T>,
-    #[pin]
-    future: Option<Fut>,
+pin_project! {
+    /// Future for the [`fold`](super::StreamExt::fold) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Fold<St, Fut, T, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<T>,
+        #[pin]
+        future: Option<Fut>,
+    }
 }
 
 impl<St, Fut, T, F> fmt::Debug for Fold<St, Fut, T, F>

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -4,17 +4,18 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`for_each`](super::StreamExt::for_each) method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ForEach<St, Fut, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    future: Option<Fut>,
+pin_project! {
+    /// Future for the [`for_each`](super::StreamExt::for_each) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct ForEach<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        future: Option<Fut>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for ForEach<St, Fut, F>

--- a/futures-util/src/stream/stream/for_each_concurrent.rs
+++ b/futures-util/src/stream/stream/for_each_concurrent.rs
@@ -5,18 +5,19 @@ use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
-/// method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ForEachConcurrent<St, Fut, F> {
-    #[pin]
-    stream: Option<St>,
-    f: F,
-    futures: FuturesUnordered<Fut>,
-    limit: Option<NonZeroUsize>,
+pin_project! {
+    /// Future for the [`for_each_concurrent`](super::StreamExt::for_each_concurrent)
+    /// method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct ForEachConcurrent<St, Fut, F> {
+        #[pin]
+        stream: Option<St>,
+        f: F,
+        futures: FuturesUnordered<Fut>,
+        limit: Option<NonZeroUsize>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for ForEachConcurrent<St, Fut, F>

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -5,18 +5,20 @@ use futures_core::ready;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`forward`](super::StreamExt::forward) method.
-#[pin_project(project = ForwardProj)]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Forward<St, Si, Item> {
-    #[pin]
-    sink: Option<Si>,
-    #[pin]
-    stream: Fuse<St>,
-    buffered_item: Option<Item>,
+pin_project! {
+    /// Future for the [`forward`](super::StreamExt::forward) method.
+    #[project = ForwardProj]
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Forward<St, Si, Item> {
+        #[pin]
+        sink: Option<Si>,
+        #[pin]
+        stream: Fuse<St>,
+        buffered_item: Option<Item>,
+    }
 }
 
 impl<St, Si, Item> Forward<St, Si, Item> {

--- a/futures-util/src/stream/stream/fuse.rs
+++ b/futures-util/src/stream/stream/fuse.rs
@@ -4,16 +4,17 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`fuse`](super::StreamExt::fuse) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Fuse<St> {
-    #[pin]
-    stream: St,
-    done: bool,
+pin_project! {
+    /// Stream for the [`fuse`](super::StreamExt::fuse) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Fuse<St> {
+        #[pin]
+        stream: St,
+        done: bool,
+    }
 }
 
 impl<St> Fuse<St> {

--- a/futures-util/src/stream/stream/map.rs
+++ b/futures-util/src/stream/stream/map.rs
@@ -5,17 +5,18 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 use crate::fns::FnMut1;
 
-/// Stream for the [`map`](super::StreamExt::map) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Map<St, F> {
-    #[pin]
-    stream: St,
-    f: F,
+pin_project! {
+    /// Stream for the [`map`](super::StreamExt::map) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Map<St, F> {
+        #[pin]
+        stream: St,
+        f: F,
+    }
 }
 
 impl<St, F> fmt::Debug for Map<St, F>

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -7,20 +7,21 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// A `Stream` that implements a `peek` method.
-///
-/// The `peek` method can be used to retrieve a reference
-/// to the next `Stream::Item` if available. A subsequent
-/// call to `poll` will return the owned item.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Peekable<St: Stream> {
-    #[pin]
-    stream: Fuse<St>,
-    peeked: Option<St::Item>,
+pin_project! {
+    /// A `Stream` that implements a `peek` method.
+    ///
+    /// The `peek` method can be used to retrieve a reference
+    /// to the next `Stream::Item` if available. A subsequent
+    /// call to `poll` will return the owned item.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Peekable<St: Stream> {
+        #[pin]
+        stream: Fuse<St>,
+        peeked: Option<St::Item>,
+    }
 }
 
 impl<St: Stream> Peekable<St> {
@@ -101,11 +102,12 @@ where
     delegate_sink!(stream, Item);
 }
 
-/// Future for the [`Peekable::peek()`](self::Peekable::peek) function from [`Peekable`]
-#[pin_project]
-#[must_use = "futures do nothing unless polled"]
-pub struct Peek<'a, St: Stream> {
-    inner: Option<Pin<&'a mut Peekable<St>>>,
+pin_project! {
+    /// Future for the [`Peekable::peek()`](self::Peekable::peek) function from [`Peekable`]
+    #[must_use = "futures do nothing unless polled"]
+    pub struct Peek<'a, St: Stream> {
+        inner: Option<Pin<&'a mut Peekable<St>>>,
+    }
 }
 
 impl<St> fmt::Debug for Peek<'_, St>

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -3,20 +3,21 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::mem;
 use core::pin::Pin;
 use alloc::vec::Vec;
 
-/// Stream for the [`ready_chunks`](super::StreamExt::ready_chunks) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct ReadyChunks<St: Stream> {
-    #[pin]
-    stream: Fuse<St>,
-    items: Vec<St::Item>,
-    cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+pin_project! {
+    /// Stream for the [`ready_chunks`](super::StreamExt::ready_chunks) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct ReadyChunks<St: Stream> {
+        #[pin]
+        stream: Fuse<St>,
+        items: Vec<St::Item>,
+        cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    }
 }
 
 impl<St: Stream> ReadyChunks<St> where St: Stream {

--- a/futures-util/src/stream/stream/scan.rs
+++ b/futures-util/src/stream/stream/scan.rs
@@ -6,22 +6,23 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 struct StateFn<S, F> {
     state: S,
     f: F,
 }
 
-/// Stream for the [`scan`](super::StreamExt::scan) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Scan<St: Stream, S, Fut, F> {
-    #[pin]
-    stream: St,
-    state_f: Option<StateFn<S, F>>,
-    #[pin]
-    future: Option<Fut>,
+pin_project! {
+    /// Stream for the [`scan`](super::StreamExt::scan) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Scan<St: Stream, S, Fut, F> {
+        #[pin]
+        stream: St,
+        state_f: Option<StateFn<S, F>>,
+        #[pin]
+        future: Option<Fut>,
+    }
 }
 
 impl<St, S, Fut, F> fmt::Debug for Scan<St, S, Fut, F>

--- a/futures-util/src/stream/stream/skip.rs
+++ b/futures-util/src/stream/stream/skip.rs
@@ -4,16 +4,17 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`skip`](super::StreamExt::skip) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Skip<St> {
-    #[pin]
-    stream: St,
-    remaining: usize,
+pin_project! {
+    /// Stream for the [`skip`](super::StreamExt::skip) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Skip<St> {
+        #[pin]
+        stream: St,
+        remaining: usize,
+    }
 }
 
 impl<St: Stream> Skip<St> {

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -6,19 +6,20 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`skip_while`](super::StreamExt::skip_while) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct SkipWhile<St, Fut, F> where St: Stream {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Item>,
-    done_skipping: bool,
+pin_project! {
+    /// Stream for the [`skip_while`](super::StreamExt::skip_while) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct SkipWhile<St, Fut, F> where St: Stream {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Item>,
+        done_skipping: bool,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for SkipWhile<St, Fut, F>

--- a/futures-util/src/stream/stream/take.rs
+++ b/futures-util/src/stream/stream/take.rs
@@ -5,16 +5,17 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`take`](super::StreamExt::take) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Take<St> {
-    #[pin]
-    stream: St,
-    remaining: usize,
+pin_project! {
+    /// Stream for the [`take`](super::StreamExt::take) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Take<St> {
+        #[pin]
+        stream: St,
+        remaining: usize,
+    }
 }
 
 impl<St: Stream> Take<St> {

--- a/futures-util/src/stream/stream/take_until.rs
+++ b/futures-util/src/stream/stream/take_until.rs
@@ -6,24 +6,25 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 // FIXME: docs, tests
 
-/// Stream for the [`take_until`](super::StreamExt::take_until) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TakeUntil<St: Stream, Fut: Future> {
-    #[pin]
-    stream: St,
-    /// Contains the inner Future on start and None once the inner Future is resolved
-    /// or taken out by the user.
-    #[pin]
-    fut: Option<Fut>,
-    /// Contains fut's return value once fut is resolved
-    fut_result: Option<Fut::Output>,
-    /// Whether the future was taken out by the user.
-    free: bool,
+pin_project! {
+    /// Stream for the [`take_until`](super::StreamExt::take_until) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TakeUntil<St: Stream, Fut: Future> {
+        #[pin]
+        stream: St,
+        // Contains the inner Future on start and None once the inner Future is resolved
+        // or taken out by the user.
+        #[pin]
+        fut: Option<Fut>,
+        // Contains fut's return value once fut is resolved
+        fut_result: Option<Fut::Output>,
+        // Whether the future was taken out by the user.
+        free: bool,
+    }
 }
 
 impl<St, Fut> fmt::Debug for TakeUntil<St, Fut>

--- a/futures-util/src/stream/stream/take_while.rs
+++ b/futures-util/src/stream/stream/take_while.rs
@@ -6,19 +6,20 @@ use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`take_while`](super::StreamExt::take_while) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TakeWhile<St: Stream, Fut, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Item>,
-    done_taking: bool,
+pin_project! {
+    /// Stream for the [`take_while`](super::StreamExt::take_while) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TakeWhile<St: Stream, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Item>,
+        done_taking: bool,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TakeWhile<St, Fut, F>

--- a/futures-util/src/stream/stream/then.rs
+++ b/futures-util/src/stream/stream/then.rs
@@ -6,17 +6,18 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`then`](super::StreamExt::then) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Then<St, Fut, F> {
-    #[pin]
-    stream: St,
-    #[pin]
-    future: Option<Fut>,
-    f: F,
+pin_project! {
+    /// Stream for the [`then`](super::StreamExt::then) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Then<St, Fut, F> {
+        #[pin]
+        stream: St,
+        #[pin]
+        future: Option<Fut>,
+        f: F,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for Then<St, Fut, F>

--- a/futures-util/src/stream/stream/unzip.rs
+++ b/futures-util/src/stream/stream/unzip.rs
@@ -4,17 +4,18 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`unzip`](super::StreamExt::unzip) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Unzip<St, FromA, FromB> {
-    #[pin]
-    stream: St,
-    left: FromA,
-    right: FromB,
+pin_project! {
+    /// Future for the [`unzip`](super::StreamExt::unzip) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Unzip<St, FromA, FromB> {
+        #[pin]
+        stream: St,
+        left: FromA,
+        right: FromB,
+    }
 }
 
 impl<St: Stream, FromA: Default, FromB: Default> Unzip<St, FromA, FromB> {

--- a/futures-util/src/stream/stream/zip.rs
+++ b/futures-util/src/stream/stream/zip.rs
@@ -3,19 +3,20 @@ use core::cmp;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`zip`](super::StreamExt::zip) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct Zip<St1: Stream, St2: Stream> {
-    #[pin]
-    stream1: Fuse<St1>,
-    #[pin]
-    stream2: Fuse<St2>,
-    queued1: Option<St1::Item>,
-    queued2: Option<St2::Item>,
+pin_project! {
+    /// Stream for the [`zip`](super::StreamExt::zip) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Zip<St1: Stream, St2: Stream> {
+        #[pin]
+        stream1: Fuse<St1>,
+        #[pin]
+        stream2: Fuse<St2>,
+        queued1: Option<St1::Item>,
+        queued2: Option<St2::Item>,
+    }
 }
 
 impl<St1: Stream, St2: Stream> Zip<St1, St2> {

--- a/futures-util/src/stream/try_stream/and_then.rs
+++ b/futures-util/src/stream/try_stream/and_then.rs
@@ -6,17 +6,18 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`and_then`](super::TryStreamExt::and_then) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct AndThen<St, Fut, F> {
-    #[pin]
-    stream: St,
-    #[pin]
-    future: Option<Fut>,
-    f: F,
+pin_project! {
+    /// Stream for the [`and_then`](super::TryStreamExt::and_then) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct AndThen<St, Fut, F> {
+        #[pin]
+        stream: St,
+        #[pin]
+        future: Option<Fut>,
+        f: F,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for AndThen<St, Fut, F>

--- a/futures-util/src/stream/try_stream/into_stream.rs
+++ b/futures-util/src/stream/try_stream/into_stream.rs
@@ -3,15 +3,16 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`into_stream`](super::TryStreamExt::into_stream) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct IntoStream<St> {
-    #[pin]
-    stream: St,
+pin_project! {
+    /// Stream for the [`into_stream`](super::TryStreamExt::into_stream) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct IntoStream<St> {
+        #[pin]
+        stream: St,
+    }
 }
 
 impl<St> IntoStream<St> {

--- a/futures-util/src/stream/try_stream/or_else.rs
+++ b/futures-util/src/stream/try_stream/or_else.rs
@@ -6,17 +6,18 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`or_else`](super::TryStreamExt::or_else) method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct OrElse<St, Fut, F> {
-    #[pin]
-    stream: St,
-    #[pin]
-    future: Option<Fut>,
-    f: F,
+pin_project! {
+    /// Stream for the [`or_else`](super::TryStreamExt::or_else) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct OrElse<St, Fut, F> {
+        #[pin]
+        stream: St,
+        #[pin]
+        future: Option<Fut>,
+        f: F,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for OrElse<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_buffer_unordered.rs
@@ -5,21 +5,22 @@ use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::pin::Pin;
 
-/// Stream for the
-/// [`try_buffer_unordered`](super::TryStreamExt::try_buffer_unordered) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryBufferUnordered<St>
-    where St: TryStream
-{
-    #[pin]
-    stream: Fuse<IntoStream<St>>,
-    in_progress_queue: FuturesUnordered<IntoFuture<St::Ok>>,
-    max: usize,
+pin_project! {
+    /// Stream for the
+    /// [`try_buffer_unordered`](super::TryStreamExt::try_buffer_unordered) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryBufferUnordered<St>
+        where St: TryStream
+    {
+        #[pin]
+        stream: Fuse<IntoStream<St>>,
+        in_progress_queue: FuturesUnordered<IntoFuture<St::Ok>>,
+        max: usize,
+    }
 }
 
 impl<St> TryBufferUnordered<St>

--- a/futures-util/src/stream/try_stream/try_buffered.rs
+++ b/futures-util/src/stream/try_stream/try_buffered.rs
@@ -5,22 +5,23 @@ use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 use core::pin::Pin;
 
-/// Stream for the [`try_buffered`](super::TryStreamExt::try_buffered) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryBuffered<St>
-where
-    St: TryStream,
-    St::Ok: TryFuture,
-{
-    #[pin]
-    stream: Fuse<IntoStream<St>>,
-    in_progress_queue: FuturesOrdered<IntoFuture<St::Ok>>,
-    max: usize,
+pin_project! {
+    /// Stream for the [`try_buffered`](super::TryStreamExt::try_buffered) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryBuffered<St>
+    where
+        St: TryStream,
+        St::Ok: TryFuture,
+    {
+        #[pin]
+        stream: Fuse<IntoStream<St>>,
+        in_progress_queue: FuturesOrdered<IntoFuture<St::Ok>>,
+        max: usize,
+    }
 }
 
 impl<St> TryBuffered<St>

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -4,16 +4,17 @@ use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`try_collect`](super::TryStreamExt::try_collect) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryCollect<St, C> {
-    #[pin]
-    stream: St,
-    items: C,
+pin_project! {
+    /// Future for the [`try_collect`](super::TryStreamExt::try_collect) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryCollect<St, C> {
+        #[pin]
+        stream: St,
+        items: C,
+    }
 }
 
 impl<St: TryStream, C: Default> TryCollect<St, C> {

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -3,16 +3,17 @@ use futures_core::future::Future;
 use futures_core::ready;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`try_concat`](super::TryStreamExt::try_concat) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryConcat<St: TryStream> {
-    #[pin]
-    stream: St,
-    accum: Option<St::Ok>,
+pin_project! {
+    /// Future for the [`try_concat`](super::TryStreamExt::try_concat) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryConcat<St: TryStream> {
+        #[pin]
+        stream: St,
+        accum: Option<St::Ok>,
+    }
 }
 
 impl<St> TryConcat<St>

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -6,21 +6,22 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`try_filter`](super::TryStreamExt::try_filter)
-/// method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryFilter<St, Fut, F>
-    where St: TryStream
-{
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Ok>,
+pin_project! {
+    /// Stream for the [`try_filter`](super::TryStreamExt::try_filter)
+    /// method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryFilter<St, Fut, F>
+        where St: TryStream
+    {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Ok>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TryFilter<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -6,18 +6,19 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`try_filter_map`](super::TryStreamExt::try_filter_map)
-/// method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryFilterMap<St, Fut, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending: Option<Fut>,
+pin_project! {
+    /// Stream for the [`try_filter_map`](super::TryStreamExt::try_filter_map)
+    /// method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryFilterMap<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending: Option<Fut>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TryFilterMap<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_flatten.rs
+++ b/futures-util/src/stream/try_stream/try_flatten.rs
@@ -4,20 +4,21 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`try_flatten`](super::TryStreamExt::try_flatten) method.
-#[pin_project]
-#[derive(Debug)]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryFlatten<St>
-where
-    St: TryStream,
-{
-    #[pin]
-    stream: St,
-    #[pin]
-    next: Option<St::Ok>,
+pin_project! {
+    /// Stream for the [`try_flatten`](super::TryStreamExt::try_flatten) method.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryFlatten<St>
+    where
+        St: TryStream,
+    {
+        #[pin]
+        stream: St,
+        #[pin]
+        next: Option<St::Ok>,
+    }
 }
 
 impl<St> TryFlatten<St>

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -4,18 +4,19 @@ use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryFold<St, Fut, T, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    accum: Option<T>,
-    #[pin]
-    future: Option<Fut>,
+pin_project! {
+    /// Future for the [`try_fold`](super::TryStreamExt::try_fold) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryFold<St, Fut, T, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<T>,
+        #[pin]
+        future: Option<Fut>,
+    }
 }
 
 impl<St, Fut, T, F> fmt::Debug for TryFold<St, Fut, T, F>

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -4,17 +4,18 @@ use futures_core::future::{Future, TryFuture};
 use futures_core::ready;
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryForEach<St, Fut, F> {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    future: Option<Fut>,
+pin_project! {
+    /// Future for the [`try_for_each`](super::TryStreamExt::try_for_each) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryForEach<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        future: Option<Fut>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TryForEach<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -6,19 +6,20 @@ use core::num::NonZeroUsize;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Future for the
-/// [`try_for_each_concurrent`](super::TryStreamExt::try_for_each_concurrent)
-/// method.
-#[pin_project]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryForEachConcurrent<St, Fut, F> {
-    #[pin]
-    stream: Option<St>,
-    f: F,
-    futures: FuturesUnordered<Fut>,
-    limit: Option<NonZeroUsize>,
+pin_project! {
+    /// Future for the
+    /// [`try_for_each_concurrent`](super::TryStreamExt::try_for_each_concurrent)
+    /// method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryForEachConcurrent<St, Fut, F> {
+        #[pin]
+        stream: Option<St>,
+        f: F,
+        futures: FuturesUnordered<Fut>,
+        limit: Option<NonZeroUsize>,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TryForEachConcurrent<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -6,20 +6,21 @@ use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`try_skip_while`](super::TryStreamExt::try_skip_while)
-/// method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TrySkipWhile<St, Fut, F> where St: TryStream {
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Ok>,
-    done_skipping: bool,
+pin_project! {
+    /// Stream for the [`try_skip_while`](super::TryStreamExt::try_skip_while)
+    /// method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TrySkipWhile<St, Fut, F> where St: TryStream {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Ok>,
+        done_skipping: bool,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TrySkipWhile<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -6,23 +6,24 @@ use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`try_take_while`](super::TryStreamExt::try_take_while)
-/// method.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryTakeWhile<St, Fut, F>
-where
-    St: TryStream,
-{
-    #[pin]
-    stream: St,
-    f: F,
-    #[pin]
-    pending_fut: Option<Fut>,
-    pending_item: Option<St::Ok>,
-    done_taking: bool,
+pin_project! {
+    /// Stream for the [`try_take_while`](super::TryStreamExt::try_take_while)
+    /// method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryTakeWhile<St, Fut, F>
+    where
+        St: TryStream,
+    {
+        #[pin]
+        stream: St,
+        f: F,
+        #[pin]
+        pending_fut: Option<Fut>,
+        pending_item: Option<St::Ok>,
+        done_taking: bool,
+    }
 }
 
 impl<St, Fut, F> fmt::Debug for TryTakeWhile<St, Fut, F>

--- a/futures-util/src/stream/try_stream/try_unfold.rs
+++ b/futures-util/src/stream/try_stream/try_unfold.rs
@@ -4,7 +4,7 @@ use futures_core::future::TryFuture;
 use futures_core::ready;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 /// Creates a `TryStream` from a seed and a closure returning a `TryFuture`.
 ///
@@ -67,14 +67,15 @@ where
     }
 }
 
-/// Stream for the [`try_unfold`] function.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct TryUnfold<T, F, Fut> {
-    f: F,
-    state: Option<T>,
-    #[pin]
-    fut: Option<Fut>,
+pin_project! {
+    /// Stream for the [`try_unfold`] function.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct TryUnfold<T, F, Fut> {
+        f: F,
+        state: Option<T>,
+        #[pin]
+        fut: Option<Fut>,
+    }
 }
 
 impl<T, F, Fut> fmt::Debug for TryUnfold<T, F, Fut>

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -4,7 +4,7 @@ use futures_core::future::Future;
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use pin_project::pin_project;
+use pin_project_lite::pin_project;
 
 /// Creates a `Stream` from a seed and a closure returning a `Future`.
 ///
@@ -56,14 +56,15 @@ pub fn unfold<T, F, Fut, Item>(init: T, f: F) -> Unfold<T, F, Fut>
     }
 }
 
-/// Stream for the [`unfold`] function.
-#[pin_project]
-#[must_use = "streams do nothing unless polled"]
-pub struct Unfold<T, F, Fut> {
-    f: F,
-    state: Option<T>,
-    #[pin]
-    fut: Option<Fut>,
+pin_project! {
+    /// Stream for the [`unfold`] function.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Unfold<T, F, Fut> {
+        f: F,
+        state: Option<T>,
+        #[pin]
+        fut: Option<Fut>,
+    }
 }
 
 impl<T, F, Fut> fmt::Debug for Unfold<T, F, Fut>


### PR DESCRIPTION
[`pin-project-lite`](https://github.com/taiki-e/pin-project-lite) 0.2 supports enum. However, unfortunately, some enums (`Either`, `(Try)MaybeDone`) that require pin-projection used in futures-util have tuple variants and are also public APIs, so, we cannot use pin-project-lite for these enums.

`futures-test` also depends on pin-project, but this PR doesn't touch that as that needs support for custom Drop implementation (https://github.com/taiki-e/pin-project-lite/pull/25) and `futures-test` is a crate intended to be used as a dev-dependency.

Closes #2170