### PR TITLE
Fix type-inference in sink::unfold() by specifying more of its types

### DIFF
--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -35,7 +35,11 @@ pin_project! {
 /// unfold.send(5).await?;
 /// # Ok::<(), futures::never::Never>(()) }).unwrap();
 /// ```
-pub fn unfold<T, F, R>(init: T, function: F) -> Unfold<T, F, R> {
+pub fn unfold<T, F, R, Item, E>(init: T, function: F) -> Unfold<T, F, R>
+where
+    F: FnMut(T, Item) -> R,
+    R: Future<Output = Result<T, E>>,
+{
     Unfold {
         function,
         state: UnfoldState::Value { value: init },


### PR DESCRIPTION
This is an API change, at least if
  1. Any code uses different types for the existing type parameters, in which case the `Sink` impl was not available
  2. Any code specifies the type parameters (their number changed)

Without this it's impossible to use a "unnameable" type for the state, which happened to me unfortunately.

```rust
pub fn async_write<W: AsyncWrite + Unpin + Send>(
    write: W,
) -> impl Sink<Message>, Error = std::io::Error> + Send {
    struct State<W> {
        write: W,
        buffer: Vec<u8>,
    }

    let state = State {
        write,
        buffer: Vec::with_capacity(8192),
    };

    sink::unfold(state, |mut state, item: Message| {
        async move {
            state.buffer.clear();
            item.write(&mut state.buffer).expect("can't fail");

            match state.write.write_all(&state.buffer).await {
                Ok(_) => {
                    Ok(state)
                }
                Err(err) => {
                    Err(err)
                }
            }
        }
    })
}
```

Without the changes from this PR this fails with

```
error[E0282]: type annotations needed
   --> src/utils.rs:175:35
    |
175 |     futures::sink::unfold(state, |mut state, item: Message| {
    |                                   ^^^^^^^^^ consider giving this closure parameter a type
    |
    = note: type must be known at this point
```

Specifying it as `state: State<_>` is not sufficient and the actual type can't be named in this context.

With my changes it works as expected.