### PR TITLE
FuturesUnordered: Do not poll the same future twice per iteration

### DIFF
--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -277,12 +277,13 @@ fn futures_not_moved_after_poll() {
     use futures::future;
     use futures::stream::FuturesUnordered;
     use futures_test::future::FutureTestExt;
-    use futures_test::{assert_stream_done, assert_stream_next};
+    use futures_test::{assert_stream_done, assert_stream_next, assert_stream_pending};
 
     // Future that will be ready after being polled twice,
     // asserting that it does not move.
     let fut = future::ready(()).pending_once().assert_unmoved();
     let mut stream = vec![fut; 3].into_iter().collect::<FuturesUnordered<_>>();
+    assert_stream_pending!(stream);
     assert_stream_next!(stream, ());
     assert_stream_next!(stream, ());
     assert_stream_next!(stream, ());


### PR DESCRIPTION
Instead of using a constant, use the length of FuturesUnordered to ensures that each future is polled only once at most per iteration. This does not solve the fundamental problem, but should be able to improve the current situation somewhat.

This fixes at least one of the problems reported in https://github.com/tokio-rs/tokio/issues/3493. See that issue for details of the bug.

r? @cramertj @jonhoo
cc #2053