### PR TITLE
Fix typo in io/cursor.rs

### DIFF
--- a/futures-util/src/io/cursor.rs
+++ b/futures-util/src/io/cursor.rs
@@ -13,7 +13,7 @@ use std::pin::Pin;
 /// allowing these buffers to be used anywhere you might use a reader or writer
 /// that does actual I/O.
 ///
-/// The standard library implements some I/O traits on various types which
+/// This library implements some I/O traits on various types which
 /// are commonly used as a buffer, like `Cursor<`[`Vec`]`<u8>>` and
 /// `Cursor<`[`&[u8]`][bytes]`>`.
 ///


### PR DESCRIPTION
https://github.com/rust-lang/futures-rs/commit/38b908f0ad309218f261a619911c6dd7cdee1a17#r35852273