### PR TITLE
Use assert_* functions for all future/stream/sink/io combinators

### DIFF
--- a/futures-util/src/future/abortable.rs
+++ b/futures-util/src/future/abortable.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use crate::task::AtomicWaker;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
@@ -39,10 +40,10 @@ impl<Fut> Abortable<Fut> where Fut: Future {
     /// # });
     /// ```
     pub fn new(future: Fut, reg: AbortRegistration) -> Self {
-        Self {
+        assert_future::<Result<Fut::Output, Aborted>, _>(Self {
             future,
             inner: reg.inner,
-        }
+        })
     }
 }
 

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -7,10 +7,10 @@
 use alloc::boxed::Box;
 use core::pin::Pin;
 
-use crate::future::{assert_future, Either};
-use crate::stream::assert_stream;
 use crate::fns::{inspect_fn, into_fn, ok_fn, InspectFn, IntoFn, OkFn};
+use crate::future::{assert_future, Either};
 use crate::never::Never;
+use crate::stream::assert_stream;
 #[cfg(feature = "alloc")]
 use futures_core::future::{BoxFuture, LocalBoxFuture};
 use futures_core::{
@@ -506,7 +506,8 @@ pub trait FutureExt: Future {
     where
         Self: Sized,
     {
-        remote_handle::remote_handle(self)
+        let (wrapped, handle) = remote_handle::remote_handle(self);
+        (assert_future::<(), _>(wrapped), handle)
     }
 
     /// Wrap the future in a Box, pinning it.

--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -1,13 +1,12 @@
 #![allow(non_snake_case)]
 
-use crate::future::{MaybeDone, maybe_done};
+use super::assert_future;
+use crate::future::{maybe_done, MaybeDone};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
-
-use super::assert_future;
 
 macro_rules! generate {
     ($(
@@ -144,7 +143,8 @@ where
     Fut2: Future,
     Fut3: Future,
 {
-    Join3::new(future1, future2, future3)
+    let f = Join3::new(future1, future2, future3);
+    assert_future::<(Fut1::Output, Fut2::Output, Fut3::Output), _>(f)
 }
 
 /// Same as [`join`](join()), but with more futures.
@@ -176,7 +176,8 @@ where
     Fut3: Future,
     Fut4: Future,
 {
-    Join4::new(future1, future2, future3, future4)
+    let f = Join4::new(future1, future2, future3, future4);
+    assert_future::<(Fut1::Output, Fut2::Output, Fut3::Output, Fut4::Output), _>(f)
 }
 
 /// Same as [`join`](join()), but with more futures.
@@ -211,5 +212,15 @@ where
     Fut4: Future,
     Fut5: Future,
 {
-    Join5::new(future1, future2, future3, future4, future5)
+    let f = Join5::new(future1, future2, future3, future4, future5);
+    assert_future::<
+        (
+            Fut1::Output,
+            Fut2::Output,
+            Fut3::Output,
+            Fut4::Output,
+            Fut5::Output,
+        ),
+        _,
+    >(f)
 }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -10,7 +10,7 @@ use core::task::{Context, Poll};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use super::MaybeDone;
+use super::{MaybeDone, assert_future};
 
 fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
@@ -85,7 +85,7 @@ where
     I::Item: Future,
 {
     let elems: Box<[_]> = i.into_iter().map(MaybeDone::Future).collect();
-    JoinAll { elems: elems.into() }
+    assert_future::<Vec<<I::Item as Future>::Output>, _>(JoinAll { elems: elems.into() })
 }
 
 impl<F> Future for JoinAll<F>

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
@@ -34,7 +35,7 @@ impl<F> Unpin for Lazy<F> {}
 pub fn lazy<F, R>(f: F) -> Lazy<F>
     where F: FnOnce(&mut Context<'_>) -> R,
 {
-    Lazy { f: Some(f) }
+    assert_future::<R, _>(Lazy { f: Some(f) })
 }
 
 impl<F, R> FusedFuture for Lazy<F>

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -1,5 +1,6 @@
 //! Definition of the MaybeDone combinator
 
+use super::assert_future;
 use core::mem;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
@@ -40,7 +41,7 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 /// # });
 /// ```
 pub fn maybe_done<Fut: Future>(future: Fut) -> MaybeDone<Fut> {
-    MaybeDone::Future(future)
+    assert_future::<(), _>(MaybeDone::Future(future))
 }
 
 impl<Fut: Future> MaybeDone<Fut> {

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use core::marker;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
@@ -33,9 +34,9 @@ impl<T> FusedFuture for Pending<T> {
 /// # });
 /// ```
 pub fn pending<T>() -> Pending<T> {
-    Pending {
+    assert_future::<T, _>(Pending {
         _data: marker::PhantomData,
-    }
+    })
 }
 
 impl<T> Future for Pending<T> {

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,5 +1,6 @@
 //! Definition of the `PollFn` adapter combinator
 
+use super::assert_future;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
@@ -36,7 +37,7 @@ pub fn poll_fn<T, F>(f: F) -> PollFn<F>
 where
     F: FnMut(&mut Context<'_>) -> Poll<T>
 {
-    PollFn { f }
+    assert_future::<T, _>(PollFn { f })
 }
 
 impl<F> fmt::Debug for PollFn<F> {

--- a/futures-util/src/future/ready.rs
+++ b/futures-util/src/future/ready.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
@@ -45,7 +46,7 @@ impl<T> Future for Ready<T> {
 /// # });
 /// ```
 pub fn ready<T>(t: T) -> Ready<T> {
-    Ready(Some(t))
+    assert_future::<T, _>(Ready(Some(t)))
 }
 
 /// Create a future that is immediately ready with a success value.

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use core::pin::Pin;
 use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{Context, Poll};
@@ -75,7 +76,7 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 pub fn select<A, B>(future1: A, future2: B) -> Select<A, B>
     where A: Future + Unpin, B: Future + Unpin
 {
-    Select { inner: Some((future1, future2)) }
+    assert_future::<Either<(A::Output, B), (B::Output, A)>, _>(Select { inner: Some((future1, future2)) })
 }
 
 impl<A, B> Future for Select<A, B>

--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use crate::future::FutureExt;
 use core::iter::FromIterator;
 use core::mem;
@@ -38,7 +39,7 @@ pub fn select_all<I>(iter: I) -> SelectAll<I::Item>
         inner: iter.into_iter().collect()
     };
     assert!(!ret.inner.is_empty());
-    ret
+    assert_future::<(<I::Item as Future>::Output, usize, Vec<I::Item>), _>(ret)
 }
 
 impl<Fut: Future + Unpin> Future for SelectAll<Fut> {

--- a/futures-util/src/future/select_ok.rs
+++ b/futures-util/src/future/select_ok.rs
@@ -1,3 +1,4 @@
+use super::assert_future;
 use crate::future::TryFutureExt;
 use core::iter::FromIterator;
 use core::mem;
@@ -36,7 +37,7 @@ pub fn select_ok<I>(iter: I) -> SelectOk<I::Item>
         inner: iter.into_iter().collect()
     };
     assert!(!ret.inner.is_empty(), "iterator provided to select_ok was empty");
-    ret
+    assert_future::<Result<(<I::Item as TryFuture>::Ok, Vec<I::Item>), <I::Item as TryFuture>::Error>, _>(ret)
 }
 
 impl<Fut: TryFuture + Unpin> Future for SelectOk<Fut> {

--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -173,7 +173,7 @@ pub trait TryFutureExt: TryFuture {
         Self::Ok: Sink<Item, Error = Self::Error>,
         Self: Sized,
     {
-        FlattenSink::new(self)
+        crate::sink::assert_sink::<Item, Self::Error, _>(FlattenSink::new(self))
     }
 
     /// Maps this future's success value to a different value.
@@ -501,7 +501,7 @@ pub trait TryFutureExt: TryFuture {
         Self::Ok: TryFuture<Error = Self::Error>,
         Self: Sized,
     {
-        TryFlatten::new(self)
+        assert_future::<Result<<Self::Ok as TryFuture>::Ok, Self::Error>, _>(TryFlatten::new(self))
     }
 
     /// Flatten the execution of this future when the successful result of this

--- a/futures-util/src/future/try_join.rs
+++ b/futures-util/src/future/try_join.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use crate::future::{TryMaybeDone, try_maybe_done};
+use crate::future::{assert_future, try_maybe_done, TryMaybeDone};
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
@@ -150,7 +150,7 @@ where
     Fut1: TryFuture,
     Fut2: TryFuture<Error = Fut1::Error>,
 {
-    TryJoin::new(future1, future2)
+    assert_future::<Result<(Fut1::Ok, Fut2::Ok), Fut1::Error>, _>(TryJoin::new(future1, future2))
 }
 
 /// Same as [`try_join`](try_join()), but with more futures.
@@ -179,7 +179,9 @@ where
     Fut2: TryFuture<Error = Fut1::Error>,
     Fut3: TryFuture<Error = Fut1::Error>,
 {
-    TryJoin3::new(future1, future2, future3)
+    assert_future::<Result<(Fut1::Ok, Fut2::Ok, Fut3::Ok), Fut1::Error>, _>(TryJoin3::new(
+        future1, future2, future3,
+    ))
 }
 
 /// Same as [`try_join`](try_join()), but with more futures.
@@ -211,7 +213,9 @@ where
     Fut3: TryFuture<Error = Fut1::Error>,
     Fut4: TryFuture<Error = Fut1::Error>,
 {
-    TryJoin4::new(future1, future2, future3, future4)
+    assert_future::<Result<(Fut1::Ok, Fut2::Ok, Fut3::Ok, Fut4::Ok), Fut1::Error>, _>(
+        TryJoin4::new(future1, future2, future3, future4),
+    )
 }
 
 /// Same as [`try_join`](try_join()), but with more futures.
@@ -246,5 +250,7 @@ where
     Fut4: TryFuture<Error = Fut1::Error>,
     Fut5: TryFuture<Error = Fut1::Error>,
 {
-    TryJoin5::new(future1, future2, future3, future4, future5)
+    assert_future::<Result<(Fut1::Ok, Fut2::Ok, Fut3::Ok, Fut4::Ok, Fut5::Ok), Fut1::Error>, _>(
+        TryJoin5::new(future1, future2, future3, future4, future5),
+    )
 }

--- a/futures-util/src/future/try_join_all.rs
+++ b/futures-util/src/future/try_join_all.rs
@@ -10,7 +10,7 @@ use core::task::{Context, Poll};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use super::{TryFuture, TryMaybeDone};
+use super::{assert_future, TryFuture, TryMaybeDone};
 
 fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
@@ -93,9 +93,9 @@ where
     I::Item: TryFuture,
 {
     let elems: Box<[_]> = i.into_iter().map(TryMaybeDone::Future).collect();
-    TryJoinAll {
+    assert_future::<Result<Vec<<I::Item as TryFuture>::Ok>, <I::Item as TryFuture>::Error>, _>(TryJoinAll {
         elems: elems.into(),
-    }
+    })
 }
 
 impl<F> Future for TryJoinAll<F>

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -1,5 +1,6 @@
 //! Definition of the TryMaybeDone combinator
 
+use super::assert_future;
 use core::mem;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
@@ -25,7 +26,7 @@ impl<Fut: TryFuture + Unpin> Unpin for TryMaybeDone<Fut> {}
 
 /// Wraps a future into a `TryMaybeDone`
 pub fn try_maybe_done<Fut: TryFuture>(future: Fut) -> TryMaybeDone<Fut> {
-    TryMaybeDone::Future(future)
+    assert_future::<Result<(), Fut::Error>, _>(TryMaybeDone::Future(future))
 }
 
 impl<Fut: TryFuture> TryMaybeDone<Fut> {

--- a/futures-util/src/future/try_select.rs
+++ b/futures-util/src/future/try_select.rs
@@ -50,7 +50,10 @@ impl<A: Unpin, B: Unpin> Unpin for TrySelect<A, B> {}
 pub fn try_select<A, B>(future1: A, future2: B) -> TrySelect<A, B>
     where A: TryFuture + Unpin, B: TryFuture + Unpin
 {
-    TrySelect { inner: Some((future1, future2)) }
+    super::assert_future::<Result<
+        Either<(A::Ok, B), (B::Ok, A)>,
+        Either<(A::Error, B), (B::Error, A)>,
+    >, _>(TrySelect { inner: Some((future1, future2)) })
 }
 
 impl<A: Unpin, B: Unpin> Future for TrySelect<A, B>

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -1,3 +1,4 @@
+use super::assert_sink;
 use crate::never::Never;
 use core::marker::PhantomData;
 use core::pin::Pin;
@@ -26,7 +27,7 @@ pub struct Drain<T> {
 /// # Ok::<(), futures::never::Never>(()) }).unwrap();
 /// ```
 pub fn drain<T>() -> Drain<T> {
-    Drain { marker: PhantomData }
+    assert_sink::<T, Never, _>(Drain { marker: PhantomData })
 }
 
 impl<T> Unpin for Drain<T> {}

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -6,7 +6,7 @@
 //! - The [`SinkExt`] trait, which provides adapters for chaining and composing
 //!   sinks.
 
-use crate::future::Either;
+use crate::future::{assert_future, Either};
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::stream::{Stream, TryStream};
@@ -81,7 +81,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         E: From<Self::Error>,
         Self: Sized,
     {
-        With::new(self, f)
+        assert_sink::<U, E, _>(With::new(self, f))
     }
 
     /// Composes a function *in front of* the sink.
@@ -122,7 +122,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         St: Stream<Item = Result<Item, Self::Error>>,
         Self: Sized,
     {
-        WithFlatMap::new(self, f)
+        assert_sink::<U, Self::Error, _>(WithFlatMap::new(self, f))
     }
 
     /*
@@ -145,7 +145,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         F: FnOnce(Self::Error) -> E,
         Self: Sized,
     {
-        SinkMapErr::new(self, f)
+        assert_sink::<Item, E, _>(SinkMapErr::new(self, f))
     }
 
     /// Map this sink's error to a different error type using the `Into` trait.
@@ -156,7 +156,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         Self: Sized,
         Self::Error: Into<E>,
     {
-        SinkErrInto::new(self)
+        assert_sink::<Item, E, _>(SinkErrInto::new(self))
     }
 
     /// Adds a fixed-size buffer to the current sink.
@@ -176,7 +176,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     where
         Self: Sized,
     {
-        Buffer::new(self, capacity)
+        assert_sink::<Item, Self::Error, _>(Buffer::new(self, capacity))
     }
 
     /// Close the sink.
@@ -184,7 +184,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     where
         Self: Unpin,
     {
-        Close::new(self)
+        assert_future::<Result<(), Self::Error>, _>(Close::new(self))
     }
 
     /// Fanout items to multiple sinks.
@@ -197,7 +197,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         Item: Clone,
         Si: Sink<Item, Error = Self::Error>,
     {
-        Fanout::new(self, other)
+        assert_sink::<Item, Self::Error, _>(Fanout::new(self, other))
     }
 
     /// Flush the sink, processing all pending items.
@@ -208,7 +208,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     where
         Self: Unpin,
     {
-        Flush::new(self)
+        assert_future::<Result<(), Self::Error>, _>(Flush::new(self))
     }
 
     /// A future that completes after the given item has been fully processed
@@ -221,7 +221,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     where
         Self: Unpin,
     {
-        Send::new(self, item)
+        assert_future::<Result<(), Self::Error>, _>(Send::new(self, item))
     }
 
     /// A future that completes after the given item has been received
@@ -231,9 +231,10 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// It is the caller's responsibility to ensure all pending items
     /// are processed, which can be done via `flush` or `close`.
     fn feed(&mut self, item: Item) -> Feed<'_, Self, Item>
-        where Self: Unpin,
+    where
+        Self: Unpin,
     {
-        Feed::new(self, item)
+        assert_future::<Result<(), Self::Error>, _>(Feed::new(self, item))
     }
 
     /// A future that completes after the given stream has been fully processed
@@ -250,8 +251,11 @@ pub trait SinkExt<Item>: Sink<Item> {
     fn send_all<'a, St>(&'a mut self, stream: &'a mut St) -> SendAll<'a, Self, St>
     where
         St: TryStream<Ok = Item, Error = Self::Error> + Stream + Unpin + ?Sized,
+        // St: Stream<Item = Result<Item, Self::Error>> + Unpin + ?Sized,
         Self: Unpin,
     {
+        // TODO: type mismatch resolving `<St as Stream>::Item == std::result::Result<Item, <Self as futures_sink::Sink<Item>>::Error>`
+        // assert_future::<Result<(), Self::Error>, _>(SendAll::new(self, stream))
         SendAll::new(self, stream)
     }
 
@@ -265,7 +269,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         Si2: Sink<Item, Error = Self::Error>,
         Self: Sized,
     {
-        Either::Left(self)
+        assert_sink::<Item, Self::Error, _>(Either::Left(self))
     }
 
     /// Wrap this stream in an `Either` stream, making it the right-hand variant
@@ -278,7 +282,7 @@ pub trait SinkExt<Item>: Sink<Item> {
         Si1: Sink<Item, Error = Self::Error>,
         Self: Sized,
     {
-        Either::Right(self)
+        assert_sink::<Item, Self::Error, _>(Either::Right(self))
     }
 
     /// Wraps a [`Sink`] into a sink compatible with libraries using
@@ -327,4 +331,13 @@ pub trait SinkExt<Item>: Sink<Item> {
     {
         Pin::new(self).poll_close(cx)
     }
+}
+
+// Just a helper function to ensure the sinks we're returning all have the
+// right implementations.
+pub(crate) fn assert_sink<T, E, S>(sink: S) -> S
+where
+    S: Sink<T, Error = E>,
+{
+    sink
 }

--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -1,3 +1,4 @@
+use super::assert_sink;
 use crate::unfold_state::UnfoldState;
 use core::{future::Future, pin::Pin};
 use futures_core::ready;
@@ -40,10 +41,10 @@ where
     F: FnMut(T, Item) -> R,
     R: Future<Output = Result<T, E>>,
 {
-    Unfold {
+    assert_sink::<Item, E, _>(Unfold {
         function,
         state: UnfoldState::Value { value: init },
-    }
+    })
 }
 
 impl<T, F, R, Item, E> Sink<Item> for Unfold<T, F, R>

--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
@@ -14,9 +15,9 @@ pub struct Empty<T> {
 ///
 /// The returned stream will always return `Ready(None)` when polled.
 pub fn empty<T>() -> Empty<T> {
-    Empty {
+    assert_stream::<T, _>(Empty {
         _phantom: PhantomData
-    }
+    })
 }
 
 impl<T> Unpin for Empty<T> {}

--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::pin::Pin;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
@@ -28,9 +29,9 @@ impl<I> Unpin for Iter<I> {}
 pub fn iter<I>(i: I) -> Iter<I::IntoIter>
     where I: IntoIterator,
 {
-    Iter {
+    assert_stream::<I::Item, _>(Iter {
         iter: i.into_iter(),
-    }
+    })
 }
 
 impl<I> Stream for Iter<I>

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -109,11 +109,11 @@ cfg_target_has_atomic! {
     pub use self::select_all::{select_all, SelectAll};
 }
 
-// Just a helper function to ensure the futures we're returning all have the
+// Just a helper function to ensure the streams we're returning all have the
 // right implementations.
 pub(crate) fn assert_stream<T, S>(stream: S) -> S
-    where
-        S: Stream<Item = T>,
+where
+    S: Stream<Item = T>,
 {
     stream
 }

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
@@ -17,7 +18,7 @@ use pin_project_lite::pin_project;
 /// # });
 /// ```
 pub fn once<Fut: Future>(future: Fut) -> Once<Fut> {
-    Once::new(future)
+    assert_stream::<Fut::Output, _>(Once::new(future))
 }
 
 pin_project! {

--- a/futures-util/src/stream/pending.rs
+++ b/futures-util/src/stream/pending.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::marker;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
@@ -14,7 +15,7 @@ pub struct Pending<T> {
 ///
 /// The returned stream will always return `Pending` when polled.
 pub fn pending<T>() -> Pending<T> {
-    Pending { _data: marker::PhantomData }
+    assert_stream::<T, _>(Pending { _data: marker::PhantomData })
 }
 
 impl<T> Unpin for Pending<T> {}

--- a/futures-util/src/stream/poll_fn.rs
+++ b/futures-util/src/stream/poll_fn.rs
@@ -1,5 +1,6 @@
 //! Definition of the `PollFn` combinator
 
+use super::assert_stream;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::stream::Stream;
@@ -41,7 +42,7 @@ pub fn poll_fn<T, F>(f: F) -> PollFn<F>
 where
     F: FnMut(&mut Context<'_>) -> Poll<Option<T>>,
 {
-    PollFn { f }
+    assert_stream::<T, _>(PollFn { f })
 }
 
 impl<T, F> Stream for PollFn<F>

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::pin::Pin;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
@@ -26,7 +27,7 @@ pub struct Repeat<T> {
 pub fn repeat<T>(item: T) -> Repeat<T>
     where T: Clone
 {
-    Repeat { item }
+    assert_stream::<T, _>(Repeat { item })
 }
 
 impl<T> Unpin for Repeat<T> {}

--- a/futures-util/src/stream/repeat_with.rs
+++ b/futures-util/src/stream/repeat_with.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::pin::Pin;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
@@ -89,5 +90,5 @@ impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F>
 /// # });
 /// ```
 pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
-    RepeatWith { repeater }
+    assert_stream::<A, _>(RepeatWith { repeater })
 }

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use crate::stream::{StreamExt, Fuse};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
@@ -31,11 +32,11 @@ pub fn select<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2>
     where St1: Stream,
           St2: Stream<Item = St1::Item>
 {
-    Select {
+    assert_stream::<St1::Item, _>(Select {
         stream1: stream1.fuse(),
         stream2: stream2.fuse(),
         flag: false,
-    }
+    })
 }
 
 impl<St1, St2> Select<St1, St2> {

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -8,6 +8,7 @@ use futures_core::ready;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
 
+use super::assert_stream;
 use crate::stream::{StreamExt, StreamFuture, FuturesUnordered};
 
 /// An unbounded set of streams
@@ -124,7 +125,7 @@ pub fn select_all<I>(streams: I) -> SelectAll<I::Item>
         set.push(stream);
     }
 
-    set
+    assert_stream::<<I::Item as Stream>::Item, _>(set)
 }
 
 impl<St: Stream + Unpin> FromIterator<St> for SelectAll<St> {

--- a/futures-util/src/stream/try_stream/try_unfold.rs
+++ b/futures-util/src/stream/try_stream/try_unfold.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
@@ -60,11 +61,11 @@ where
     F: FnMut(T) -> Fut,
     Fut: TryFuture<Ok = Option<(Item, T)>>,
 {
-    TryUnfold {
+    assert_stream::<Result<Item, Fut::Error>, _>(TryUnfold {
         f,
         state: Some(init),
         fut: None,
-    }
+    })
 }
 
 pin_project! {

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -1,3 +1,4 @@
+use super::assert_stream;
 use crate::unfold_state::UnfoldState;
 use core::fmt;
 use core::pin::Pin;
@@ -51,10 +52,10 @@ where
     F: FnMut(T) -> Fut,
     Fut: Future<Output = Option<(Item, T)>>,
 {
-    Unfold {
+    assert_stream::<Item, _>(Unfold {
         f,
         state: UnfoldState::Value { value: init },
-    }
+    })
 }
 
 pin_project! {


### PR DESCRIPTION
Measures to prevent recurrence of #2311.

Refs: #2020
Closes #2320