### PR TITLE
SinkExt::feed_all

### DIFF
--- a/futures-util/src/sink/feed_all.rs
+++ b/futures-util/src/sink/feed_all.rs
@@ -1,0 +1,116 @@
+use crate::stream::TryStreamExt;
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::Future;
+use futures_core::ready;
+use futures_core::stream::{TryStream, Stream};
+use futures_core::task::{Context, Poll};
+use futures_sink::Sink;
+
+/// Future for the [`feed_all`](super::SinkExt::feed_all) method.
+#[allow(explicit_outlives_requirements)] // https://github.com/rust-lang/rust/issues/60993
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct FeedAll<'a, Si, St>
+where
+    Si: ?Sized,
+    St: ?Sized + TryStream,
+{
+    sink: &'a mut Si,
+    stream: &'a mut St,
+    buffered: Option<St::Ok>,
+}
+
+impl<Si, St> fmt::Debug for FeedAll<'_, Si, St>
+where
+    Si: fmt::Debug + ?Sized,
+    St: fmt::Debug + ?Sized + TryStream,
+    St::Ok: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FeedAll")
+            .field("sink", &self.sink)
+            .field("stream", &self.stream)
+            .field("buffered", &self.buffered)
+            .finish()
+    }
+}
+
+// Pinning is never projected to any fields
+impl<Si, St> Unpin for FeedAll<'_, Si, St>
+where
+    Si: Unpin + ?Sized,
+    St: TryStream + Unpin + ?Sized,
+{}
+
+impl<'a, Si, St, Ok, Error> FeedAll<'a, Si, St>
+where
+    Si: Sink<Ok, Error = Error> + Unpin + ?Sized,
+    St: TryStream<Ok = Ok, Error = Error> + Stream + Unpin + ?Sized,
+{
+    pub(super) fn new(
+        sink: &'a mut Si,
+        stream: &'a mut St,
+    ) -> Self {
+        Self {
+            sink,
+            stream,
+            buffered: None,
+        }
+    }
+
+    pub(super) fn sink_pin_mut(&mut self) -> Pin<&mut Si> {
+        Pin::new(self.sink)
+    }
+
+    fn try_start_send(
+        &mut self,
+        cx: &mut Context<'_>,
+        item: St::Ok,
+    ) -> Poll<Result<(), Si::Error>> {
+        debug_assert!(self.buffered.is_none());
+        match Pin::new(&mut self.sink).poll_ready(cx)? {
+            Poll::Ready(()) => {
+                Poll::Ready(Pin::new(&mut self.sink).start_send(item))
+            }
+            Poll::Pending => {
+                self.buffered = Some(item);
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl<Si, St, Ok, Error> Future for FeedAll<'_, Si, St>
+where
+    Si: Sink<Ok, Error = Error> + Unpin + ?Sized,
+    St: Stream<Item = Result<Ok, Error>> + Unpin + ?Sized,
+{
+    type Output = Result<(), Error>;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        // If we've got an item buffered already, we need to write it to the
+        // sink before we can do anything else
+        if let Some(item) = this.buffered.take() {
+            ready!(this.try_start_send(cx, item))?
+        }
+
+        loop {
+            match this.stream.try_poll_next_unpin(cx)? {
+                Poll::Ready(Some(item)) => {
+                    ready!(this.try_start_send(cx, item))?
+                }
+                Poll::Ready(None) => {
+                    return Poll::Ready(Ok(()))
+                }
+                Poll::Pending => {
+                    ready!(Pin::new(&mut this.sink).poll_flush(cx))?;
+                    return Poll::Pending
+                }
+            }
+        }
+    }
+}

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -29,6 +29,9 @@ pub use self::fanout::Fanout;
 mod feed;
 pub use self::feed::Feed;
 
+mod feed_all;
+pub use self::feed_all::FeedAll;
+
 mod flush;
 pub use self::flush::Flush;
 
@@ -215,7 +218,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// into the sink, including flushing.
     ///
     /// Note that, **because of the flushing requirement, it is usually better
-    /// to batch together items to send via `feed` or `send_all`,
+    /// to batch together items to send via `feed`, `feed_all`, or `send_all`,
     /// rather than flushing between each item.**
     fn send(&mut self, item: Item) -> Send<'_, Self, Item>
     where
@@ -253,6 +256,28 @@ pub trait SinkExt<Item>: Sink<Item> {
         Self: Unpin,
     {
         SendAll::new(self, stream)
+    }
+
+    /// A future that completes after the given stream has been fully received
+    /// by the sink.
+    ///
+    /// This future will drive the stream to keep producing items until it is
+    /// exhausted, sending each item to the sink. It will complete once the
+    /// stream is exhausted and the sink has received all items.
+    /// Note that the sink is **not** closed.
+    ///
+    /// Unlike `send_all`, the returned future does not fully flush the sink
+    /// before completion.
+    /// It is the caller's responsibility to ensure all pending items
+    /// are processed, which can be done via `flush` or `close`.
+    fn feed_all<'a, St>(
+        &'a mut self,
+        stream: &'a mut St
+    ) -> FeedAll<'a, Self, St>
+        where St: TryStream<Ok = Item, Error = Self::Error> + Stream + Unpin + ?Sized,
+              Self: Unpin,
+    {
+        FeedAll::new(self, stream)
     }
 
     /// Wrap this sink in an `Either` sink, making it the left-hand variant

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -264,6 +264,8 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// This future will drive the stream to keep producing items until it is
     /// exhausted, sending each item to the sink. It will complete once the
     /// stream is exhausted and the sink has received all items.
+    /// While the stream is not ready to yield the next item, this future will
+    /// drive the sink to flush any pending items.
     /// Note that the sink is **not** closed.
     ///
     /// Unlike `send_all`, the returned future does not fully flush the sink

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -417,7 +417,7 @@ pub mod sink {
     pub use futures_sink::Sink;
 
     pub use futures_util::sink::{
-        Close, Feed, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
+        Close, Feed, FeedAll, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
         SinkExt, Fanout, Drain, drain, Unfold, unfold,
         WithFlatMap,
     };


### PR DESCRIPTION
Add method `feed_all` to `SinkExt`.

This combinator is like `send_all`, except that it does not flush the sink at the end.

This was originally submitted as part of #2155, but left out due to concerns about the new API: https://github.com/rust-lang/futures-rs/pull/2155#issuecomment-740413707