### PR TITLE
futures_util::stream::SelectAll::push should use &self.

### DIFF
--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -60,7 +60,7 @@ impl<St: Stream + Unpin> SelectAll<St> {
     /// function will not call `poll` on the submitted stream. The caller must
     /// ensure that `SelectAll::poll` is called in order to receive task
     /// notifications.
-    pub fn push(&mut self, stream: St) {
+    pub fn push(&self, stream: St) {
         self.inner.push(stream.into_future());
     }
 }
@@ -118,7 +118,7 @@ pub fn select_all<I>(streams: I) -> SelectAll<I::Item>
     where I: IntoIterator,
           I::Item: Stream + Unpin
 {
-    let mut set = SelectAll::new();
+    let set = SelectAll::new();
 
     for stream in streams {
         set.push(stream);


### PR DESCRIPTION
FuturesUnordered::push bound is &self, so SelectAll should be able to use the same bound.