### PR TITLE
Avoid once_cell in static wakers

### DIFF
--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -13,7 +13,7 @@ Tools for working with tasks.
 
 [features]
 default = ["std"]
-std = ["alloc", "once_cell"]
+std = ["alloc"]
 alloc = []
 
 # Unstable features
@@ -23,7 +23,6 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures" }

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -48,7 +48,6 @@ pub use crate::future_obj::{FutureObj, LocalFutureObj, UnsafeFutureObj};
 
 mod noop_waker;
 pub use crate::noop_waker::noop_waker;
-#[cfg(feature = "std")]
 pub use crate::noop_waker::noop_waker_ref;
 
 #[doc(no_inline)]

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -19,7 +19,6 @@ futures-util = { version = "0.3.12", path = "../futures-util", default-features 
 futures-executor = { version = "0.3.12", path = "../futures-executor", default-features = false }
 futures-sink = { version = "0.3.12", path = "../futures-sink", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
-once_cell = { version = "1.3.1", default-features = false, features = ["std"], optional = true }
 pin-project = "1.0.1"
 
 [dev-dependencies]
@@ -27,7 +26,7 @@ futures = { path = "../futures", default-features = false, features = ["std", "e
 
 [features]
 default = ["std"]
-std = ["futures-core/std", "futures-task/std", "futures-io/std", "futures-util/std", "futures-util/io", "futures-executor/std", "once_cell"]
+std = ["futures-core/std", "futures-task/std", "futures-io/std", "futures-util/std", "futures-util/io", "futures-executor/std"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
`Waker`s are `#[repr(transparent)]` over their inner `RawWakers`. Therefore, instead of using a `once_cell` to lazily initialize a `Waker` with `Waker::from_raw`, we can instead simply store a static `RawWaker` and then use pointer casts to obtain a `Waker`. This also removes the `once_cell` dependency.