### PR TITLE
Use #[doc(no_inline)] on re-exports from core/std

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -4,6 +4,7 @@ use core::ops::DerefMut;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
+#[doc(no_inline)]
 pub use core::future::Future;
 
 /// An owned dynamically typed [`Future`] for use in cases where you can't

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -6,4 +6,5 @@ mod poll;
 #[doc(hidden)]
 pub mod __internal;
 
+#[doc(no_inline)]
 pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -33,19 +33,13 @@ mod if_std {
     // Re-export some types from `std::io` so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-    pub use io::{
-        Error as Error,
-        ErrorKind as ErrorKind,
-        Result as Result,
-        IoSlice as IoSlice,
-        IoSliceMut as IoSliceMut,
-        SeekFrom as SeekFrom,
-    };
-
+    #[doc(no_inline)]
+    pub use io::{Error, ErrorKind, Result, IoSlice, IoSliceMut, SeekFrom};
     #[cfg(feature = "read-initializer")]
     #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
+    #[doc(no_inline)]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-    pub use io::Initializer as Initializer;
+    pub use io::Initializer;
 
     /// Read bytes asynchronously.
     ///

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -51,4 +51,5 @@ pub use crate::noop_waker::noop_waker;
 #[cfg(feature = "std")]
 pub use crate::noop_waker::noop_waker_ref;
 
+#[doc(no_inline)]
 pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -9,9 +9,12 @@
 //!   from a closure that defines its return value, and [`ready`](ready()),
 //!   which constructs a future with an immediate defined value.
 
+#[doc(no_inline)]
+pub use core::future::Future;
+
 #[cfg(feature = "alloc")]
 pub use futures_core::future::{BoxFuture, LocalBoxFuture};
-pub use futures_core::future::{FusedFuture, Future, TryFuture};
+pub use futures_core::future::{FusedFuture, TryFuture};
 pub use futures_task::{FutureObj, LocalFutureObj, UnsafeFutureObj};
 
 // Extension traits and combinators

--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -23,13 +23,16 @@ use crate::future::assert_future;
 use crate::stream::assert_stream;
 use std::{ptr, pin::Pin};
 
-pub use futures_io::{
-    AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead, Error, ErrorKind,
-    IoSlice, IoSliceMut, Result, SeekFrom,
-};
+// Re-export some types from `std::io` so that users don't have to deal
+// with conflicts when `use`ing `futures::io` and `std::io`.
+#[doc(no_inline)]
+pub use std::io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
+#[doc(no_inline)]
 #[cfg(feature = "read-initializer")]
 #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
-pub use futures_io::Initializer;
+pub use std::io::Initializer;
+
+pub use futures_io::{AsyncRead, AsyncWrite, AsyncSeek, AsyncBufRead};
 
 // used by `BufReader` and `BufWriter`
 // https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/io.rs#L1

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -10,7 +10,8 @@
 //! The remaining types and traits in the module are used for implementing
 //! executors or dealing with synchronization issues around task wakeup.
 
-pub use futures_core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+#[doc(no_inline)]
+pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
 
 pub use futures_task::{
     Spawn, LocalSpawn, SpawnError,


### PR DESCRIPTION
Probably easier to understand.

See also https://github.com/rust-lang/futures-rs/issues/2113, https://github.com/tokio-rs/tokio/pull/2874, https://github.com/tokio-rs/tokio/issues/2873

before: https://docs.rs/futures-util/0.3.12/futures_util/io/index.html

after:
<img src="https://user-images.githubusercontent.com/43724913/104839742-6f7beb00-5906-11eb-96e5-e7765e9ae854.png" width="400px">

