### PR TITLE
Run sanitizers on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
       matrix:
         sanitizer:
           - address
+          - memory
           - thread
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,26 @@ jobs:
             --workspace --exclude futures-test \
             --features unstable --ignore-unknown-features
 
+  san:
+    name: cargo test -Z sanitizer=${{ matrix.sanitizer }}
+    strategy:
+      matrix:
+        sanitizer:
+          - address
+          - thread
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update nightly && rustup default nightly
+      - run: rustup component add rust-src
+      - run: cargo -Z build-std test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests
+        env:
+          # TODO: Once `cfg(sanitize = "..")` is stable, replace
+          # `cfg(futures_sanitizer)` with `cfg(sanitize = "..")` and remove
+          # `--cfg futures_sanitizer`.
+          RUSTFLAGS: -D warnings -Z sanitizer=${{ matrix.sanitizer }} --cfg futures_sanitizer
+
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest

--- a/futures/tests/recurse.rs
+++ b/futures/tests/recurse.rs
@@ -5,6 +5,11 @@ fn lots() {
     use std::sync::mpsc;
     use std::thread;
 
+    #[cfg(not(futures_sanitizer))]
+    const N: i32 = 1_000;
+    #[cfg(futures_sanitizer)] // If N is many, asan reports stack-overflow: https://gist.github.com/taiki-e/099446d21cbec69d4acbacf7a9646136
+    const N: i32 = 100;
+
     fn do_it(input: (i32, i32)) -> BoxFuture<'static, i32> {
         let (n, x) = input;
         if n == 0 {
@@ -16,7 +21,7 @@ fn lots() {
 
     let (tx, rx) = mpsc::channel();
     thread::spawn(|| {
-        block_on(do_it((1_000, 0)).map(move |x| tx.send(x).unwrap()))
+        block_on(do_it((N, 0)).map(move |x| tx.send(x).unwrap()))
     });
-    assert_eq!(500_500, rx.recv().unwrap());
+    assert_eq!((0..=N).sum::<i32>(), rx.recv().unwrap());
 }


### PR DESCRIPTION
This adds asan/msan/tsan tests to CI.

Closes #1319

Refs: 
- https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html
- https://github.com/google/sanitizers/wiki