### PR TITLE
Remove unneeded fields from examples/*/Cargo.toml

### DIFF
--- a/examples/functional/Cargo.toml
+++ b/examples/functional/Cargo.toml
@@ -1,20 +1,9 @@
 [package]
 name = "futures-example-functional"
 edition = "2018"
-version = "0.3.11"
+version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT OR Apache-2.0"
-readme = "../README.md"
-keywords = ["futures", "async", "future"]
-repository = "https://github.com/rust-lang/futures-rs"
-homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3"
-description = """
-An implementation of futures and streams featuring zero allocations,
-composability, and iterator-like interfaces.
-"""
-categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.11", features = ["thread-pool"] }
+futures = { path = "../../futures", features = ["thread-pool"] }

--- a/examples/imperative/Cargo.toml
+++ b/examples/imperative/Cargo.toml
@@ -1,20 +1,9 @@
 [package]
 name = "futures-example-imperative"
 edition = "2018"
-version = "0.3.11"
+version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-license = "MIT OR Apache-2.0"
-readme = "../README.md"
-keywords = ["futures", "async", "future"]
-repository = "https://github.com/rust-lang/futures-rs"
-homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3"
-description = """
-An implementation of futures and streams featuring zero allocations,
-composability, and iterator-like interfaces.
-"""
-categories = ["asynchronous"]
 publish = false
 
 [dependencies]
-futures = { path = "../../futures", version = "0.3.11", features = ["thread-pool"] }
+futures = { path = "../../futures", features = ["thread-pool"] }


### PR DESCRIPTION
These fields are of little use in `publish = false` crates where they are not intended to upload to crates.io, e.g., examples.
Also, the current one is a copy of `futures` crate, and does not provide any additional information.