### PR TITLE
Start futures 0.4 and futures-core 1.0 development

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-channel"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-channel/0.3"
+documentation = "https://docs.rs/futures-channel/0.4.0-alpha.0"
 description = """
 Channels for asynchronous communication using futures-rs.
 """
@@ -24,8 +24,8 @@ unstable = ["futures-core/unstable"]
 cfg-target-has-atomic = ["futures-core/cfg-target-has-atomic"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.13", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.13", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "=1.0.0-alpha.0", default-features = false }
+futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-core"
 edition = "2018"
-version = "0.3.13"
+version = "1.0.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-core/0.3"
+documentation = "https://docs.rs/futures-core/1.0.0-alpha.0"
 description = """
 The core traits and types in for the `futures` library.
 """

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-executor"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-executor/0.3"
+documentation = "https://docs.rs/futures-executor/0.4.0-alpha.0"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.13", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.13", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.13", default-features = false }
+futures-core = { path = "../futures-core", version = "=1.0.0-alpha.0", default-features = false }
+futures-task = { path = "../futures-task", version = "=0.4.0-alpha.0", default-features = false }
+futures-util = { path = "../futures-util", version = "=0.4.0-alpha.0", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-macro"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-macro/0.3"
+documentation = "https://docs.rs/futures-macro/0.4.0-alpha.0"
 description = """
 The futures-rs procedural macro implementations.
 """

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-sink"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-sink/0.3"
+documentation = "https://docs.rs/futures-sink/0.4.0-alpha.0"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-task"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-task/0.3"
+documentation = "https://docs.rs/futures-task/0.4.0-alpha.0"
 description = """
 Tools for working with tasks.
 """

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "futures-test"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-test/0.3"
+documentation = "https://docs.rs/futures-test/0.4.0-alpha.0"
 description = """
 Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.13", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.13", path = "../futures-task", default-features = false }
+futures-core = { version = "=1.0.0-alpha.0", path = "../futures-core", default-features = false }
+futures-task = { version = "=0.4.0-alpha.0", path = "../futures-task", default-features = false }
 futures-io = { version = "0.3.13", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.13", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.13", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.13", path = "../futures-sink", default-features = false }
+futures-util = { version = "=0.4.0-alpha.0", path = "../futures-util", default-features = false }
+futures-executor = { version = "=0.4.0-alpha.0", path = "../futures-executor", default-features = false }
+futures-sink = { version = "=0.4.0-alpha.0", path = "../futures-sink", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.1"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "futures-util"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-util/0.3"
+documentation = "https://docs.rs/futures-util/0.4.0-alpha.0"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """
@@ -33,12 +33,12 @@ read-initializer = ["io", "futures-io/read-initializer", "futures-io/unstable"]
 write-all-vectored = ["io"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.13", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.13", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.13", default-features = false, features = ["std"], optional = true }
+futures-core = { path = "../futures-core", version = "=1.0.0-alpha.0", default-features = false }
+futures-task = { path = "../futures-task", version = "=0.4.0-alpha.0", default-features = false }
+futures-channel = { path = "../futures-channel", version = "=0.4.0-alpha.0", default-features = false, features = ["std"], optional = true }
 futures-io = { path = "../futures-io", version = "0.3.13", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.13", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.13", default-features = false, optional = true }
+futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "futures"
 edition = "2018"
-version = "0.3.13"
+version = "0.4.0-alpha.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.3"
+documentation = "https://docs.rs/futures/0.4.0-alpha.0"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.13", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.13", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.13", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.13", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "=1.0.0-alpha.0", default-features = false }
+futures-task = { path = "../futures-task", version = "=0.4.0-alpha.0", default-features = false }
+futures-channel = { path = "../futures-channel", version = "=0.4.0-alpha.0", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 futures-io = { path = "../futures-io", version = "0.3.13", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.13", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.13", default-features = false, features = ["sink"] }
+futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false }
+futures-util = { path = "../futures-util", version = "=0.4.0-alpha.0", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/macro-reexport/Cargo.toml
+++ b/futures/tests/macro-reexport/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures03 = { path = "../..", package = "futures" }
+futures04 = { path = "../..", package = "futures" }

--- a/futures/tests/macro-reexport/src/lib.rs
+++ b/futures/tests/macro-reexport/src/lib.rs
@@ -1,8 +1,8 @@
 // normal reexport
-pub use futures03::{join, try_join, select, select_biased};
+pub use futures04::{join, try_join, select, select_biased};
 
 // reexport + rename
-pub use futures03::{
+pub use futures04::{
     join as join2, try_join as try_join2,
     select as select2, select_biased as select_biased2,
 };

--- a/futures/tests/macro-tests/Cargo.toml
+++ b/futures/tests/macro-tests/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures03 = { path = "../..", package = "futures" }
+futures04 = { path = "../..", package = "futures" }
 macro-reexport = { path = "../macro-reexport" }

--- a/futures/tests/macro-tests/src/main.rs
+++ b/futures/tests/macro-tests/src/main.rs
@@ -1,18 +1,18 @@
 // Check that it works even if proc-macros are reexported.
 
 fn main() {
-    use futures03::{executor::block_on, future};
+    use futures04::{executor::block_on, future};
 
     // join! macro
     let _ = block_on(async {
-        let _ = futures03::join!(async {}, async {});
+        let _ = futures04::join!(async {}, async {});
         let _ = macro_reexport::join!(async {}, async {});
         let _ = macro_reexport::join2!(async {}, async {});
     });
 
     // try_join! macro
     let _ = block_on(async {
-        let _ = futures03::try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
+        let _ = futures04::try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
         let _ = macro_reexport::try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
         let _ = macro_reexport::try_join2!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) });
         Ok::<(), ()>(())
@@ -22,7 +22,7 @@ fn main() {
     let _ = block_on(async {
         let mut a = future::ready(());
         let mut b = future::pending::<()>();
-        let _ = futures03::select! {
+        let _ = futures04::select! {
             _ = a => {},
             _ = b => unreachable!(),
         };
@@ -46,7 +46,7 @@ fn main() {
     let _ = block_on(async {
         let mut a = future::ready(());
         let mut b = future::pending::<()>();
-        let _ = futures03::select_biased! {
+        let _ = futures04::select_biased! {
             _ = a => {},
             _ = b => unreachable!(),
         };


### PR DESCRIPTION
Now that the `Stream` trait has been added to the standard library as an unstable feature, we can start developing the next major version.

For now, I'm planning to release the next futures-core as 1.0 and the almost of other futures- * crates as 0.4, and not change the version of futures-io.

- futures-core: 0.3 -> 1.0
- futures-io: as-is
- others: 0.3 -> 0.4

See [milestone](https://github.com/rust-lang/futures-rs/milestone/3) for changes planned or considered.

I think the release of futures 0.4/futures-core 1.0 may be the time when the stream stabilizes. (Unlike what I said in #2207.)

cc https://github.com/rust-lang/futures-rs/issues/2207

r? @cramertj @Nemo157 @seanmonstar 
FYI @rust-lang/wg-async-foundations 