### PR TITLE
Implement Stream::size_hint() for Either

### DIFF
--- a/futures-util/src/future/either.rs
+++ b/futures-util/src/future/either.rs
@@ -101,6 +101,13 @@ where
             Either::Right(x) => x.poll_next(cx),
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Either::Left(x) => x.size_hint(),
+            Either::Right(x) => x.size_hint(),
+        }
+    }
 }
 
 impl<A, B> FusedStream for Either<A, B>


### PR DESCRIPTION
`futures::future::Either` should delegate `futures::stream::Stream::size_hint()` to its left/right branches.  This was done automatically by the either crate in futures 0.2, but the functionality was lost in futures 0.3 when we implemented our own `Either` type.