### PR TITLE
Implement Clone on With combinator

### DIFF
--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -11,7 +11,6 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// Sink for the [`with`](super::SinkExt::with) method.
     #[must_use = "sinks do nothing unless polled"]
-    #[derive(Clone)]
     pub struct With<Si, Item, U, Fut, F> {
         #[pin]
         sink: Si,
@@ -49,6 +48,22 @@ where Si: Sink<Item>,
             state: None,
             sink,
             f,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Si, Item, U, Fut, F> Clone for With<Si, Item, U, Fut, F>
+where
+    Si: Clone,
+    F: Clone,
+    Fut: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            sink: self.sink.clone(),
+            f: self.f.clone(),
             _phantom: PhantomData,
         }
     }

--- a/futures-util/src/sink/with.rs
+++ b/futures-util/src/sink/with.rs
@@ -11,6 +11,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// Sink for the [`with`](super::SinkExt::with) method.
     #[must_use = "sinks do nothing unless polled"]
+    #[derive(Clone)]
     pub struct With<Si, Item, U, Fut, F> {
         #[pin]
         sink: Si,


### PR DESCRIPTION
Consider the following use-case of mpsc channels. There are two
categories of producers which produce items of two distinct types,
later unified in one using `With` combinator:

```
let (sender, receiver) = mspc::channel(100);

let download_status = sender.clone().with(|item| {
    futures::future::ok(Status::Download(item))
});

let unpack_status = sender.clone().with(|item| {
    futures::future::ok(Status::Unpack(item))
});
```

It would be convenient for `With` combinator to implement `Clone`,
since the underlying sink, `futures::channel::mpsc::Sender`,
implements it.

This change adds `#[derive(Clone)]` to `With` combinator