### PR TITLE
Do not redefine modules in futures crate

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -1,9 +1,14 @@
 //! Asynchronous channels.
 //!
-//! This crate provides channels that can be used to communicate between
-//! asynchronous tasks.
+//! Like threads, concurrent tasks sometimes need to communicate with each
+//! other. This module contains two basic abstractions for doing so:
 //!
-//! All items of this library are only available when the `std` or `alloc` feature of this
+//! - [oneshot], a way of sending a single value from one task to another.
+//! - [mpsc], a multi-producer, single-consumer channel for sending values
+//!   between tasks, analogous to the similarly-named structure in the standard
+//!   library.
+//!
+//! All items are only available when the `std` or `alloc` feature of this
 //! library is activated, and it is activated by default.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -1,7 +1,40 @@
 //! Built-in executors and related tools.
 //!
-//! All items of this library are only available when the `std` feature of this
+//! All asynchronous computation occurs within an executor, which is
+//! capable of spawning futures as tasks. This module provides several
+//! built-in executors, as well as tools for building your own.
+//!
+//! All items are only available when the `std` feature of this
 //! library is activated, and it is activated by default.
+//!
+//! # Using a thread pool (M:N task scheduling)
+//!
+//! Most of the time tasks should be executed on a [thread pool](ThreadPool).
+//! A small set of worker threads can handle a very large set of spawned tasks
+//! (which are much lighter weight than threads). Tasks spawned onto the pool
+//! with the [`spawn_ok`](ThreadPool::spawn_ok) function will run ambiently on
+//! the created threads.
+//!
+//! # Spawning additional tasks
+//!
+//! Tasks can be spawned onto a spawner by calling its [`spawn_obj`] method
+//! directly. In the case of `!Send` futures, [`spawn_local_obj`] can be used
+//! instead.
+//!
+//! # Single-threaded execution
+//!
+//! In addition to thread pools, it's possible to run a task (and the tasks
+//! it spawns) entirely within a single thread via the [`LocalPool`] executor.
+//! Aside from cutting down on synchronization costs, this executor also makes
+//! it possible to spawn non-`Send` tasks, via [`spawn_local_obj`]. The
+//! [`LocalPool`] is best suited for running I/O-bound tasks that do relatively
+//! little work between I/O operations.
+//!
+//! There is also a convenience function [`block_on`] for simply running a
+//! future to completion on the current thread.
+//!
+//! [`spawn_obj`]: https://docs.rs/futures/0.3/futures/task/trait.Spawn.html#tymethod.spawn_obj
+//! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -1,4 +1,4 @@
-//! Futures 0.1 / 0.3 shims
+//! Interop between `futures` 0.1 and 0.3.
 //!
 //! This module is only available when the `compat` feature of this
 //! library is activated.

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -1,8 +1,13 @@
-//! Futures
+//! Asynchronous values.
 //!
-//! This module contains a number of functions for working with `Future`s,
-//! including the [`FutureExt`] trait and the [`TryFutureExt`] trait which add
-//! methods to `Future` types.
+//! This module contains:
+//!
+//! - The [`Future`] trait.
+//! - The [`FutureExt`] and [`TryFutureExt`] trait, which provides adapters for
+//!   chaining and composing futures.
+//! - Top-level future combinators like [`lazy`](lazy()) which creates a future
+//!   from a closure that defines its return value, and [`ready`](ready()),
+//!   which constructs a future with an immediate defined value.
 
 #[cfg(feature = "alloc")]
 pub use futures_core::future::{BoxFuture, LocalBoxFuture};

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -1,12 +1,19 @@
-//! IO
+//! Asynchronous I/O.
 //!
-//! This module contains a number of functions for working with
-//! `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` types, including
-//! the `AsyncReadExt`, `AsyncWriteExt`, `AsyncSeekExt`, and `AsyncBufReadExt`
-//! traits which add methods to the `AsyncRead`, `AsyncWrite`, `AsyncSeek`,
-//! and `AsyncBufRead` types.
+//! This module is the asynchronous version of `std::io`. It defines four
+//! traits, [`AsyncRead`], [`AsyncWrite`], [`AsyncSeek`], and [`AsyncBufRead`],
+//! which mirror the `Read`, `Write`, `Seek`, and `BufRead` traits of the
+//! standard library. However, these traits integrate with the asynchronous
+//! task system, so that if an I/O object isn't ready for reading (or writing),
+//! the thread is not blocked, and instead the current task is queued to be
+//! woken when I/O is ready.
 //!
-//! This module is only available when the `io` and `std` features of this
+//! In addition, the [`AsyncReadExt`], [`AsyncWriteExt`], [`AsyncSeekExt`], and
+//! [`AsyncBufReadExt`] extension traits offer a variety of useful combinators
+//! for operating with asynchronous I/O objects, including ways to work with
+//! them using futures, streams and sinks.
+//!
+//! This module is only available when the `std` feature of this
 //! library is activated, and it is activated by default.
 
 #[cfg(feature = "io-compat")]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -343,10 +343,8 @@ pub mod io;
 #[doc(hidden)]
 pub use crate::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
+#[cfg(feature = "alloc")]
+pub mod lock;
+
 mod fns;
 mod unfold_state;
-
-cfg_target_has_atomic! {
-    #[cfg(feature = "alloc")]
-    pub mod lock;
-}

--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -3,18 +3,20 @@
 //! This module is only available when the `std` or `alloc` feature of this
 //! library is activated, and it is activated by default.
 
-#[cfg(feature = "std")]
-mod mutex;
-#[cfg(feature = "std")]
-pub use self::mutex::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
+cfg_target_has_atomic! {
+    #[cfg(feature = "std")]
+    mod mutex;
+    #[cfg(feature = "std")]
+    pub use self::mutex::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
 
-#[cfg(any(feature = "bilock", feature = "sink", feature = "io"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
-#[cfg_attr(not(feature = "bilock"), allow(unreachable_pub))]
-mod bilock;
-#[cfg(feature = "bilock")]
-#[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
-pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
-#[cfg(any(feature = "sink", feature = "io"))]
-#[cfg(not(feature = "bilock"))]
-pub(crate) use self::bilock::BiLock;
+    #[cfg(any(feature = "bilock", feature = "sink", feature = "io"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
+    #[cfg_attr(not(feature = "bilock"), allow(unreachable_pub))]
+    mod bilock;
+    #[cfg(feature = "bilock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
+    pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
+    #[cfg(any(feature = "sink", feature = "io"))]
+    #[cfg(not(feature = "bilock"))]
+    pub(crate) use self::bilock::BiLock;
+}

--- a/futures-util/src/never.rs
+++ b/futures-util/src/never.rs
@@ -1,5 +1,6 @@
-//! Definition of the `Never` type,
-//! a stand-in for the `!` type until it becomes stable.
+//! This module contains the `Never` type.
+//!
+//! Values of this type can never be created and will never exist.
 
 /// A type with no possible values.
 ///

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -1,10 +1,10 @@
-//! Sinks
+//! Asynchronous sinks.
 //!
-//! This module contains a number of functions for working with `Sink`s,
-//! including the `SinkExt` trait which adds methods to `Sink` types.
+//! This module contains:
 //!
-//! This module is only available when the `sink` feature of this
-//! library is activated, and it is activated by default.
+//! - The [`Sink`] trait, which allows you to asynchronously write data.
+//! - The [`SinkExt`] trait, which provides adapters for chaining and composing
+//!   sinks.
 
 use crate::future::Either;
 use core::pin::Pin;

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -1,8 +1,13 @@
-//! Streams
+//! Asynchronous streams.
 //!
-//! This module contains a number of functions for working with `Stream`s,
-//! including the [`StreamExt`] trait and the [`TryStreamExt`] trait which add
-//! methods to `Stream` types
+//! This module contains:
+//!
+//! - The [`Stream`] trait, for objects that can asynchronously produce a
+//!   sequence of values.
+//! - The [`StreamExt`] and [`TryStreamExt`] trait, which provides adapters for
+//!   chaining and composing streams.
+//! - Top-level stream constructors like [`iter`](iter()) which creates a
+//!   stream from an iterator.
 
 #[cfg(feature = "alloc")]
 pub use futures_core::stream::{BoxStream, LocalBoxStream};

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -1,4 +1,25 @@
-//! Task notification
+//! Tools for working with tasks.
+//!
+//! This module contains:
+//!
+//! - [`Spawn`], a trait for spawning new tasks.
+//! - [`Context`], a context of an asynchronous task,
+//!   including a handle for waking up the task.
+//! - [`Waker`], a handle for waking up a task.
+//!
+//! The remaining types and traits in the module are used for implementing
+//! executors or dealing with synchronization issues around task wakeup.
+
+pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+
+pub use futures_task::{
+    Spawn, LocalSpawn, SpawnError,
+    FutureObj, LocalFutureObj, UnsafeFutureObj,
+};
+
+pub use futures_task::noop_waker;
+#[cfg(feature = "std")]
+pub use futures_task::noop_waker_ref;
 
 cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]
@@ -15,14 +36,3 @@ cfg_target_has_atomic! {
 
 mod spawn;
 pub use self::spawn::{SpawnExt, LocalSpawnExt};
-
-pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
-
-pub use futures_task::{
-    Spawn, LocalSpawn, SpawnError,
-    FutureObj, LocalFutureObj, UnsafeFutureObj,
-};
-
-pub use futures_task::noop_waker;
-#[cfg(feature = "std")]
-pub use futures_task::noop_waker_ref;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -106,266 +106,61 @@ compile_error!("The `bilock` feature requires the `unstable` feature as an expli
 #[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
 compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
-#[doc(hidden)] pub use futures_core::future::{Future, TryFuture};
-#[doc(hidden)] pub use futures_util::future::{FutureExt, TryFutureExt};
+#[doc(hidden)]
+pub use futures_core::future::{Future, TryFuture};
+#[doc(hidden)]
+pub use futures_util::future::{FutureExt, TryFutureExt};
 
-#[doc(hidden)] pub use futures_core::stream::{Stream, TryStream};
-#[doc(hidden)] pub use futures_util::stream::{StreamExt, TryStreamExt};
+#[doc(hidden)]
+pub use futures_core::stream::{Stream, TryStream};
+#[doc(hidden)]
+pub use futures_util::stream::{StreamExt, TryStreamExt};
 
-#[doc(hidden)] pub use futures_sink::Sink;
-#[doc(hidden)] pub use futures_util::sink::SinkExt;
+#[doc(hidden)]
+pub use futures_sink::Sink;
+#[doc(hidden)]
+pub use futures_util::sink::SinkExt;
 
 #[cfg(feature = "std")]
-#[doc(hidden)] pub use futures_io::{AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead};
+#[doc(hidden)]
+pub use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 #[cfg(feature = "std")]
-#[doc(hidden)] pub use futures_util::{AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt};
+#[doc(hidden)]
+pub use futures_util::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 
 // Macro reexports
 pub use futures_core::ready; // Readiness propagation
 pub use futures_util::pin_mut;
-#[cfg(feature = "async-await")]
-pub use futures_util::{pending, poll, join, try_join, select_biased}; // Async-await
 #[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 pub use futures_util::select;
+#[cfg(feature = "async-await")]
+pub use futures_util::{join, pending, poll, select_biased, try_join}; // Async-await
 
-#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
+// Module reexports
+#[doc(inline)]
+pub use futures_util::{future, never, sink, stream, task};
+
 #[cfg(feature = "alloc")]
-pub mod channel {
-    //! Cross-task communication.
-    //!
-    //! Like threads, concurrent tasks sometimes need to communicate with each
-    //! other. This module contains two basic abstractions for doing so:
-    //!
-    //! - [oneshot](crate::channel::oneshot), a way of sending a single value
-    //!   from one task to another.
-    //! - [mpsc](crate::channel::mpsc), a multi-producer, single-consumer
-    //!   channel for sending values between tasks, analogous to the
-    //!   similarly-named structure in the standard library.
-    //!
-    //! This module is only available when the `std` or `alloc` feature of this
-    //! library is activated, and it is activated by default.
+#[doc(inline)]
+pub use futures_channel as channel;
+#[cfg(feature = "alloc")]
+#[doc(inline)]
+pub use futures_util::lock;
 
-    pub use futures_channel::oneshot;
+#[cfg(feature = "std")]
+#[doc(inline)]
+pub use futures_util::io;
 
-    #[cfg(feature = "std")]
-    pub use futures_channel::mpsc;
-}
+#[cfg(feature = "executor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "executor")))]
+#[doc(inline)]
+pub use futures_executor as executor;
 
 #[cfg(feature = "compat")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
-pub mod compat {
-    //! Interop between `futures` 0.1 and 0.3.
-    //!
-    //! This module is only available when the `compat` feature of this
-    //! library is activated.
-
-    pub use futures_util::compat::{
-        Compat,
-        CompatSink,
-        Compat01As03,
-        Compat01As03Sink,
-        Executor01Future,
-        Executor01As03,
-        Executor01CompatExt,
-        Future01CompatExt,
-        Stream01CompatExt,
-        Sink01CompatExt,
-    };
-
-    #[cfg(feature = "io-compat")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
-    pub use futures_util::compat::{
-        AsyncRead01CompatExt,
-        AsyncWrite01CompatExt,
-    };
-}
-
-#[cfg(feature = "executor")]
-pub mod executor {
-    //! Task execution.
-    //!
-    //! All asynchronous computation occurs within an executor, which is
-    //! capable of spawning futures as tasks. This module provides several
-    //! built-in executors, as well as tools for building your own.
-    //!
-    //! This module is only available when the `executor` feature of this
-    //! library is activated, and it is activated by default.
-    //!
-    //! # Using a thread pool (M:N task scheduling)
-    //!
-    //! Most of the time tasks should be executed on a [thread
-    //! pool](crate::executor::ThreadPool). A small set of worker threads can
-    //! handle a very large set of spawned tasks (which are much lighter weight
-    //! than threads). Tasks spawned onto the pool with the
-    //! [`spawn_ok()`](crate::executor::ThreadPool::spawn_ok)
-    //! function will run ambiently on the created threads.
-    //!
-    //! # Spawning additional tasks
-    //!
-    //! Tasks can be spawned onto a spawner by calling its
-    //! [`spawn_obj`](crate::task::Spawn::spawn_obj) method directly.
-    //! In the case of `!Send` futures,
-    //! [`spawn_local_obj`](crate::task::LocalSpawn::spawn_local_obj)
-    //! can be used instead.
-    //!
-    //! # Single-threaded execution
-    //!
-    //! In addition to thread pools, it's possible to run a task (and the tasks
-    //! it spawns) entirely within a single thread via the
-    //! [`LocalPool`](crate::executor::LocalPool) executor. Aside from cutting
-    //! down on synchronization costs, this executor also makes it possible to
-    //! spawn non-`Send` tasks, via
-    //! [`spawn_local_obj`](crate::task::LocalSpawn::spawn_local_obj).
-    //! The `LocalPool` is best suited for running I/O-bound tasks that do
-    //! relatively little work between I/O operations.
-    //!
-    //! There is also a convenience function
-    //! [`block_on`](crate::executor::block_on) for simply running a future to
-    //! completion on the current thread.
-
-    pub use futures_executor::{
-        BlockingStream,
-        Enter, EnterError,
-        LocalSpawner, LocalPool,
-        block_on, block_on_stream, enter,
-    };
-
-    #[cfg(feature = "thread-pool")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
-    pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
-}
-
-pub mod future {
-    //! Asynchronous values.
-    //!
-    //! This module contains:
-    //!
-    //! - The [`Future` trait](crate::future::Future).
-    //! - The [`FutureExt`](crate::future::FutureExt) trait, which provides
-    //!   adapters for chaining and composing futures.
-    //! - Top-level future combinators like [`lazy`](crate::future::lazy) which
-    //!   creates a future from a closure that defines its return value, and
-    //!   [`ready`](crate::future::ready), which constructs a future with an
-    //!   immediate defined value.
-
-    pub use futures_core::future::{
-        Future, TryFuture, FusedFuture,
-    };
-
-    #[cfg(feature = "alloc")]
-    pub use futures_core::future::{BoxFuture, LocalBoxFuture};
-
-    pub use futures_task::{FutureObj, LocalFutureObj, UnsafeFutureObj};
-
-    pub use futures_util::future::{
-        lazy, Lazy,
-        maybe_done, MaybeDone,
-        pending, Pending,
-        poll_fn, PollFn,
-        ready, ok, err, Ready,
-        join, join3, join4, join5,
-        Join, Join3, Join4, Join5,
-        select, Select,
-        try_join, try_join3, try_join4, try_join5,
-        TryJoin, TryJoin3, TryJoin4, TryJoin5,
-        try_select, TrySelect,
-        Either,
-        OptionFuture,
-
-        FutureExt,
-        FlattenStream, Flatten, Fuse, Inspect, IntoStream, Map, Then, UnitError,
-        NeverError,
-
-        TryFutureExt,
-        AndThen, ErrInto, FlattenSink, IntoFuture, MapErr, MapOk, MapOkOrElse, MapInto,
-        OrElse, OkInto, InspectOk, InspectErr, TryFlatten, TryFlattenStream, UnwrapOrElse,
-    };
-
-    #[cfg(feature = "alloc")]
-    pub use futures_util::future::{
-        join_all, JoinAll,
-        select_all, SelectAll,
-        try_join_all, TryJoinAll,
-        select_ok, SelectOk,
-    };
-
-    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-    #[cfg(feature = "alloc")]
-    pub use futures_util::future::{
-        abortable, Abortable, AbortHandle, AbortRegistration, Aborted,
-    };
-
-    #[cfg(feature = "std")]
-    pub use futures_util::future::{
-        Remote, RemoteHandle,
-        CatchUnwind, Shared, WeakShared,
-    };
-}
-
-#[cfg(feature = "std")]
-pub mod io {
-    //! Asynchronous I/O.
-    //!
-    //! This module is the asynchronous version of `std::io`. It defines four
-    //! traits, [`AsyncRead`](crate::io::AsyncRead),
-    //! [`AsyncWrite`](crate::io::AsyncWrite),
-    //! [`AsyncSeek`](crate::io::AsyncSeek), and
-    //! [`AsyncBufRead`](crate::io::AsyncBufRead), which mirror the `Read`,
-    //! `Write`, `Seek`, and `BufRead` traits of the standard library. However,
-    //! these traits integrate
-    //! with the asynchronous task system, so that if an I/O object isn't ready
-    //! for reading (or writing), the thread is not blocked, and instead the
-    //! current task is queued to be woken when I/O is ready.
-    //!
-    //! In addition, the [`AsyncReadExt`](crate::io::AsyncReadExt),
-    //! [`AsyncWriteExt`](crate::io::AsyncWriteExt),
-    //! [`AsyncSeekExt`](crate::io::AsyncSeekExt), and
-    //! [`AsyncBufReadExt`](crate::io::AsyncBufReadExt) extension traits offer a
-    //! variety of useful combinators for operating with asynchronous I/O
-    //! objects, including ways to work with them using futures, streams and
-    //! sinks.
-    //!
-    //! This module is only available when the `std` feature of this
-    //! library is activated, and it is activated by default.
-
-    pub use futures_io::{
-        AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, Error, ErrorKind,
-        IoSlice, IoSliceMut, Result, SeekFrom,
-    };
-
-    #[cfg(feature = "read-initializer")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
-    pub use futures_io::Initializer;
-
-    pub use futures_util::io::{
-        AsyncReadExt, AsyncWriteExt, AsyncSeekExt, AsyncBufReadExt, AllowStdIo,
-        BufReader, BufWriter, Cursor, Chain, Close, copy, Copy, copy_buf, CopyBuf,
-        empty, Empty, FillBuf, Flush, IntoSink, Lines, Read, ReadExact, ReadHalf,
-        ReadLine, ReadToEnd, ReadToString, ReadUntil, ReadVectored, repeat,
-        Repeat, ReuniteError, Seek, sink, Sink, Take, Window, Write, WriteAll, WriteHalf,
-        WriteVectored,
-    };
-
-    #[cfg(feature = "write-all-vectored")]
-    pub use futures_util::io::WriteAllVectored;
-}
-
-#[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-#[cfg(feature = "alloc")]
-pub mod lock {
-    //! Futures-powered synchronization primitives.
-    //!
-    //! This module is only available when the `std` or `alloc` feature of this
-    //! library is activated, and it is activated by default.
-
-    #[cfg(feature = "bilock")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
-    pub use futures_util::lock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
-
-    #[cfg(feature = "std")]
-    pub use futures_util::lock::{MappedMutexGuard, Mutex, MutexLockFuture, MutexGuard};
-}
+#[doc(inline)]
+pub use futures_util::compat;
 
 pub mod prelude {
     //! A "prelude" for crates using the `futures` crate.
@@ -382,171 +177,22 @@ pub mod prelude {
     //! The prelude may grow over time as additional items see ubiquitous use.
 
     pub use crate::future::{self, Future, TryFuture};
-    pub use crate::stream::{self, Stream, TryStream};
     pub use crate::sink::{self, Sink};
+    pub use crate::stream::{self, Stream, TryStream};
 
     #[doc(no_inline)]
     pub use crate::future::{FutureExt as _, TryFutureExt as _};
     #[doc(no_inline)]
-    pub use crate::stream::{StreamExt as _, TryStreamExt as _};
-    #[doc(no_inline)]
     pub use crate::sink::SinkExt as _;
+    #[doc(no_inline)]
+    pub use crate::stream::{StreamExt as _, TryStreamExt as _};
 
     #[cfg(feature = "std")]
-    pub use crate::io::{
-        AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead,
-    };
+    pub use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
     #[cfg(feature = "std")]
     #[doc(no_inline)]
     pub use crate::io::{
-        AsyncReadExt as _, AsyncWriteExt as _, AsyncSeekExt as _, AsyncBufReadExt as _,
+        AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
     };
-}
-
-pub mod sink {
-    //! Asynchronous sinks.
-    //!
-    //! This module contains:
-    //!
-    //! - The [`Sink` trait](crate::sink::Sink), which allows you to
-    //!   asynchronously write data.
-    //! - The [`SinkExt`](crate::sink::SinkExt) trait, which provides adapters
-    //!   for chaining and composing sinks.
-
-    pub use futures_sink::Sink;
-
-    pub use futures_util::sink::{
-        Close, Feed, Flush, Send, SendAll, SinkErrInto, SinkMapErr, With,
-        SinkExt, Fanout, Drain, drain, Unfold, unfold,
-        WithFlatMap,
-    };
-
-    #[cfg(feature = "alloc")]
-    pub use futures_util::sink::Buffer;
-}
-
-pub mod stream {
-    //! Asynchronous streams.
-    //!
-    //! This module contains:
-    //!
-    //! - The [`Stream` trait](crate::stream::Stream), for objects that can
-    //!   asynchronously produce a sequence of values.
-    //! - The [`StreamExt`](crate::stream::StreamExt) trait, which provides
-    //!   adapters for chaining and composing streams.
-    //! - Top-level stream constructors like [`iter`](crate::stream::iter)
-    //!   which creates a stream from an iterator.
-
-    pub use futures_core::stream::{
-        Stream, TryStream, FusedStream,
-    };
-
-    #[cfg(feature = "alloc")]
-    pub use futures_core::stream::{BoxStream, LocalBoxStream};
-
-    pub use futures_util::stream::{
-        iter, Iter,
-        repeat, Repeat,
-        repeat_with,RepeatWith,
-        empty, Empty,
-        pending, Pending,
-        once, Once,
-        poll_fn, PollFn,
-        select, Select,
-        unfold, Unfold,
-        try_unfold, TryUnfold,
-
-        StreamExt,
-        Chain, Collect, Concat, Cycle, Enumerate, Filter, FilterMap, FlatMap, Flatten,
-        Fold, Forward, ForEach, Fuse, StreamFuture, Inspect, Map, Next,
-        SelectNextSome, Peek, Peekable, Scan, Skip, SkipWhile, Take, TakeUntil,
-        TakeWhile, Then, Unzip, Zip,
-
-        TryStreamExt,
-        AndThen, ErrInto, MapOk, MapErr, OrElse,
-        InspectOk, InspectErr,
-        TryNext, TryForEach, TryFilter, TryFilterMap, TryFlatten,
-        TryCollect, TryConcat, TryFold, TrySkipWhile, TryTakeWhile,
-        IntoStream,
-    };
-
-    #[cfg(feature = "alloc")]
-    pub use futures_util::stream::{
-        // For StreamExt:
-        Chunks, ReadyChunks,
-    };
-
-    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-    #[cfg(feature = "alloc")]
-    pub use futures_util::stream::{
-        FuturesOrdered,
-        futures_unordered, FuturesUnordered,
-
-        // For StreamExt:
-        BufferUnordered, Buffered, ForEachConcurrent, SplitStream, SplitSink,
-        ReuniteError,
-
-        select_all, SelectAll,
-    };
-
-    #[cfg(feature = "std")]
-    pub use futures_util::stream::{
-        // For StreamExt:
-        CatchUnwind,
-    };
-
-    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-    #[cfg(feature = "alloc")]
-    pub use futures_util::stream::{
-        // For TryStreamExt:
-        TryBufferUnordered, TryBuffered, TryForEachConcurrent,
-    };
-
-    #[cfg(feature = "std")]
-    pub use futures_util::stream::IntoAsyncRead;
-}
-
-pub mod task {
-    //! Tools for working with tasks.
-    //!
-    //! This module contains:
-    //!
-    //! - [`Spawn`](crate::task::Spawn), a trait for spawning new tasks.
-    //! - [`Context`](crate::task::Context), a context of an asynchronous task,
-    //!   including a handle for waking up the task.
-    //! - [`Waker`](crate::task::Waker), a handle for waking up a task.
-    //!
-    //! The remaining types and traits in the module are used for implementing
-    //! executors or dealing with synchronization issues around task wakeup.
-
-    pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
-
-    pub use futures_task::{
-        Spawn, LocalSpawn, SpawnError,
-        FutureObj, LocalFutureObj, UnsafeFutureObj,
-    };
-
-    pub use futures_util::task::noop_waker;
-
-    #[cfg(feature = "std")]
-    pub use futures_util::task::noop_waker_ref;
-
-    #[cfg(feature = "alloc")]
-    pub use futures_util::task::{SpawnExt, LocalSpawnExt};
-
-    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-    #[cfg(feature = "alloc")]
-    pub use futures_util::task::{waker, waker_ref, WakerRef, ArcWake};
-
-    #[cfg_attr(feature = "cfg-target-has-atomic", cfg(target_has_atomic = "ptr"))]
-    pub use futures_util::task::AtomicWaker;
-}
-
-pub mod never {
-    //! This module contains the `Never` type.
-    //!
-    //! Values of this type can never be created and will never exist.
-
-    pub use futures_util::never::Never;
 }


### PR DESCRIPTION
This is the fundamental solution to the "missing re-export" issues that sometimes happen (e.g., #2275, #2235, #1814). 

Also, document unification by this patch is useful when doing #2295.