### PR TITLE
Release 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.10 - 2021-01-12
+* Fixed type-inference in `sink::unfold` by specifying more of its types (breaking change -- see #2311)
+
 # 0.3.9 - 2021-01-08
 * Significantly improved compile time when `async-await` crate feature is disabled (#2273)
 * Added `stream::repeat_with` (#2279)

--- a/examples/functional/Cargo.toml
+++ b/examples/functional/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-example-functional"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.9", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.10", features = ["thread-pool"] }

--- a/examples/imperative/Cargo.toml
+++ b/examples/imperative/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-example-imperative"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -17,4 +17,4 @@ categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.9", features = ["thread-pool"] }
+futures = { path = "../../futures", version = "0.3.10", features = ["thread-pool"] }

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-channel"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -24,8 +24,8 @@ unstable = ["futures-core/unstable"]
 cfg-target-has-atomic = ["futures-core/cfg-target-has-atomic"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.10", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.10", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-core"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-executor"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.9", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.10", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.10", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.10", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-io"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-macro"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-sink"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-task"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-test"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -12,12 +12,12 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.9", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.9", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.9", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.9", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.9", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.9", path = "../futures-sink", default-features = false }
+futures-core = { version = "0.3.10", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.10", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.10", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.10", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.10", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.10", path = "../futures-sink", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 pin-project = "1.0.1"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-util"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -33,12 +33,12 @@ read-initializer = ["io", "futures-io/read-initializer", "futures-io/unstable"]
 write-all-vectored = ["io"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.9", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.9", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.9", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.10", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.10", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.10", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.10", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.10", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.10", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures"
 edition = "2018"
-version = "0.3.9"
+version = "0.3.10"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.9", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.9", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.9", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.9", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.9", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.9", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.9", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.10", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.10", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.10", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.10", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.10", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.10", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.10", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 pin-utils = "0.1.0"


### PR DESCRIPTION
Changes:
* Fixed type-inference in `sink::unfold` by specifying more of its types (breaking change -- see #2311)
