### PR TITLE
Release 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
+# 0.3.9 - 2021-01-08
+* Significantly improved compile time when `async-await` crate feature is disabled (#2273)
+* Added `stream::repeat_with` (#2279)
+* Added `StreamExt::unzip` (#2263)
+* Added `sink::unfold` (#2268)
+* Added `SinkExt::feed` (#2155)
+* Implemented `FusedFuture` for `oneshot::Receiver` (#2300)
+* Implemented `Clone` for `sink::With` (#2290)
+* Re-exported `MapOkOrElse`, `MapInto`, `OkInto`, `TryFlatten`, `WriteAllVectored` (#2275)
+
 # 0.3.8 - 2020-11-04
-* Switch proc-macros to use native `#[proc_macro]` at Rust 1.45+ (#2243)
-* Add `WeakShared` (#2169)
-* Add `TryStreamExt::try_buffered` (#2245)
-* Add `StreamExt::cycle` (#2252)
+* Switched proc-macros to use native `#[proc_macro]` at Rust 1.45+ (#2243)
+* Added `WeakShared` (#2169)
+* Added `TryStreamExt::try_buffered` (#2245)
+* Added `StreamExt::cycle` (#2252)
 * Implemented `Clone` for `stream::{Empty, Pending, Repeat, Iter}` (#2248, #2252)
-* Fix panic in some `TryStreamExt` combinators (#2250)
+* Fixed panic in some `TryStreamExt` combinators (#2250)
 
 # 0.3.7 - 2020-10-23
 * Fixed unsoundness in `MappedMutexGuard` (#2240)

--- a/examples/functional/Cargo.toml
+++ b/examples/functional/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures-example-functional"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.8"
+documentation = "https://docs.rs/futures/0.3"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.8", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.9", features = ["thread-pool"] }

--- a/examples/imperative/Cargo.toml
+++ b/examples/imperative/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures-example-imperative"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.8"
+documentation = "https://docs.rs/futures/0.3"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.8", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.9", features = ["thread-pool"] }

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-channel"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-channel/0.3.8"
+documentation = "https://docs.rs/futures-channel/0.3"
 description = """
 Channels for asynchronous communication using futures-rs.
 """
@@ -24,8 +24,8 @@ unstable = ["futures-core/unstable"]
 cfg-target-has-atomic = ["futures-core/cfg-target-has-atomic"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.8", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.8", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-core"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-core/0.3.8"
+documentation = "https://docs.rs/futures-core/0.3"
 description = """
 The core traits and types in for the `futures` library.
 """

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-executor"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-executor/0.3.8"
+documentation = "https://docs.rs/futures-executor/0.3"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.8", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.8", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.8", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.9", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-io"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-io/0.3.8"
+documentation = "https://docs.rs/futures-io/0.3"
 description = """
 The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library.
 """

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-macro"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-macro/0.3.8"
+documentation = "https://docs.rs/futures-macro/0.3"
 description = """
 The futures-rs procedural macro implementations.
 """

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-sink"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-sink/0.3.8"
+documentation = "https://docs.rs/futures-sink/0.3"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-task"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-task/0.3.8"
+documentation = "https://docs.rs/futures-task/0.3"
 description = """
 Tools for working with tasks.
 """

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "futures-test"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-test/0.3.8"
+documentation = "https://docs.rs/futures-test/0.3"
 description = """
 Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.8", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.8", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.8", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.8", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.8", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.8", path = "../futures-sink", default-features = false }
+futures-core = { version = "0.3.9", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.9", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.9", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.9", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.9", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.9", path = "../futures-sink", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 pin-project = "1.0.1"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-util"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-util/0.3.8"
+documentation = "https://docs.rs/futures-util/0.3"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """
@@ -33,12 +33,12 @@ read-initializer = ["io", "futures-io/read-initializer", "futures-io/unstable"]
 write-all-vectored = ["io"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.8", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.8", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.8", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.8", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.8", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.8", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.9", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.9", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.9", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures"
 edition = "2018"
-version = "0.3.8"
+version = "0.3.9"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3.8"
+documentation = "https://docs.rs/futures/0.3"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.8", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.8", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.8", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.8", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.8", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.8", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.8", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.9", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.9", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.9", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.9", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 pin-utils = "0.1.0"


### PR DESCRIPTION
Changes:
* Significantly improved compile time when `async-await` crate feature is disabled (#2273)
* Added `stream::repeat_with` (#2279)
* Added `StreamExt::unzip` (#2263)
* Added `sink::unfold` (#2268)
* Added `SinkExt::feed` (#2155)
* Implemented `FusedFuture` for `oneshot::Receiver` (#2300)
* Implemented `Clone` for `sink::With` (#2290)
* Re-exported `MapOkOrElse`, `MapInto`, `OkInto`, `TryFlatten`, `WriteAllVectored` (#2275)