### PR TITLE
Remove version from path dev-dependencies to make it easier to publish

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -28,8 +28,8 @@ futures-core = { path = "../futures-core", version = "0.3.8", default-features =
 futures-sink = { path = "../futures-sink", version = "0.3.8", default-features = false, optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.8", default-features = true }
-futures-test = { path = "../futures-test", version = "0.3.8", default-features = true }
+futures = { path = "../futures", default-features = true }
+futures-test = { path = "../futures-test", default-features = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -25,7 +25,7 @@ cfg-target-has-atomic = []
 [dependencies]
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.8" }
+futures = { path = "../futures" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -23,7 +23,7 @@ futures-util = { path = "../futures-util", version = "0.3.8", default-features =
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.8" }
+futures = { path = "../futures" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -26,7 +26,7 @@ cfg-target-has-atomic = []
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.8" }
+futures = { path = "../futures" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = { version = "1.3.1", default-features = false, features = ["std"], o
 pin-project = "1.0.1"
 
 [dev-dependencies]
-futures = { version = "0.3.8", path = "../futures", default-features = false, features = ["std", "executor"] }
+futures = { path = "../futures", default-features = false, features = ["std", "executor"] }
 
 [features]
 default = ["std"]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -49,8 +49,8 @@ pin-utils = "0.1.0"
 pin-project-lite = "0.2"
 
 [dev-dependencies]
-futures = { path = "../futures", version = "0.3.8", features = ["async-await", "thread-pool"] }
-futures-test = { path = "../futures-test", version = "0.3.8" }
+futures = { path = "../futures", features = ["async-await", "thread-pool"] }
+futures-test = { path = "../futures-test" }
 tokio = "0.1.11"
 
 [package.metadata.docs.rs]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -26,8 +26,8 @@ futures-util = { path = "../futures-util", version = "0.3.8", default-features =
 
 [dev-dependencies]
 pin-utils = "0.1.0"
-futures-executor = { path = "../futures-executor", version = "0.3.8", features = ["thread-pool"] }
-futures-test = { path = "../futures-test", version = "0.3.8" }
+futures-executor = { path = "../futures-executor", features = ["thread-pool"] }
+futures-test = { path = "../futures-test" }
 tokio = "0.1.11"
 assert_matches = "1.3.0"
 pin-project = "1.0.1"


### PR DESCRIPTION
Since 1.40 (https://github.com/rust-lang/cargo/pull/7333), cargo will strip dev-dependencies that don't have a version.
This removes the need to manually strip dev-dependencies when publishing a crate that has circular dev-dependencies. (i.e., this works as a workaround of https://github.com/rust-lang/cargo/issues/4242) 
I recently confirmed in pin-project(-internal) that this works: https://github.com/taiki-e/pin-project/commit/8525d86823e87cd4eb1d3236c1122efbfdc03c05, https://crates.io/crates/pin-project-internal/1.0.3

FYI @cramertj @Nemo157 
FYI https://github.com/rust-lang/futures-rs/issues/2025