### PR TITLE
Format most crates with rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"

--- a/examples/functional/src/main.rs
+++ b/examples/functional/src/main.rs
@@ -30,9 +30,7 @@ fn main() {
         // responsible for transmission
         pool.spawn_ok(fut_tx_result);
 
-        let fut_values = rx
-            .map(|v| v * 2)
-            .collect();
+        let fut_values = rx.map(|v| v * 2).collect();
 
         // Use the executor provided to this async block to wait for the
         // future to complete.

--- a/examples/imperative/src/main.rs
+++ b/examples/imperative/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         // of the stream to be available.
         while let Some(v) = rx.next().await {
             pending.push(v * 2);
-        };
+        }
 
         pending
     };

--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -119,12 +119,7 @@ fn bounded_100_tx(b: &mut Bencher) {
         // Each sender can send one item after specified capacity
         let (tx, mut rx) = mpsc::channel(0);
 
-        let mut tx: Vec<_> = (0..100)
-            .map(|_| TestSender {
-                tx: tx.clone(),
-                last: 0,
-            })
-            .collect();
+        let mut tx: Vec<_> = (0..100).map(|_| TestSender { tx: tx.clone(), last: 0 }).collect();
 
         for i in 0..10 {
             for x in &mut tx {

--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -7,8 +7,8 @@ use {
     futures::{
         channel::mpsc::{self, Sender, UnboundedSender},
         ready,
-        stream::{Stream, StreamExt},
         sink::Sink,
+        stream::{Stream, StreamExt},
         task::{Context, Poll},
     },
     futures_test::task::noop_context,
@@ -25,7 +25,6 @@ fn unbounded_1_tx(b: &mut Bencher) {
         // 1000 iterations to avoid measuring overhead of initialization
         // Result should be divided by 1000
         for i in 0..1000 {
-
             // Poll, not ready, park
             assert_eq!(Poll::Pending, rx.poll_next_unpin(&mut cx));
 
@@ -73,7 +72,6 @@ fn unbounded_uncontended(b: &mut Bencher) {
     })
 }
 
-
 /// A Stream that continuously sends incrementing number of the queue
 struct TestSender {
     tx: Sender<u32>,
@@ -84,9 +82,7 @@ struct TestSender {
 impl Stream for TestSender {
     type Item = u32;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>)
-        -> Poll<Option<Self::Item>>
-    {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
         let mut tx = Pin::new(&mut this.tx);
 
@@ -123,12 +119,12 @@ fn bounded_100_tx(b: &mut Bencher) {
         // Each sender can send one item after specified capacity
         let (tx, mut rx) = mpsc::channel(0);
 
-        let mut tx: Vec<_> = (0..100).map(|_| {
-            TestSender {
+        let mut tx: Vec<_> = (0..100)
+            .map(|_| TestSender {
                 tx: tx.clone(),
-                last: 0
-            }
-        }).collect();
+                last: 0,
+            })
+            .collect();
 
         for i in 0..10 {
             for x in &mut tx {

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -12,10 +12,13 @@
 //! library is activated, and it is activated by default.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -13,12 +13,7 @@
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -1,8 +1,8 @@
 use futures::channel::mpsc;
 use futures::executor::block_on;
 use futures::future::poll_fn;
-use futures::stream::StreamExt;
 use futures::sink::SinkExt;
+use futures::stream::StreamExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
@@ -11,9 +11,7 @@ fn sequence() {
     let (tx, rx) = mpsc::channel(1);
 
     let amt = 20;
-    let t = thread::spawn(move || {
-        block_on(send_sequence(amt, tx))
-    });
+    let t = thread::spawn(move || block_on(send_sequence(amt, tx)));
     let list: Vec<_> = block_on(rx.collect());
     let mut list = list.into_iter();
     for i in (1..=amt).rev() {
@@ -34,9 +32,7 @@ async fn send_sequence(n: u32, mut sender: mpsc::Sender<u32>) {
 fn drop_sender() {
     let (tx, mut rx) = mpsc::channel::<u32>(1);
     drop(tx);
-    let f = poll_fn(|cx| {
-        rx.poll_next_unpin(cx)
-    });
+    let f = poll_fn(|cx| rx.poll_next_unpin(cx));
     assert_eq!(block_on(f), None)
 }
 

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -406,9 +406,7 @@ fn stress_poll_ready() {
         let mut threads = Vec::new();
         for _ in 0..NTHREADS {
             let sender = tx.clone();
-            threads.push(thread::spawn(move || {
-                block_on(stress_poll_ready_sender(sender, AMT))
-            }));
+            threads.push(thread::spawn(move || block_on(stress_poll_ready_sender(sender, AMT))));
         }
         drop(tx);
 

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,13 +1,13 @@
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
-use futures::future::{FutureExt, poll_fn};
-use futures::stream::{Stream, StreamExt};
-use futures::sink::{Sink, SinkExt};
-use futures::task::{Context, Poll};
+use futures::future::{poll_fn, FutureExt};
 use futures::pin_mut;
+use futures::sink::{Sink, SinkExt};
+use futures::stream::{Stream, StreamExt};
+use futures::task::{Context, Poll};
 use futures_test::task::{new_count_waker, noop_context};
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 trait AssertSend: Send {}
@@ -77,7 +77,7 @@ fn send_shared_recv() {
 fn send_recv_threads() {
     let (mut tx, rx) = mpsc::channel::<i32>(16);
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         block_on(tx.send(1)).unwrap();
     });
 
@@ -204,7 +204,7 @@ fn stress_shared_unbounded() {
     const NTHREADS: u32 = 8;
     let (tx, rx) = mpsc::unbounded::<i32>();
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let result: Vec<_> = block_on(rx.collect());
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
@@ -215,7 +215,7 @@ fn stress_shared_unbounded() {
     for _ in 0..NTHREADS {
         let tx = tx.clone();
 
-        thread::spawn(move|| {
+        thread::spawn(move || {
             for _ in 0..AMT {
                 tx.unbounded_send(1).unwrap();
             }
@@ -233,7 +233,7 @@ fn stress_shared_bounded_hard() {
     const NTHREADS: u32 = 8;
     let (tx, rx) = mpsc::channel::<i32>(0);
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let result: Vec<_> = block_on(rx.collect());
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
@@ -297,9 +297,9 @@ fn stress_receiver_multi_task_bounded_hard() {
                             }
                             Poll::Ready(None) => {
                                 *rx_opt = None;
-                                break
-                            },
-                            Poll::Pending => {},
+                                break;
+                            }
+                            Poll::Pending => {}
                         }
                     }
                 } else {
@@ -310,7 +310,6 @@ fn stress_receiver_multi_task_bounded_hard() {
 
         th.push(t);
     }
-
 
     for i in 0..AMT {
         block_on(tx.send(i)).unwrap();
@@ -328,7 +327,7 @@ fn stress_receiver_multi_task_bounded_hard() {
 /// after sender dropped.
 #[test]
 fn stress_drop_sender() {
-    fn list() -> impl Stream<Item=i32> {
+    fn list() -> impl Stream<Item = i32> {
         let (tx, rx) = mpsc::channel(1);
         thread::spawn(move || {
             block_on(send_one_two_three(tx));
@@ -436,7 +435,7 @@ fn try_send_1() {
         for i in 0..N {
             loop {
                 if tx.try_send(i).is_ok() {
-                    break
+                    break;
                 }
             }
         }
@@ -542,8 +541,8 @@ fn is_connected_to() {
 
 #[test]
 fn hash_receiver() {
-    use std::hash::Hasher;
     use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
 
     let mut hasher_a1 = DefaultHasher::new();
     let mut hasher_a2 = DefaultHasher::new();

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot::{self, Sender};
 use futures::executor::block_on;
-use futures::future::{FutureExt, poll_fn};
+use futures::future::{poll_fn, FutureExt};
 use futures::task::{Context, Poll};
 use futures_test::task::panic_waker_ref;
 use std::sync::mpsc;
@@ -70,7 +70,7 @@ fn close() {
     rx.close();
     block_on(poll_fn(|cx| {
         match rx.poll_unpin(cx) {
-            Poll::Ready(Err(_)) => {},
+            Poll::Ready(Err(_)) => {}
             _ => panic!(),
         };
         assert!(tx.poll_canceled(cx).is_ready());

--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -67,14 +67,12 @@ pub trait TryFuture: Future + private_try_future::Sealed {
     /// This method is a stopgap for a compiler limitation that prevents us from
     /// directly inheriting from the `Future` trait; in the future it won't be
     /// needed.
-    fn try_poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Self::Ok, Self::Error>>;
+    fn try_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Self::Ok, Self::Error>>;
 }
 
 impl<F, T, E> TryFuture for F
-    where F: ?Sized + Future<Output = Result<T, E>>
+where
+    F: ?Sized + Future<Output = Result<T, E>>,
 {
     type Ok = T;
     type Error = E;
@@ -87,8 +85,8 @@ impl<F, T, E> TryFuture for F
 
 #[cfg(feature = "alloc")]
 mod if_alloc {
-    use alloc::boxed::Box;
     use super::*;
+    use alloc::boxed::Box;
 
     impl<F: FusedFuture + ?Sized + Unpin> FusedFuture for Box<F> {
         fn is_terminated(&self) -> bool {

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,10 +1,13 @@
 //! Core traits and types for asynchronous operations in Rust.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
@@ -17,10 +20,12 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 extern crate alloc;
 
 pub mod future;
-#[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};
+#[doc(hidden)]
+pub use self::future::{FusedFuture, Future, TryFuture};
 
 pub mod stream;
-#[doc(hidden)] pub use self::stream::{Stream, FusedStream, TryStream};
+#[doc(hidden)]
+pub use self::stream::{FusedStream, Stream, TryStream};
 
 #[macro_use]
 pub mod task;

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -2,12 +2,7 @@
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -1,7 +1,7 @@
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{Acquire, Release, AcqRel};
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
 /// A synchronization primitive for task wakeup.
@@ -279,8 +279,9 @@ impl AtomicWaker {
                     // nothing to acquire, only release. In case of concurrent
                     // wakers, we need to acquire their releases, so success needs
                     // to do both.
-                    let res = self.state.compare_exchange(
-                        REGISTERING, WAITING, AcqRel, Acquire);
+                    let res = self
+                        .state
+                        .compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
 
                     match res {
                         Ok(_) => {
@@ -344,9 +345,7 @@ impl AtomicWaker {
                 //
                 // We just want to maintain memory safety. It is ok to drop the
                 // call to `register`.
-                debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | WAKING);
+                debug_assert!(state == REGISTERING || state == REGISTERING | WAKING);
             }
         }
     }
@@ -391,9 +390,8 @@ impl AtomicWaker {
                 // not.
                 //
                 debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | WAKING ||
-                    state == WAKING);
+                    state == REGISTERING || state == REGISTERING | WAKING || state == WAKING
+                );
                 None
             }
         }

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -202,10 +202,7 @@ impl AtomicWaker {
         trait AssertSync: Sync {}
         impl AssertSync for Waker {}
 
-        Self {
-            state: AtomicUsize::new(WAITING),
-            waker: UnsafeCell::new(None),
-        }
+        Self { state: AtomicUsize::new(WAITING), waker: UnsafeCell::new(None) }
     }
 
     /// Registers the waker to be notified on calls to `wake`.
@@ -279,9 +276,7 @@ impl AtomicWaker {
                     // nothing to acquire, only release. In case of concurrent
                     // wakers, we need to acquire their releases, so success needs
                     // to do both.
-                    let res = self
-                        .state
-                        .compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
+                    let res = self.state.compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
 
                     match res {
                         Ok(_) => {

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -7,4 +7,4 @@ mod poll;
 pub mod __internal;
 
 #[doc(no_inline)]
-pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -3,9 +3,10 @@
 /// This macro bakes in propagation of `Pending` signals by returning early.
 #[macro_export]
 macro_rules! ready {
-    ($e:expr $(,)?) => (match $e {
-        $crate::__private::Poll::Ready(t) => t,
-        $crate::__private::Poll::Pending =>
-            return $crate::__private::Poll::Pending,
-    })
+    ($e:expr $(,)?) => {
+        match $e {
+            $crate::__private::Poll::Ready(t) => t,
+            $crate::__private::Poll::Pending => return $crate::__private::Poll::Pending,
+        }
+    };
 }

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -102,10 +102,7 @@ fn thread_yield_multi_thread(b: &mut Bencher) {
     });
 
     b.iter(move || {
-        let y = Yield {
-            rem: NUM,
-            tx: tx.clone(),
-        };
+        let y = Yield { rem: NUM, tx: tx.clone() };
 
         block_on(y);
     });

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -37,13 +37,16 @@
 //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
@@ -52,12 +55,12 @@ mod local_pool;
 pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
 
 #[cfg(feature = "thread-pool")]
-#[cfg(feature = "std")]
-mod unpark_mutex;
-#[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]
 mod thread_pool;
+#[cfg(feature = "thread-pool")]
+#[cfg(feature = "std")]
+mod unpark_mutex;
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -37,12 +37,7 @@
 //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -10,7 +10,10 @@ use futures_util::stream::StreamExt;
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread::{self, Thread};
 
 /// A single-threaded task pool for polling futures to completion.

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -122,17 +122,12 @@ fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
 impl LocalPool {
     /// Create a new, empty pool of tasks.
     pub fn new() -> Self {
-        Self {
-            pool: FuturesUnordered::new(),
-            incoming: Default::default(),
-        }
+        Self { pool: FuturesUnordered::new(), incoming: Default::default() }
     }
 
     /// Get a clonable handle to the pool as a [`Spawn`].
     pub fn spawner(&self) -> LocalSpawner {
-        LocalSpawner {
-            incoming: Rc::downgrade(&self.incoming),
-        }
+        LocalSpawner { incoming: Rc::downgrade(&self.incoming) }
     }
 
     /// Run all tasks in the pool to completion.

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -54,9 +54,7 @@ struct PoolState {
 
 impl fmt::Debug for ThreadPool {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ThreadPool")
-            .field("size", &self.state.size)
-            .finish()
+        f.debug_struct("ThreadPool").field("size", &self.state.size).finish()
     }
 }
 
@@ -100,10 +98,7 @@ impl ThreadPool {
     pub fn spawn_obj_ok(&self, future: FutureObj<'static, ()>) {
         let task = Task {
             future,
-            wake_handle: Arc::new(WakeHandle {
-                exec: self.clone(),
-                mutex: UnparkMutex::new(),
-            }),
+            wake_handle: Arc::new(WakeHandle { exec: self.clone(), mutex: UnparkMutex::new() }),
             exec: self.clone(),
         };
         self.state.send(Message::Run(task));
@@ -169,9 +164,7 @@ impl PoolState {
 impl Clone for ThreadPool {
     fn clone(&self) -> Self {
         self.state.cnt.fetch_add(1, Ordering::Relaxed);
-        Self {
-            state: self.state.clone(),
-        }
+        Self { state: self.state.clone() }
     }
 }
 
@@ -316,11 +309,7 @@ impl Task {
     /// Actually run the task (invoking `poll` on the future) on the current
     /// thread.
     fn run(self) {
-        let Self {
-            mut future,
-            wake_handle,
-            mut exec,
-        } = self;
+        let Self { mut future, wake_handle, mut exec } = self;
         let waker = waker_ref(&wake_handle);
         let mut cx = Context::from_waker(&waker);
 
@@ -335,11 +324,7 @@ impl Task {
                     Poll::Pending => {}
                     Poll::Ready(()) => return wake_handle.mutex.complete(),
                 }
-                let task = Self {
-                    future,
-                    wake_handle: wake_handle.clone(),
-                    exec,
-                };
+                let task = Self { future, wake_handle: wake_handle.clone(), exec };
                 match wake_handle.mutex.wait(task) {
                     Ok(()) => return, // we've waited
                     Err(task) => {

--- a/futures-executor/src/unpark_mutex.rs
+++ b/futures-executor/src/unpark_mutex.rs
@@ -29,18 +29,18 @@ unsafe impl<D: Send> Sync for UnparkMutex<D> {}
 // transitions:
 
 // The task is blocked, waiting on an event
-const WAITING: usize = 0;       // --> POLLING
+const WAITING: usize = 0; // --> POLLING
 
 // The task is actively being polled by a thread; arrival of additional events
 // of interest should move it to the REPOLL state
-const POLLING: usize = 1;       // --> WAITING, REPOLL, or COMPLETE
+const POLLING: usize = 1; // --> WAITING, REPOLL, or COMPLETE
 
 // The task is actively being polled, but will need to be re-polled upon
 // completion to ensure that all events were observed.
-const REPOLL: usize = 2;        // --> POLLING
+const REPOLL: usize = 2; // --> POLLING
 
 // The task has finished executing (either successfully or with an error/panic)
-const COMPLETE: usize = 3;      // No transitions out
+const COMPLETE: usize = 3; // No transitions out
 
 impl<D> UnparkMutex<D> {
     pub(crate) fn new() -> Self {
@@ -62,8 +62,10 @@ impl<D> UnparkMutex<D> {
             match status {
                 // The task is idle, so try to run it immediately.
                 WAITING => {
-                    match self.status.compare_exchange(WAITING, POLLING,
-                                                       SeqCst, SeqCst) {
+                    match self
+                        .status
+                        .compare_exchange(WAITING, POLLING, SeqCst, SeqCst)
+                    {
                         Ok(_) => {
                             let data = unsafe {
                                 // SAFETY: we've ensured mutual exclusion via
@@ -83,8 +85,10 @@ impl<D> UnparkMutex<D> {
                 // The task is being polled, so we need to record that it should
                 // be *repolled* when complete.
                 POLLING => {
-                    match self.status.compare_exchange(POLLING, REPOLL,
-                                                       SeqCst, SeqCst) {
+                    match self
+                        .status
+                        .compare_exchange(POLLING, REPOLL, SeqCst, SeqCst)
+                    {
                         Ok(_) => return Err(()),
                         Err(cur) => status = cur,
                     }
@@ -117,7 +121,10 @@ impl<D> UnparkMutex<D> {
     pub(crate) unsafe fn wait(&self, data: D) -> Result<(), D> {
         *self.inner.get() = Some(data);
 
-        match self.status.compare_exchange(POLLING, WAITING, SeqCst, SeqCst) {
+        match self
+            .status
+            .compare_exchange(POLLING, WAITING, SeqCst, SeqCst)
+        {
             // no unparks came in while we were running
             Ok(_) => Ok(()),
 

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -248,16 +248,12 @@ fn run_until_stalled_returns_multiple_times() {
     let cnt = Rc::new(Cell::new(0));
 
     let cnt1 = cnt.clone();
-    spawn
-        .spawn_local_obj(Box::pin(lazy(move |_| cnt1.set(cnt1.get() + 1))).into())
-        .unwrap();
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| cnt1.set(cnt1.get() + 1))).into()).unwrap();
     pool.run_until_stalled();
     assert_eq!(cnt.get(), 1);
 
     let cnt2 = cnt.clone();
-    spawn
-        .spawn_local_obj(Box::pin(lazy(move |_| cnt2.set(cnt2.get() + 1))).into())
-        .unwrap();
+    spawn.spawn_local_obj(Box::pin(lazy(move |_| cnt2.set(cnt2.get() + 1))).into()).unwrap();
     pool.run_until_stalled();
     assert_eq!(cnt.get(), 2);
 }
@@ -400,19 +396,9 @@ fn tasks_are_scheduled_fairly() {
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
 
-    spawn
-        .spawn_local_obj(
-            Box::pin(Spin {
-                state: state.clone(),
-                idx: 0,
-            })
-            .into(),
-        )
-        .unwrap();
+    spawn.spawn_local_obj(Box::pin(Spin { state: state.clone(), idx: 0 }).into()).unwrap();
 
-    spawn
-        .spawn_local_obj(Box::pin(Spin { state, idx: 1 }).into())
-        .unwrap();
+    spawn.spawn_local_obj(Box::pin(Spin { state, idx: 1 }).into()).unwrap();
 
     pool.run();
 }

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -1,14 +1,14 @@
 use futures::channel::oneshot;
 use futures::executor::LocalPool;
-use futures::future::{self, Future, lazy, poll_fn};
-use futures::task::{Context, Poll, Spawn, LocalSpawn, Waker};
+use futures::future::{self, lazy, poll_fn, Future};
+use futures::task::{Context, LocalSpawn, Poll, Spawn, Waker};
 use std::cell::{Cell, RefCell};
 use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use std::sync::Arc;
-use std::sync::atomic::{Ordering, AtomicBool};
 
 struct Pending(Rc<()>);
 
@@ -52,9 +52,14 @@ fn run_until_executes_spawned() {
     let (tx, rx) = oneshot::channel();
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
-    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
-        tx.send(()).unwrap();
-    })).into()).unwrap();
+    spawn
+        .spawn_local_obj(
+            Box::pin(lazy(move |_| {
+                tx.send(()).unwrap();
+            }))
+            .into(),
+        )
+        .unwrap();
     pool.run_until(rx).unwrap();
 }
 
@@ -74,17 +79,26 @@ fn run_executes_spawned() {
     let spawn = pool.spawner();
     let spawn2 = pool.spawner();
 
-    spawn.spawn_local_obj(Box::pin(lazy(move |_| {
-        spawn2.spawn_local_obj(Box::pin(lazy(move |_| {
-            cnt2.set(cnt2.get() + 1);
-        })).into()).unwrap();
-    })).into()).unwrap();
+    spawn
+        .spawn_local_obj(
+            Box::pin(lazy(move |_| {
+                spawn2
+                    .spawn_local_obj(
+                        Box::pin(lazy(move |_| {
+                            cnt2.set(cnt2.get() + 1);
+                        }))
+                        .into(),
+                    )
+                    .unwrap();
+            }))
+            .into(),
+        )
+        .unwrap();
 
     pool.run();
 
     assert_eq!(cnt.get(), 1);
 }
-
 
 #[test]
 fn run_spawn_many() {
@@ -97,9 +111,14 @@ fn run_spawn_many() {
 
     for _ in 0..ITER {
         let cnt = cnt.clone();
-        spawn.spawn_local_obj(Box::pin(lazy(move |_| {
-            cnt.set(cnt.get() + 1);
-        })).into()).unwrap();
+        spawn
+            .spawn_local_obj(
+                Box::pin(lazy(move |_| {
+                    cnt.set(cnt.get() + 1);
+                }))
+                .into(),
+            )
+            .unwrap();
     }
 
     pool.run();
@@ -126,9 +145,14 @@ fn try_run_one_executes_one_ready() {
         spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
 
         let cnt = cnt.clone();
-        spawn.spawn_local_obj(Box::pin(lazy(move |_| {
-            cnt.set(cnt.get() + 1);
-        })).into()).unwrap();
+        spawn
+            .spawn_local_obj(
+                Box::pin(lazy(move |_| {
+                    cnt.set(cnt.get() + 1);
+                }))
+                .into(),
+            )
+            .unwrap();
 
         spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
     }
@@ -154,15 +178,20 @@ fn try_run_one_returns_on_no_progress() {
     {
         let cnt = cnt.clone();
         let waker = waker.clone();
-        spawn.spawn_local_obj(Box::pin(poll_fn(move |ctx| {
-            cnt.set(cnt.get() + 1);
-            waker.set(Some(ctx.waker().clone()));
-            if cnt.get() == ITER {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })).into()).unwrap();
+        spawn
+            .spawn_local_obj(
+                Box::pin(poll_fn(move |ctx| {
+                    cnt.set(cnt.get() + 1);
+                    waker.set(Some(ctx.waker().clone()));
+                    if cnt.get() == ITER {
+                        Poll::Ready(())
+                    } else {
+                        Poll::Pending
+                    }
+                }))
+                .into(),
+            )
+            .unwrap();
     }
 
     for i in 0..ITER - 1 {
@@ -185,16 +214,21 @@ fn try_run_one_runs_sub_futures() {
 
     let inner_spawner = spawn.clone();
     let cnt1 = cnt.clone();
-    spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
-        cnt1.set(cnt1.get() + 1);
-        
-        let cnt2 = cnt1.clone();
-        inner_spawner.spawn_local_obj(Box::pin(lazy(move |_|{
-            cnt2.set(cnt2.get() + 1)
-        })).into()).unwrap();
+    spawn
+        .spawn_local_obj(
+            Box::pin(poll_fn(move |_| {
+                cnt1.set(cnt1.get() + 1);
 
-        Poll::Pending
-    })).into()).unwrap();
+                let cnt2 = cnt1.clone();
+                inner_spawner
+                    .spawn_local_obj(Box::pin(lazy(move |_| cnt2.set(cnt2.get() + 1))).into())
+                    .unwrap();
+
+                Poll::Pending
+            }))
+            .into(),
+        )
+        .unwrap();
 
     pool.try_run_one();
     assert_eq!(cnt.get(), 2);
@@ -214,12 +248,16 @@ fn run_until_stalled_returns_multiple_times() {
     let cnt = Rc::new(Cell::new(0));
 
     let cnt1 = cnt.clone();
-    spawn.spawn_local_obj(Box::pin(lazy(move |_|{ cnt1.set(cnt1.get() + 1) })).into()).unwrap();
+    spawn
+        .spawn_local_obj(Box::pin(lazy(move |_| cnt1.set(cnt1.get() + 1))).into())
+        .unwrap();
     pool.run_until_stalled();
     assert_eq!(cnt.get(), 1);
 
     let cnt2 = cnt.clone();
-    spawn.spawn_local_obj(Box::pin(lazy(move |_|{ cnt2.set(cnt2.get() + 1) })).into()).unwrap();
+    spawn
+        .spawn_local_obj(Box::pin(lazy(move |_| cnt2.set(cnt2.get() + 1))).into())
+        .unwrap();
     pool.run_until_stalled();
     assert_eq!(cnt.get(), 2);
 }
@@ -232,16 +270,21 @@ fn run_until_stalled_runs_spawned_sub_futures() {
 
     let inner_spawner = spawn.clone();
     let cnt1 = cnt.clone();
-    spawn.spawn_local_obj(Box::pin(poll_fn(move |_| {
-        cnt1.set(cnt1.get() + 1);
-        
-        let cnt2 = cnt1.clone();
-        inner_spawner.spawn_local_obj(Box::pin(lazy(move |_|{
-            cnt2.set(cnt2.get() + 1)
-        })).into()).unwrap();
+    spawn
+        .spawn_local_obj(
+            Box::pin(poll_fn(move |_| {
+                cnt1.set(cnt1.get() + 1);
 
-        Poll::Pending
-    })).into()).unwrap();
+                let cnt2 = cnt1.clone();
+                inner_spawner
+                    .spawn_local_obj(Box::pin(lazy(move |_| cnt2.set(cnt2.get() + 1))).into())
+                    .unwrap();
+
+                Poll::Pending
+            }))
+            .into(),
+        )
+        .unwrap();
 
     pool.run_until_stalled();
     assert_eq!(cnt.get(), 2);
@@ -262,9 +305,14 @@ fn run_until_stalled_executes_all_ready() {
             spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
 
             let cnt = cnt.clone();
-            spawn.spawn_local_obj(Box::pin(lazy(move |_| {
-                cnt.set(cnt.get() + 1);
-            })).into()).unwrap();
+            spawn
+                .spawn_local_obj(
+                    Box::pin(lazy(move |_| {
+                        cnt.set(cnt.get() + 1);
+                    }))
+                    .into(),
+                )
+                .unwrap();
 
             // also add some pending tasks to test if they are ignored
             spawn.spawn_local_obj(Box::pin(pending()).into()).unwrap();
@@ -281,10 +329,15 @@ fn nesting_run() {
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
 
-    spawn.spawn_obj(Box::pin(lazy(|_| {
-        let mut pool = LocalPool::new();
-        pool.run();
-    })).into()).unwrap();
+    spawn
+        .spawn_obj(
+            Box::pin(lazy(|_| {
+                let mut pool = LocalPool::new();
+                pool.run();
+            }))
+            .into(),
+        )
+        .unwrap();
 
     pool.run();
 }
@@ -295,10 +348,15 @@ fn nesting_run_run_until_stalled() {
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
 
-    spawn.spawn_obj(Box::pin(lazy(|_| {
-        let mut pool = LocalPool::new();
-        pool.run_until_stalled();
-    })).into()).unwrap();
+    spawn
+        .spawn_obj(
+            Box::pin(lazy(|_| {
+                let mut pool = LocalPool::new();
+                pool.run_until_stalled();
+            }))
+            .into(),
+        )
+        .unwrap();
 
     pool.run();
 }
@@ -342,15 +400,19 @@ fn tasks_are_scheduled_fairly() {
     let mut pool = LocalPool::new();
     let spawn = pool.spawner();
 
-    spawn.spawn_local_obj(Box::pin(Spin {
-        state: state.clone(),
-        idx: 0,
-    }).into()).unwrap();
+    spawn
+        .spawn_local_obj(
+            Box::pin(Spin {
+                state: state.clone(),
+                idx: 0,
+            })
+            .into(),
+        )
+        .unwrap();
 
-    spawn.spawn_local_obj(Box::pin(Spin {
-        state,
-        idx: 1,
-    }).into()).unwrap();
+    spawn
+        .spawn_local_obj(Box::pin(Spin { state, idx: 1 }).into())
+        .unwrap();
 
     pool.run();
 }
@@ -363,11 +425,11 @@ fn park_unpark_independence() {
 
     let future = future::poll_fn(move |cx| {
         if done {
-            return Poll::Ready(())
+            return Poll::Ready(());
         }
         done = true;
         cx.waker().clone().wake(); // (*)
-        // some user-code that temporarily parks the thread
+                                   // some user-code that temporarily parks the thread
         let test = thread::current();
         let latch = Arc::new(AtomicBool::new(false));
         let signal = latch.clone();
@@ -384,4 +446,3 @@ fn park_unpark_independence() {
 
     futures::executor::block_on(future)
 }
-

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -429,7 +429,8 @@ fn park_unpark_independence() {
         }
         done = true;
         cx.waker().clone().wake(); // (*)
-                                   // some user-code that temporarily parks the thread
+
+        // some user-code that temporarily parks the thread
         let test = thread::current();
         let latch = Arc::new(AtomicBool::new(false));
         let signal = latch.clone();

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -8,17 +8,9 @@
 //! All items of this library are only available when the `std` feature of this
 //! library is activated, and it is activated by default.
 
-#![cfg_attr(
-    all(feature = "read-initializer", feature = "std"),
-    feature(read_initializer)
-)]
+#![cfg_attr(all(feature = "read-initializer", feature = "std"), feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -8,16 +8,21 @@
 //! All items of this library are only available when the `std` feature of this
 //! library is activated, and it is activated by default.
 
-#![cfg_attr(all(feature = "read-initializer", feature = "std"), feature(read_initializer))]
-
+#![cfg_attr(
+    all(feature = "read-initializer", feature = "std"),
+    feature(read_initializer)
+)]
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
@@ -32,14 +37,14 @@ mod if_std {
 
     // Re-export some types from `std::io` so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
-    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-    #[doc(no_inline)]
-    pub use io::{Error, ErrorKind, Result, IoSlice, IoSliceMut, SeekFrom};
     #[cfg(feature = "read-initializer")]
     #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
     #[doc(no_inline)]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
     pub use io::Initializer;
+    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+    #[doc(no_inline)]
+    pub use io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
 
     /// Read bytes asynchronously.
     ///
@@ -85,8 +90,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<Result<usize>>;
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>>;
 
         /// Attempt to read from the `AsyncRead` into `bufs` using vectored
         /// IO operations.
@@ -110,9 +118,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
             for b in bufs {
                 if !b.is_empty() {
                     return self.poll_read(cx, b);
@@ -149,8 +159,11 @@ mod if_std {
         ///
         /// `poll_write` must try to make progress by flushing the underlying object if
         /// that is the only way the underlying object can become writable again.
-        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-            -> Poll<Result<usize>>;
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>>;
 
         /// Attempt to write bytes from `bufs` into the object using vectored
         /// IO operations.
@@ -175,9 +188,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
             for b in bufs {
                 if !b.is_empty() {
                     return self.poll_write(cx, b);
@@ -252,8 +267,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<Result<u64>>;
+        fn poll_seek(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<Result<u64>>;
     }
 
     /// Read bytes asynchronously.
@@ -292,8 +310,7 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&[u8]>>;
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>>;
 
         /// Tells this buffer that `amt` bytes have been consumed from the buffer,
         /// so they should no longer be returned in calls to [`poll_read`].
@@ -320,18 +337,22 @@ mod if_std {
                 (**self).initializer()
             }
 
-            fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &mut [u8],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_read(cx, buf)
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read_vectored(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                bufs: &mut [IoSliceMut<'_>],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_read_vectored(cx, bufs)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for Box<T> {
@@ -352,15 +373,19 @@ mod if_std {
             (**self).initializer()
         }
 
-        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_read(cx, buf)
         }
 
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_read_vectored(cx, bufs)
         }
     }
@@ -372,18 +397,22 @@ mod if_std {
                 io::Read::initializer(self)
             }
 
-            fn poll_read(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &mut [u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                buf: &mut [u8],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Read::read(&mut *self, buf))
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read_vectored(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                bufs: &mut [IoSliceMut<'_>],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Read::read_vectored(&mut *self, bufs))
             }
-        }
+        };
     }
 
     impl AsyncRead for &[u8] {
@@ -392,15 +421,19 @@ mod if_std {
 
     macro_rules! deref_async_write {
         () => {
-            fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_write(cx, buf)
             }
 
-            fn poll_write_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write_vectored(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                bufs: &[IoSlice<'_>],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_write_vectored(cx, bufs)
             }
 
@@ -411,7 +444,7 @@ mod if_std {
             fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
                 Pin::new(&mut **self).poll_close(cx)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for Box<T> {
@@ -427,15 +460,19 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncWrite,
     {
-        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_write(cx, buf)
         }
 
-        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_write_vectored(cx, bufs)
         }
 
@@ -450,15 +487,19 @@ mod if_std {
 
     macro_rules! delegate_async_write_to_stdio {
         () => {
-            fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Write::write(&mut *self, buf))
             }
 
-            fn poll_write_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &[IoSlice<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write_vectored(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                bufs: &[IoSlice<'_>],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
             }
 
@@ -469,7 +510,7 @@ mod if_std {
             fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
                 self.poll_flush(cx)
             }
-        }
+        };
     }
 
     impl AsyncWrite for Vec<u8> {
@@ -478,12 +519,14 @@ mod if_std {
 
     macro_rules! deref_async_seek {
         () => {
-            fn poll_seek(mut self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-                -> Poll<Result<u64>>
-            {
+            fn poll_seek(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                pos: SeekFrom,
+            ) -> Poll<Result<u64>> {
                 Pin::new(&mut **self).poll_seek(cx, pos)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for Box<T> {
@@ -499,25 +542,25 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncSeek,
     {
-        fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<Result<u64>>
-        {
+        fn poll_seek(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<Result<u64>> {
             self.get_mut().as_mut().poll_seek(cx, pos)
         }
     }
 
     macro_rules! deref_async_buf_read {
         () => {
-            fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-                -> Poll<Result<&[u8]>>
-            {
+            fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
                 Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
             }
 
             fn consume(mut self: Pin<&mut Self>, amt: usize) {
                 Pin::new(&mut **self).consume(amt)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
@@ -533,9 +576,7 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncBufRead,
     {
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&[u8]>>
-        {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
             self.get_mut().as_mut().poll_fill_buf(cx)
         }
 
@@ -546,16 +587,14 @@ mod if_std {
 
     macro_rules! delegate_async_buf_read_to_stdio {
         () => {
-            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>)
-                -> Poll<Result<&[u8]>>
-            {
+            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
                 Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
             }
 
             fn consume(self: Pin<&mut Self>, amt: usize) {
                 io::BufRead::consume(self.get_mut(), amt)
             }
-        }
+        };
     }
 
     impl AsyncBufRead for &[u8] {

--- a/futures-macro/src/join.rs
+++ b/futures-macro/src/join.rs
@@ -27,10 +27,7 @@ impl Parse for Join {
     }
 }
 
-fn bind_futures(
-    fut_exprs: Vec<Expr>,
-    span: Span,
-) -> (Vec<TokenStream2>, Vec<Ident>) {
+fn bind_futures(fut_exprs: Vec<Expr>, span: Span) -> (Vec<TokenStream2>, Vec<Ident>) {
     let mut future_let_bindings = Vec::with_capacity(fut_exprs.len());
     let future_names: Vec<_> = fut_exprs
         .into_iter()

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -98,18 +98,13 @@ fn declare_result_enum(
     span: Span,
 ) -> (Vec<Ident>, syn::ItemEnum) {
     // "_0", "_1", "_2"
-    let variant_names: Vec<Ident> = (0..variants)
-        .map(|num| format_ident!("_{}", num, span = span))
-        .collect();
+    let variant_names: Vec<Ident> =
+        (0..variants).map(|num| format_ident!("_{}", num, span = span)).collect();
 
     let type_parameters = &variant_names;
     let variants = &variant_names;
 
-    let complete_variant = if complete {
-        Some(quote!(Complete))
-    } else {
-        None
-    };
+    let complete_variant = if complete { Some(quote!(Complete)) } else { None };
 
     let enum_item = parse_quote! {
         enum #result_ident<#(#type_parameters,)*> {
@@ -234,15 +229,13 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
         }
     };
 
-    let branches = parsed
-        .normal_fut_handlers
-        .into_iter()
-        .zip(variant_names.iter())
-        .map(|((pat, expr), variant_name)| {
+    let branches = parsed.normal_fut_handlers.into_iter().zip(variant_names.iter()).map(
+        |((pat, expr), variant_name)| {
             quote! {
                 #enum_ident::#variant_name(#pat) => { #expr },
             }
-        });
+        },
+    );
     let branches = quote! { #( #branches )* };
 
     let complete_branch = parsed.complete.map(|complete_expr| {

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -3,8 +3,8 @@
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::{parse_quote, Expr, Ident, Pat, Token};
 use syn::parse::{Parse, ParseStream};
+use syn::{parse_quote, Expr, Ident, Pat, Token};
 
 mod kw {
     syn::custom_keyword!(complete);
@@ -63,7 +63,10 @@ impl Parse for Select {
 
             // Commas after the expression are only optional if it's a `Block`
             // or it is the last branch in the `match`.
-            let is_block = match expr { Expr::Block(_) => true, _ => false };
+            let is_block = match expr {
+                Expr::Block(_) => true,
+                _ => false,
+            };
             if is_block || input.is_empty() {
                 input.parse::<Option<Token![,]>>()?;
             } else {
@@ -76,7 +79,7 @@ impl Parse for Select {
                 CaseKind::Normal(pat, fut_expr) => {
                     select.normal_fut_exprs.push(fut_expr);
                     select.normal_fut_handlers.push((pat, expr));
-                },
+                }
             }
         }
 
@@ -92,13 +95,12 @@ fn declare_result_enum(
     result_ident: Ident,
     variants: usize,
     complete: bool,
-    span: Span
+    span: Span,
 ) -> (Vec<Ident>, syn::ItemEnum) {
     // "_0", "_1", "_2"
-    let variant_names: Vec<Ident> =
-        (0..variants)
-            .map(|num| format_ident!("_{}", num, span = span))
-            .collect();
+    let variant_names: Vec<Ident> = (0..variants)
+        .map(|num| format_ident!("_{}", num, span = span))
+        .collect();
 
     let type_parameters = &variant_names;
     let variants = &variant_names;
@@ -148,7 +150,9 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
 
     // bind non-`Ident` future exprs w/ `let`
     let mut future_let_bindings = Vec::with_capacity(parsed.normal_fut_exprs.len());
-    let bound_future_names: Vec<_> = parsed.normal_fut_exprs.into_iter()
+    let bound_future_names: Vec<_> = parsed
+        .normal_fut_exprs
+        .into_iter()
         .zip(variant_names.iter())
         .map(|(expr, variant_name)| {
             match expr {
@@ -164,7 +168,7 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                         __futures_crate::async_await::assert_unpin(&#path);
                     });
                     path
-                },
+                }
                 _ => {
                     // Bind and pin the resulting Future on the stack. This is
                     // necessary to support direct select! calls on !Unpin
@@ -188,8 +192,8 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
 
     // For each future, make an `&mut dyn FnMut(&mut Context<'_>) -> Option<Poll<__PrivResult<...>>`
     // to use for polling that individual future. These will then be put in an array.
-    let poll_functions = bound_future_names.iter().zip(variant_names.iter())
-        .map(|(bound_future_name, variant_name)| {
+    let poll_functions = bound_future_names.iter().zip(variant_names.iter()).map(
+        |(bound_future_name, variant_name)| {
             // Below we lazily create the Pin on the Future below.
             // This is done in order to avoid allocating memory in the generator
             // for the Pin variable.
@@ -216,7 +220,8 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                     &mut __futures_crate::task::Context<'_>
                 ) -> __futures_crate::Option<__futures_crate::task::Poll<_>> = &mut #variant_name;
             }
-        });
+        },
+    );
 
     let none_polled = if parsed.complete.is_some() {
         quote! {
@@ -229,7 +234,9 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
         }
     };
 
-    let branches = parsed.normal_fut_handlers.into_iter()
+    let branches = parsed
+        .normal_fut_handlers
+        .into_iter()
         .zip(variant_names.iter())
         .map(|((pat, expr), variant_name)| {
             quote! {

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -4,7 +4,12 @@
 //! asynchronously.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
@@ -207,7 +212,10 @@ mod if_alloc {
     impl<S: ?Sized + Sink<Item> + Unpin, Item> Sink<Item> for alloc::boxed::Box<S> {
         type Error = S::Error;
 
-        fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_ready(cx)
         }
 
@@ -215,11 +223,17 @@ mod if_alloc {
             Pin::new(&mut **self).start_send(item)
         }
 
-        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_flush(cx)
         }
 
-        fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_close(cx)
         }
     }

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -4,12 +4,7 @@
 //! asynchronously.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-task/src/future_obj.rs
+++ b/futures-task/src/future_obj.rs
@@ -1,8 +1,8 @@
 use core::{
-    mem,
     fmt,
     future::Future,
     marker::PhantomData,
+    mem,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -26,16 +26,16 @@ impl<T> Unpin for LocalFutureObj<'_, T> {}
 
 #[allow(single_use_lifetimes)]
 #[allow(clippy::transmute_ptr_to_ptr)]
-unsafe fn remove_future_lifetime<'a, T>(ptr: *mut (dyn Future<Output = T> + 'a))
-    -> *mut (dyn Future<Output = T> + 'static)
-{
+unsafe fn remove_future_lifetime<'a, T>(
+    ptr: *mut (dyn Future<Output = T> + 'a),
+) -> *mut (dyn Future<Output = T> + 'static) {
     mem::transmute(ptr)
 }
 
 #[allow(single_use_lifetimes)]
-unsafe fn remove_drop_lifetime<'a, T>(ptr: unsafe fn (*mut (dyn Future<Output = T> + 'a)))
-    -> unsafe fn(*mut (dyn Future<Output = T> + 'static))
-{
+unsafe fn remove_drop_lifetime<'a, T>(
+    ptr: unsafe fn(*mut (dyn Future<Output = T> + 'a)),
+) -> unsafe fn(*mut (dyn Future<Output = T> + 'static)) {
     mem::transmute(ptr)
 }
 
@@ -65,8 +65,7 @@ impl<'a, T> LocalFutureObj<'a, T> {
 
 impl<T> fmt::Debug for LocalFutureObj<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LocalFutureObj")
-            .finish()
+        f.debug_struct("LocalFutureObj").finish()
     }
 }
 
@@ -82,17 +81,13 @@ impl<T> Future for LocalFutureObj<'_, T> {
 
     #[inline]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        unsafe {
-            Pin::new_unchecked(&mut *self.future).poll(cx)
-        }
+        unsafe { Pin::new_unchecked(&mut *self.future).poll(cx) }
     }
 }
 
 impl<T> Drop for LocalFutureObj<'_, T> {
     fn drop(&mut self) {
-        unsafe {
-            (self.drop_fn)(self.future)
-        }
+        unsafe { (self.drop_fn)(self.future) }
     }
 }
 
@@ -120,8 +115,7 @@ impl<'a, T> FutureObj<'a, T> {
 
 impl<T> fmt::Debug for FutureObj<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FutureObj")
-            .finish()
+        f.debug_struct("FutureObj").finish()
     }
 }
 
@@ -130,7 +124,7 @@ impl<T> Future for FutureObj<'_, T> {
 
     #[inline]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        Pin::new( &mut self.0 ).poll(cx)
+        Pin::new(&mut self.0).poll(cx)
     }
 }
 
@@ -180,7 +174,7 @@ pub unsafe trait UnsafeFutureObj<'a, T>: 'a {
 
 unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for &'a mut F
 where
-    F: Future<Output = T> + Unpin + 'a
+    F: Future<Output = T> + Unpin + 'a,
 {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         self as *mut dyn Future<Output = T>
@@ -189,8 +183,7 @@ where
     unsafe fn drop(_ptr: *mut (dyn Future<Output = T> + 'a)) {}
 }
 
-unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + Unpin + 'a)
-{
+unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + Unpin + 'a) {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         self as *mut dyn Future<Output = T>
     }
@@ -200,7 +193,7 @@ unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + 
 
 unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Pin<&'a mut F>
 where
-    F: Future<Output = T> + 'a
+    F: Future<Output = T> + 'a,
 {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         unsafe { self.get_unchecked_mut() as *mut dyn Future<Output = T> }
@@ -209,8 +202,7 @@ where
     unsafe fn drop(_ptr: *mut (dyn Future<Output = T> + 'a)) {}
 }
 
-unsafe impl<'a, T> UnsafeFutureObj<'a, T> for Pin<&'a mut (dyn Future<Output = T> + 'a)>
-{
+unsafe impl<'a, T> UnsafeFutureObj<'a, T> for Pin<&'a mut (dyn Future<Output = T> + 'a)> {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         unsafe { self.get_unchecked_mut() as *mut dyn Future<Output = T> }
     }
@@ -224,7 +216,8 @@ mod if_alloc {
     use alloc::boxed::Box;
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Box<F>
-        where F: Future<Output = T> + 'a
+    where
+        F: Future<Output = T> + 'a,
     {
         fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
             Box::into_raw(self)
@@ -257,7 +250,7 @@ mod if_alloc {
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Pin<Box<F>>
     where
-        F: Future<Output = T> + 'a
+        F: Future<Output = T> + 'a,
     {
         fn into_raw(mut self) -> *mut (dyn Future<Output = T> + 'a) {
             let ptr = unsafe { self.as_mut().get_unchecked_mut() as *mut _ };

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -1,10 +1,13 @@
 //! Tools for working with tasks.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
@@ -24,7 +27,7 @@ macro_rules! cfg_target_has_atomic {
 }
 
 mod spawn;
-pub use crate::spawn::{Spawn, SpawnError, LocalSpawn};
+pub use crate::spawn::{LocalSpawn, Spawn, SpawnError};
 
 cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]
@@ -51,4 +54,4 @@ pub use crate::noop_waker::noop_waker;
 pub use crate::noop_waker::noop_waker_ref;
 
 #[doc(no_inline)]
-pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -2,12 +2,7 @@
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-task/src/spawn.rs
+++ b/futures-task/src/spawn.rs
@@ -126,7 +126,7 @@ impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
 #[cfg(feature = "alloc")]
 mod if_alloc {
     use super::*;
-    use alloc::{ boxed::Box, rc::Rc };
+    use alloc::{boxed::Box, rc::Rc};
 
     impl<Sp: ?Sized + Spawn> Spawn for Box<Sp> {
         fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {

--- a/futures-task/src/waker.rs
+++ b/futures-task/src/waker.rs
@@ -1,7 +1,7 @@
 use super::arc_wake::ArcWake;
-use core::mem;
-use core::task::{Waker, RawWaker, RawWakerVTable};
 use alloc::sync::Arc;
+use core::mem;
+use core::task::{RawWaker, RawWakerVTable, Waker};
 
 pub(super) fn waker_vtable<W: ArcWake>() -> &'static RawWakerVTable {
     &RawWakerVTable::new(
@@ -22,9 +22,7 @@ where
 {
     let ptr = Arc::into_raw(wake) as *const ();
 
-    unsafe {
-        Waker::from_raw(RawWaker::new(ptr, waker_vtable::<W>()))
-    }
+    unsafe { Waker::from_raw(RawWaker::new(ptr, waker_vtable::<W>())) }
 }
 
 // FIXME: panics on Arc::clone / refcount changes could wreak havoc on the

--- a/futures-task/src/waker_ref.rs
+++ b/futures-task/src/waker_ref.rs
@@ -1,10 +1,10 @@
-use super::arc_wake::{ArcWake};
+use super::arc_wake::ArcWake;
 use super::waker::waker_vtable;
 use alloc::sync::Arc;
-use core::mem::ManuallyDrop;
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::Deref;
-use core::task::{Waker, RawWaker};
+use core::task::{RawWaker, Waker};
 
 /// A [`Waker`] that is only valid for a given lifetime.
 ///
@@ -22,10 +22,7 @@ impl<'a> WakerRef<'a> {
         // copy the underlying (raw) waker without calling a clone,
         // as we won't call Waker::drop either.
         let waker = ManuallyDrop::new(unsafe { core::ptr::read(waker) });
-        Self {
-            waker,
-            _marker: PhantomData,
-        }
+        Self { waker, _marker: PhantomData }
     }
 
     /// Create a new [`WakerRef`] from a [`Waker`] that must not be dropped.
@@ -35,10 +32,7 @@ impl<'a> WakerRef<'a> {
     /// by the caller), and the [`Waker`] doesn't need to or must not be
     /// destroyed.
     pub fn new_unowned(waker: ManuallyDrop<Waker>) -> Self {
-        Self {
-            waker,
-            _marker: PhantomData,
-        }
+        Self { waker, _marker: PhantomData }
     }
 }
 
@@ -57,14 +51,13 @@ impl Deref for WakerRef<'_> {
 #[inline]
 pub fn waker_ref<W>(wake: &Arc<W>) -> WakerRef<'_>
 where
-    W: ArcWake
+    W: ArcWake,
 {
     // simply copy the pointer instead of using Arc::into_raw,
     // as we don't actually keep a refcount by using ManuallyDrop.<
     let ptr = (&**wake as *const W) as *const ();
 
-    let waker = ManuallyDrop::new(unsafe {
-        Waker::from_raw(RawWaker::new(ptr, waker_vtable::<W>()))
-    });
+    let waker =
+        ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(ptr, waker_vtable::<W>())) });
     WakerRef::new_unowned(waker)
 }

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -30,9 +30,7 @@ macro_rules! assert_stream_pending {
         $crate::__private::assert::assert_is_unpin_stream(stream);
         let stream = $crate::__private::Pin::new(stream);
         let mut cx = $crate::task::noop_context();
-        let poll = $crate::__private::stream::Stream::poll_next(
-            stream, &mut cx,
-        );
+        let poll = $crate::__private::stream::Stream::poll_next(stream, &mut cx);
         if poll.is_ready() {
             panic!("assertion failed: stream is not pending");
         }
@@ -71,13 +69,15 @@ macro_rules! assert_stream_next {
                 assert_eq!(x, $item);
             }
             $crate::__private::task::Poll::Ready($crate::__private::None) => {
-                panic!("assertion failed: expected stream to provide item but stream is at its end");
+                panic!(
+                    "assertion failed: expected stream to provide item but stream is at its end"
+                );
             }
             $crate::__private::task::Poll::Pending => {
                 panic!("assertion failed: expected stream to provide item but stream wasn't ready");
             }
         }
-    }}
+    }};
 }
 
 /// Assert that the next poll to the provided stream will return an empty
@@ -117,5 +117,5 @@ macro_rules! assert_stream_done {
                 panic!("assertion failed: expected stream to be done but was pending");
             }
         }
-    }}
+    }};
 }

--- a/futures-test/src/assert_unmoved.rs
+++ b/futures-test/src/assert_unmoved.rs
@@ -34,10 +34,7 @@ unsafe impl<T: Sync> Sync for AssertUnmoved<T> {}
 
 impl<T> AssertUnmoved<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            this_ptr: ptr::null(),
-        }
+        Self { inner, this_ptr: ptr::null() }
     }
 
     fn poll_with<'a, U>(mut self: Pin<&'a mut Self>, f: impl FnOnce(Pin<&'a mut T>) -> U) -> U {
@@ -46,10 +43,7 @@ impl<T> AssertUnmoved<T> {
             // First time being polled
             *self.as_mut().project().this_ptr = cur_this;
         } else {
-            assert_eq!(
-                self.this_ptr, cur_this,
-                "AssertUnmoved moved between poll calls"
-            );
+            assert_eq!(self.this_ptr, cur_this, "AssertUnmoved moved between poll calls");
         }
         f(self.project().inner)
     }

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -20,10 +20,7 @@ pub struct PendingOnce<Fut> {
 
 impl<Fut: Future> PendingOnce<Fut> {
     pub(super) fn new(future: Fut) -> Self {
-        Self {
-            future,
-            polled_before: false,
-        }
+        Self { future, polled_before: false }
     }
 }
 

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -1,7 +1,7 @@
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use std::pin::Pin;
 use pin_project::pin_project;
+use std::pin::Pin;
 
 /// Combinator that guarantees one [`Poll::Pending`] before polling its inner
 /// future.
@@ -30,10 +30,7 @@ impl<Fut: Future> PendingOnce<Fut> {
 impl<Fut: Future> Future for PendingOnce<Fut> {
     type Output = Fut::Output;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         if *this.polled_before {
             this.future.poll(cx)

--- a/futures-test/src/interleave_pending.rs
+++ b/futures-test/src/interleave_pending.rs
@@ -28,10 +28,7 @@ pub struct InterleavePending<T> {
 
 impl<T> InterleavePending<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            pended: false,
-        }
+        Self { inner, pended: false }
     }
 
     /// Acquires a reference to the underlying I/O object that this adaptor is

--- a/futures-test/src/io/limited.rs
+++ b/futures-test/src/io/limited.rs
@@ -56,8 +56,7 @@ impl<W: AsyncWrite> AsyncWrite for Limited<W> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         let this = self.project();
-        this.io
-            .poll_write(cx, &buf[..cmp::min(*this.limit, buf.len())])
+        this.io.poll_write(cx, &buf[..cmp::min(*this.limit, buf.len())])
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/futures-test/src/io/limited.rs
+++ b/futures-test/src/io/limited.rs
@@ -56,20 +56,15 @@ impl<W: AsyncWrite> AsyncWrite for Limited<W> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         let this = self.project();
-        this.io.poll_write(cx, &buf[..cmp::min(*this.limit, buf.len())])
+        this.io
+            .poll_write(cx, &buf[..cmp::min(*this.limit, buf.len())])
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project().io.poll_flush(cx)
     }
 
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project().io.poll_close(cx)
     }
 }
@@ -87,10 +82,7 @@ impl<R: AsyncRead> AsyncRead for Limited<R> {
 }
 
 impl<R: AsyncBufRead> AsyncBufRead for Limited<R> {
-    fn poll_fill_buf(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&[u8]>> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         self.project().io.poll_fill_buf(cx)
     }
 

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -1,24 +1,31 @@
 //! Utilities to make testing [`Future`s](futures_core::future::Future) easier
 
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
 #[cfg(not(feature = "std"))]
-compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");
+compile_error!(
+    "`futures-test` must have the `std` feature activated, this is a default-active feature"
+);
 
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "std")]
 pub mod __private {
+    pub use futures_core::{future, stream, task};
     pub use std::{
-        option::Option::{Some, None},
+        option::Option::{None, Some},
         pin::Pin,
         result::Result::{Err, Ok},
     };
-    pub use futures_core::{future, stream, task};
 
     pub mod assert {
         pub use crate::assert::*;

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -1,11 +1,6 @@
 //! Utilities to make testing [`Future`s](futures_core::future::Future) easier
 
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -1,4 +1,4 @@
-use crate::task::{panic_waker_ref, noop_waker_ref};
+use crate::task::{noop_waker_ref, panic_waker_ref};
 use futures_core::task::Context;
 
 /// Create a new [`Context`](core::task::Context) where the

--- a/futures-test/src/task/mod.rs
+++ b/futures-test/src/task/mod.rs
@@ -57,4 +57,4 @@ mod record_spawner;
 pub use self::record_spawner::RecordSpawner;
 
 mod wake_counter;
-pub use self::wake_counter::{AwokenCount, new_count_waker};
+pub use self::wake_counter::{new_count_waker, AwokenCount};

--- a/futures-test/src/task/wake_counter.rs
+++ b/futures-test/src/task/wake_counter.rs
@@ -1,7 +1,7 @@
 use futures_core::task::Waker;
 use futures_util::task::{self, ArcWake};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Number of times the waker was awoken.
 ///
@@ -54,6 +54,8 @@ impl ArcWake for WakerInner {
 /// assert_eq!(count, 2);
 /// ```
 pub fn new_count_waker() -> (Waker, AwokenCount) {
-    let inner = Arc::new(WakerInner { count: AtomicUsize::new(0) });
+    let inner = Arc::new(WakerInner {
+        count: AtomicUsize::new(0),
+    });
     (task::waker(inner.clone()), AwokenCount { inner })
 }

--- a/futures-test/src/task/wake_counter.rs
+++ b/futures-test/src/task/wake_counter.rs
@@ -54,8 +54,6 @@ impl ArcWake for WakerInner {
 /// assert_eq!(count, 2);
 /// ```
 pub fn new_count_waker() -> (Waker, AwokenCount) {
-    let inner = Arc::new(WakerInner {
-        count: AtomicUsize::new(0),
-    });
+    let inner = Arc::new(WakerInner { count: AtomicUsize::new(0) });
     (task::waker(inner.clone()), AwokenCount { inner })
 }

--- a/futures-test/src/track_closed.rs
+++ b/futures-test/src/track_closed.rs
@@ -21,10 +21,7 @@ pub struct TrackClosed<T> {
 
 impl<T> TrackClosed<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            closed: false,
-        }
+        Self { inner, closed: false }
     }
 
     /// Check whether this object has been closed.

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -80,15 +80,17 @@
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "read-initializer", feature(read_initializer))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
-#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -81,12 +81,7 @@
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures/tests/_require_features.rs
+++ b/futures/tests/_require_features.rs
@@ -1,8 +1,13 @@
 #[cfg(not(all(
-    feature = "std", feature = "alloc", feature = "async-await",
-    feature = "compat", feature = "io-compat",
-    feature = "executor", feature = "thread-pool",
+    feature = "std",
+    feature = "alloc",
+    feature = "async-await",
+    feature = "compat",
+    feature = "io-compat",
+    feature = "executor",
+    feature = "thread-pool",
 )))]
-compile_error!("`futures` tests must have all stable features activated: \
+compile_error!(
+    "`futures` tests must have all stable features activated: \
     use `--all-features` or `--features default,thread-pool,io-compat`"
 );

--- a/futures/tests/abortable.rs
+++ b/futures/tests/abortable.rs
@@ -1,8 +1,8 @@
 #[test]
 fn abortable_works() {
     use futures::channel::oneshot;
-    use futures::future::{abortable, Aborted};
     use futures::executor::block_on;
+    use futures::future::{abortable, Aborted};
 
     let (_tx, a_rx) = oneshot::channel::<()>();
     let (abortable_rx, abort_handle) = abortable(a_rx);
@@ -34,8 +34,8 @@ fn abortable_awakens() {
 #[test]
 fn abortable_resolves() {
     use futures::channel::oneshot;
-    use futures::future::abortable;
     use futures::executor::block_on;
+    use futures::future::abortable;
     let (tx, a_rx) = oneshot::channel::<()>();
     let (abortable_rx, _abort_handle) = abortable(a_rx);
 

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -8,9 +8,7 @@ mod countingwaker {
 
     impl CountingWaker {
         fn new() -> Self {
-            Self {
-                nr_wake: Mutex::new(0),
-            }
+            Self { nr_wake: Mutex::new(0) }
         }
 
         fn wakes(&self) -> i32 {
@@ -77,10 +75,7 @@ fn proper_refcount_on_wake_panic() {
     let w1: Waker = task::waker(some_w.clone());
     assert_eq!(
         "WAKE UP",
-        *std::panic::catch_unwind(|| w1.wake_by_ref())
-            .unwrap_err()
-            .downcast::<&str>()
-            .unwrap()
+        *std::panic::catch_unwind(|| w1.wake_by_ref()).unwrap_err().downcast::<&str>().unwrap()
     );
     assert_eq!(2, Arc::strong_count(&some_w)); // some_w + w1
     drop(w1);

--- a/futures/tests/arc_wake.rs
+++ b/futures/tests/arc_wake.rs
@@ -75,7 +75,13 @@ fn proper_refcount_on_wake_panic() {
     let some_w = Arc::new(PanicWaker);
 
     let w1: Waker = task::waker(some_w.clone());
-    assert_eq!("WAKE UP", *std::panic::catch_unwind(|| w1.wake_by_ref()).unwrap_err().downcast::<&str>().unwrap());
+    assert_eq!(
+        "WAKE UP",
+        *std::panic::catch_unwind(|| w1.wake_by_ref())
+            .unwrap_err()
+            .downcast::<&str>()
+            .unwrap()
+    );
     assert_eq!(2, Arc::strong_count(&some_w)); // some_w + w1
     drop(w1);
     assert_eq!(1, Arc::strong_count(&some_w)); // some_w

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -1,8 +1,8 @@
 #[test]
 fn poll_and_pending() {
-    use futures::{pending, pin_mut, poll};
     use futures::executor::block_on;
     use futures::task::Poll;
+    use futures::{pending, pin_mut, poll};
 
     let pending_once = async { pending!() };
     block_on(async {
@@ -14,10 +14,10 @@ fn poll_and_pending() {
 
 #[test]
 fn join() {
-    use futures::{pin_mut, poll, join};
     use futures::channel::oneshot;
     use futures::executor::block_on;
     use futures::task::Poll;
+    use futures::{join, pin_mut, poll};
 
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (tx2, rx2) = oneshot::channel::<i32>();
@@ -39,10 +39,10 @@ fn join() {
 
 #[test]
 fn select() {
-    use futures::select;
     use futures::channel::oneshot;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (_tx2, rx2) = oneshot::channel::<i32>();
@@ -85,9 +85,9 @@ fn select_biased() {
 
 #[test]
 fn select_streams() {
-    use futures::select;
     use futures::channel::mpsc;
     use futures::executor::block_on;
+    use futures::select;
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
 
@@ -134,10 +134,10 @@ fn select_streams() {
 
 #[test]
 fn select_can_move_uncompleted_futures() {
-    use futures::select;
     use futures::channel::oneshot;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (tx2, rx2) = oneshot::channel::<i32>();
@@ -165,9 +165,9 @@ fn select_can_move_uncompleted_futures() {
 
 #[test]
 fn select_nested() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future;
+    use futures::select;
 
     let mut outer_fut = future::ready(1);
     let mut inner_fut = future::ready(2);
@@ -185,8 +185,8 @@ fn select_nested() {
 
 #[test]
 fn select_size() {
-    use futures::select;
     use futures::future;
+    use futures::select;
 
     let fut = async {
         let mut ready = future::ready(0i32);
@@ -209,14 +209,12 @@ fn select_size() {
 
 #[test]
 fn select_on_non_unpin_expressions() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     // The returned Future is !Unpin
-    let make_non_unpin_fut = || { async {
-        5
-    }};
+    let make_non_unpin_fut = || async { 5 };
 
     let res = block_on(async {
         let select_res;
@@ -231,14 +229,12 @@ fn select_on_non_unpin_expressions() {
 
 #[test]
 fn select_on_non_unpin_expressions_with_default() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     // The returned Future is !Unpin
-    let make_non_unpin_fut = || { async {
-        5
-    }};
+    let make_non_unpin_fut = || async { 5 };
 
     let res = block_on(async {
         let select_res;
@@ -254,13 +250,11 @@ fn select_on_non_unpin_expressions_with_default() {
 
 #[test]
 fn select_on_non_unpin_size() {
-    use futures::select;
     use futures::future::FutureExt;
+    use futures::select;
 
     // The returned Future is !Unpin
-    let make_non_unpin_fut = || { async {
-        5
-    }};
+    let make_non_unpin_fut = || async { 5 };
 
     let fut = async {
         let select_res;
@@ -276,9 +270,9 @@ fn select_on_non_unpin_size() {
 
 #[test]
 fn select_can_be_used_as_expression() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future;
+    use futures::select;
 
     block_on(async {
         let res = select! {
@@ -291,9 +285,9 @@ fn select_can_be_used_as_expression() {
 
 #[test]
 fn select_with_default_can_be_used_as_expression() {
-    use futures::select;
     use futures::executor::block_on;
-    use futures::future::{FutureExt, poll_fn};
+    use futures::future::{poll_fn, FutureExt};
+    use futures::select;
     use futures::task::{Context, Poll};
 
     fn poll_always_pending<T>(_cx: &mut Context<'_>) -> Poll<T> {
@@ -312,9 +306,9 @@ fn select_with_default_can_be_used_as_expression() {
 
 #[test]
 fn select_with_complete_can_be_used_as_expression() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future;
+    use futures::select;
 
     block_on(async {
         let res = select! {
@@ -330,9 +324,9 @@ fn select_with_complete_can_be_used_as_expression() {
 #[test]
 #[allow(unused_assignments)]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     async fn require_mutable(_: &mut i32) {}
     async fn async_noop() {}
@@ -351,9 +345,9 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block() {
 #[test]
 #[allow(unused_assignments)]
 fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
-    use futures::select;
     use futures::executor::block_on;
     use futures::future::FutureExt;
+    use futures::select;
 
     async fn require_mutable(_: &mut i32) {}
     async fn async_noop() {}
@@ -374,8 +368,8 @@ fn select_on_mutable_borrowing_future_with_same_borrow_in_block_and_default() {
 
 #[test]
 fn join_size() {
-    use futures::join;
     use futures::future;
+    use futures::join;
 
     let fut = async {
         let ready = future::ready(0i32);
@@ -393,8 +387,8 @@ fn join_size() {
 
 #[test]
 fn try_join_size() {
-    use futures::try_join;
     use futures::future;
+    use futures::try_join;
 
     let fut = async {
         let ready = future::ready(Ok::<i32, i32>(0));
@@ -414,19 +408,12 @@ fn try_join_size() {
 fn join_doesnt_require_unpin() {
     use futures::join;
 
-    let _ = async {
-        join!(async {}, async {})
-    };
+    let _ = async { join!(async {}, async {}) };
 }
 
 #[test]
 fn try_join_doesnt_require_unpin() {
     use futures::try_join;
 
-    let _ = async {
-        try_join!(
-            async { Ok::<(), ()>(()) },
-            async { Ok::<(), ()>(()) },
-        )
-    };
+    let _ = async { try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) },) };
 }

--- a/futures/tests/basic_combinators.rs
+++ b/futures/tests/basic_combinators.rs
@@ -13,17 +13,21 @@ fn basic_future_combinators() {
             tx1.send(x).unwrap(); // Send 1
             tx1.send(2).unwrap(); // Send 2
             future::ready(3)
-        }).map(move |x| {
+        })
+        .map(move |x| {
             tx2.send(x).unwrap(); // Send 3
             tx2.send(4).unwrap(); // Send 4
             5
-        }).map(move |x| {
+        })
+        .map(move |x| {
             tx3.send(x).unwrap(); // Send 5
         });
 
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
-    for i in 1..=5 { assert_eq!(rx.recv(), Ok(i)); } // Check it
+    for i in 1..=5 {
+        assert_eq!(rx.recv(), Ok(i));
+    } // Check it
     assert!(rx.recv().is_err()); // Should be done
 }
 
@@ -93,6 +97,8 @@ fn basic_try_future_combinators() {
 
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
-    for i in 1..=12 { assert_eq!(rx.recv(), Ok(i)); } // Check it
+    for i in 1..=12 {
+        assert_eq!(rx.recv(), Ok(i));
+    } // Check it
     assert!(rx.recv().is_err()); // Should be done
 }

--- a/futures/tests/basic_combinators.rs
+++ b/futures/tests/basic_combinators.rs
@@ -26,8 +26,8 @@ fn basic_future_combinators() {
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
     for i in 1..=5 {
-        assert_eq!(rx.recv(), Ok(i));
-    } // Check it
+        assert_eq!(rx.recv(), Ok(i)); // Check it
+    }
     assert!(rx.recv().is_err()); // Should be done
 }
 
@@ -98,7 +98,7 @@ fn basic_try_future_combinators() {
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
     for i in 1..=12 {
-        assert_eq!(rx.recv(), Ok(i));
-    } // Check it
+        assert_eq!(rx.recv(), Ok(i)); // Check it
+    }
     assert!(rx.recv().is_err()); // Should be done
 }

--- a/futures/tests/buffer_unordered.rs
+++ b/futures/tests/buffer_unordered.rs
@@ -1,7 +1,7 @@
 #[test]
 #[ignore] // FIXME: https://github.com/rust-lang/futures-rs/issues/1790
 fn works() {
-    use futures::channel::{oneshot, mpsc};
+    use futures::channel::{mpsc, oneshot};
     use futures::executor::{block_on, block_on_stream};
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,14 +1,12 @@
-use tokio::timer::Delay;
-use tokio::runtime::Runtime;
-use std::time::Instant;
-use futures::prelude::*;
 use futures::compat::Future01CompatExt;
+use futures::prelude::*;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+use tokio::timer::Delay;
 
 #[test]
 fn can_use_01_futures_in_a_03_future_running_on_a_01_executor() {
-    let f = async {
-        Delay::new(Instant::now()).compat().await
-    };
+    let f = async { Delay::new(Instant::now()).compat().await };
 
     let mut runtime = Runtime::new().unwrap();
     runtime.block_on(f.boxed().compat()).unwrap();

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -80,16 +80,13 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData {
-            _data: tx1,
-            future: rx0.unwrap_or_else(|_| panic!()),
-        }
-        .then(move |_| {
-            assert!(rx1.recv().is_err()); // tx1 should have been dropped
-            tx2.send(()).unwrap();
-            future::ready(())
-        })
-        .run_in_background();
+        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+            .then(move |_| {
+                assert!(rx1.recv().is_err()); // tx1 should have been dropped
+                tx2.send(()).unwrap();
+                future::ready(())
+            })
+            .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(()).unwrap();
@@ -107,16 +104,13 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData {
-            _data: tx1,
-            future: rx0.unwrap_or_else(|_| panic!()),
-        }
-        .and_then(move |_| {
-            assert!(rx1.recv().is_err()); // tx1 should have been dropped
-            tx2.send(()).unwrap();
-            future::ready(Ok(()))
-        })
-        .run_in_background();
+        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+            .and_then(move |_| {
+                assert!(rx1.recv().is_err()); // tx1 should have been dropped
+                tx2.send(()).unwrap();
+                future::ready(Ok(()))
+            })
+            .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(Ok(())).unwrap();
@@ -134,16 +128,13 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData {
-            _data: tx1,
-            future: rx0.unwrap_or_else(|_| panic!()),
-        }
-        .or_else(move |_| {
-            assert!(rx1.recv().is_err()); // tx1 should have been dropped
-            tx2.send(()).unwrap();
-            future::ready::<Result<(), ()>>(Ok(()))
-        })
-        .run_in_background();
+        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+            .or_else(move |_| {
+                assert!(rx1.recv().is_err()); // tx1 should have been dropped
+                tx2.send(()).unwrap();
+                future::ready::<Result<(), ()>>(Ok(()))
+            })
+            .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(Err(())).unwrap();

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -10,7 +10,10 @@ fn map_ok() {
     let (tx2, rx2) = mpsc::channel::<()>();
 
     future::ready::<Result<i32, i32>>(Err(1))
-        .map_ok(move |_| { let _tx1 = tx1; panic!("should not run"); })
+        .map_ok(move |_| {
+            let _tx1 = tx1;
+            panic!("should not run");
+        })
         .map(move |_| {
             assert!(rx1.recv().is_err());
             tx2.send(()).unwrap()
@@ -32,7 +35,10 @@ fn map_err() {
     let (tx2, rx2) = mpsc::channel::<()>();
 
     future::ready::<Result<i32, i32>>(Ok(1))
-        .map_err(move |_| { let _tx1 = tx1; panic!("should not run"); })
+        .map_err(move |_| {
+            let _tx1 = tx1;
+            panic!("should not run");
+        })
         .map(move |_| {
             assert!(rx1.recv().is_err());
             tx2.send(()).unwrap()
@@ -44,7 +50,7 @@ fn map_err() {
 
 mod channelled {
     use futures::future::Future;
-    use futures::task::{Context,Poll};
+    use futures::task::{Context, Poll};
     use pin_project::pin_project;
     use std::pin::Pin;
 
@@ -74,13 +80,16 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| { panic!() }) }
-            .then(move |_| {
-                assert!(rx1.recv().is_err()); // tx1 should have been dropped
-                tx2.send(()).unwrap();
-                future::ready(())
-            })
-            .run_in_background();
+        FutureData {
+            _data: tx1,
+            future: rx0.unwrap_or_else(|_| panic!()),
+        }
+        .then(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready(())
+        })
+        .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(()).unwrap();
@@ -98,13 +107,16 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| { panic!() }) }
-            .and_then(move |_| {
-                assert!(rx1.recv().is_err()); // tx1 should have been dropped
-                tx2.send(()).unwrap();
-                future::ready(Ok(()))
-            })
-            .run_in_background();
+        FutureData {
+            _data: tx1,
+            future: rx0.unwrap_or_else(|_| panic!()),
+        }
+        .and_then(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready(Ok(()))
+        })
+        .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(Ok(())).unwrap();
@@ -122,13 +134,16 @@ mod channelled {
         let (tx1, rx1) = mpsc::channel::<()>();
         let (tx2, rx2) = mpsc::channel::<()>();
 
-        FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| { panic!() }) }
-            .or_else(move |_| {
-                assert!(rx1.recv().is_err()); // tx1 should have been dropped
-                tx2.send(()).unwrap();
-                future::ready::<Result<(), ()>>(Ok(()))
-            })
-            .run_in_background();
+        FutureData {
+            _data: tx1,
+            future: rx0.unwrap_or_else(|_| panic!()),
+        }
+        .or_else(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready::<Result<(), ()>>(Ok(()))
+        })
+        .run_in_background();
 
         assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
         tx0.send(Err(())).unwrap();

--- a/futures/tests/future_obj.rs
+++ b/futures/tests/future_obj.rs
@@ -1,6 +1,6 @@
-use futures::future::{Future, FutureObj, FutureExt};
-use std::pin::Pin;
+use futures::future::{Future, FutureExt, FutureObj};
 use futures::task::{Context, Poll};
+use std::pin::Pin;
 
 #[test]
 fn dropping_does_not_segfault() {

--- a/futures/tests/future_try_flatten_stream.rs
+++ b/futures/tests/future_try_flatten_stream.rs
@@ -25,7 +25,7 @@ fn failed_future() {
     use futures::task::{Context, Poll};
 
     struct PanickingStream<T, E> {
-        _marker: PhantomData<(T, E)>
+        _marker: PhantomData<(T, E)>,
     }
 
     impl<T, E> Stream for PanickingStream<T, E> {
@@ -47,10 +47,10 @@ fn failed_future() {
 fn assert_impls() {
     use core::marker::PhantomData;
     use core::pin::Pin;
+    use futures::future::{ok, TryFutureExt};
     use futures::sink::Sink;
     use futures::stream::Stream;
     use futures::task::{Context, Poll};
-    use futures::future::{ok, TryFutureExt};
 
     struct StreamSink<T, E, Item>(PhantomData<(T, E, Item)>);
 

--- a/futures/tests/futures_ordered.rs
+++ b/futures/tests/futures_ordered.rs
@@ -2,14 +2,16 @@
 fn works_1() {
     use futures::channel::oneshot;
     use futures::executor::block_on_stream;
-    use futures::stream::{StreamExt, FuturesOrdered};
+    use futures::stream::{FuturesOrdered, StreamExt};
     use futures_test::task::noop_context;
 
     let (a_tx, a_rx) = oneshot::channel::<i32>();
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesOrdered<_>>();
+    let mut stream = vec![a_rx, b_rx, c_rx]
+        .into_iter()
+        .collect::<FuturesOrdered<_>>();
 
     b_tx.send(99).unwrap();
     assert!(stream.poll_next_unpin(&mut noop_context()).is_pending());
@@ -28,7 +30,7 @@ fn works_1() {
 fn works_2() {
     use futures::channel::oneshot;
     use futures::future::{join, FutureExt};
-    use futures::stream::{StreamExt, FuturesOrdered};
+    use futures::stream::{FuturesOrdered, StreamExt};
     use futures_test::task::noop_context;
 
     let (a_tx, a_rx) = oneshot::channel::<i32>();
@@ -38,7 +40,9 @@ fn works_2() {
     let mut stream = vec![
         a_rx.boxed(),
         join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed(),
-    ].into_iter().collect::<FuturesOrdered<_>>();
+    ]
+    .into_iter()
+    .collect::<FuturesOrdered<_>>();
 
     let mut cx = noop_context();
     a_tx.send(33).unwrap();
@@ -53,22 +57,24 @@ fn works_2() {
 fn from_iterator() {
     use futures::executor::block_on;
     use futures::future;
-    use futures::stream::{StreamExt, FuturesOrdered};
+    use futures::stream::{FuturesOrdered, StreamExt};
 
     let stream = vec![
         future::ready::<i32>(1),
         future::ready::<i32>(2),
-        future::ready::<i32>(3)
-    ].into_iter().collect::<FuturesOrdered<_>>();
+        future::ready::<i32>(3),
+    ]
+    .into_iter()
+    .collect::<FuturesOrdered<_>>();
     assert_eq!(stream.len(), 3);
-    assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1,2,3]);
+    assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }
 
 #[test]
 fn queue_never_unblocked() {
     use futures::channel::oneshot;
     use futures::future::{self, Future, TryFutureExt};
-    use futures::stream::{StreamExt, FuturesOrdered};
+    use futures::stream::{FuturesOrdered, StreamExt};
     use futures_test::task::noop_context;
     use std::any::Any;
 
@@ -78,10 +84,14 @@ fn queue_never_unblocked() {
 
     let mut stream = vec![
         Box::new(a_rx) as Box<dyn Future<Output = _> + Unpin>,
-        Box::new(future::try_select(b_rx, c_rx)
-            .map_err(|e| e.factor_first().0)
-            .and_then(|e| future::ok(Box::new(e) as Box<dyn Any + Send>))) as _,
-    ].into_iter().collect::<FuturesOrdered<_>>();
+        Box::new(
+            future::try_select(b_rx, c_rx)
+                .map_err(|e| e.factor_first().0)
+                .and_then(|e| future::ok(Box::new(e) as Box<dyn Any + Send>)),
+        ) as _,
+    ]
+    .into_iter()
+    .collect::<FuturesOrdered<_>>();
 
     let cx = &mut noop_context();
     for _ in 0..10 {

--- a/futures/tests/futures_ordered.rs
+++ b/futures/tests/futures_ordered.rs
@@ -9,9 +9,7 @@ fn works_1() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![a_rx, b_rx, c_rx]
-        .into_iter()
-        .collect::<FuturesOrdered<_>>();
+    let mut stream = vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesOrdered<_>>();
 
     b_tx.send(99).unwrap();
     assert!(stream.poll_next_unpin(&mut noop_context()).is_pending());
@@ -37,12 +35,9 @@ fn works_2() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![
-        a_rx.boxed(),
-        join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed(),
-    ]
-    .into_iter()
-    .collect::<FuturesOrdered<_>>();
+    let mut stream = vec![a_rx.boxed(), join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed()]
+        .into_iter()
+        .collect::<FuturesOrdered<_>>();
 
     let mut cx = noop_context();
     a_tx.send(33).unwrap();
@@ -59,13 +54,9 @@ fn from_iterator() {
     use futures::future;
     use futures::stream::{FuturesOrdered, StreamExt};
 
-    let stream = vec![
-        future::ready::<i32>(1),
-        future::ready::<i32>(2),
-        future::ready::<i32>(3),
-    ]
-    .into_iter()
-    .collect::<FuturesOrdered<_>>();
+    let stream = vec![future::ready::<i32>(1), future::ready::<i32>(2), future::ready::<i32>(3)]
+        .into_iter()
+        .collect::<FuturesOrdered<_>>();
     assert_eq!(stream.len(), 3);
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }

--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -104,11 +104,11 @@ fn from_iterator() {
 
 #[test]
 fn finished_future() {
-    use std::marker::Unpin;
     use futures::channel::oneshot;
     use futures::future::{self, Future, FutureExt};
     use futures::stream::{FuturesUnordered, StreamExt};
     use futures_test::task::noop_context;
+    use std::marker::Unpin;
 
     let (_a_tx, a_rx) = oneshot::channel::<i32>();
     let (b_tx, b_rx) = oneshot::channel::<i32>();
@@ -217,7 +217,10 @@ fn iter_cancel() {
 
     impl<F: Future + Unpin> AtomicCancel<F> {
         fn new(future: F) -> Self {
-            Self { future, cancel: AtomicBool::new(false) }
+            Self {
+                future,
+                cancel: AtomicBool::new(false),
+            }
         }
     }
 

--- a/futures/tests/futures_unordered.rs
+++ b/futures/tests/futures_unordered.rs
@@ -40,11 +40,8 @@ fn works_1() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut iter = block_on_stream(
-        vec![a_rx, b_rx, c_rx]
-            .into_iter()
-            .collect::<FuturesUnordered<_>>(),
-    );
+    let mut iter =
+        block_on_stream(vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesUnordered<_>>());
 
     b_tx.send(99).unwrap();
     assert_eq!(Some(Ok(99)), iter.next());
@@ -68,12 +65,9 @@ fn works_2() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![
-        a_rx.boxed(),
-        join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let mut stream = vec![a_rx.boxed(), join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed()]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
 
     a_tx.send(9).unwrap();
     b_tx.send(10).unwrap();
@@ -91,13 +85,9 @@ fn from_iterator() {
     use futures::future;
     use futures::stream::{FuturesUnordered, StreamExt};
 
-    let stream = vec![
-        future::ready::<i32>(1),
-        future::ready::<i32>(2),
-        future::ready::<i32>(3),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let stream = vec![future::ready::<i32>(1), future::ready::<i32>(2), future::ready::<i32>(3)]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
     assert_eq!(stream.len(), 3);
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }
@@ -143,9 +133,7 @@ fn iter_mut_cancel() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![a_rx, b_rx, c_rx]
-        .into_iter()
-        .collect::<FuturesUnordered<_>>();
+    let mut stream = vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesUnordered<_>>();
 
     for rx in stream.iter_mut() {
         rx.close();
@@ -168,13 +156,10 @@ fn iter_mut_len() {
     use futures::future;
     use futures::stream::FuturesUnordered;
 
-    let mut stream = vec![
-        future::pending::<()>(),
-        future::pending::<()>(),
-        future::pending::<()>(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let mut stream =
+        vec![future::pending::<()>(), future::pending::<()>(), future::pending::<()>()]
+            .into_iter()
+            .collect::<FuturesUnordered<_>>();
 
     let mut iter_mut = stream.iter_mut();
     assert_eq!(iter_mut.len(), 3);
@@ -217,10 +202,7 @@ fn iter_cancel() {
 
     impl<F: Future + Unpin> AtomicCancel<F> {
         fn new(future: F) -> Self {
-            Self {
-                future,
-                cancel: AtomicBool::new(false),
-            }
+            Self { future, cancel: AtomicBool::new(false) }
         }
     }
 
@@ -249,13 +231,9 @@ fn iter_len() {
     use futures::future;
     use futures::stream::FuturesUnordered;
 
-    let stream = vec![
-        future::pending::<()>(),
-        future::pending::<()>(),
-        future::pending::<()>(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let stream = vec![future::pending::<()>(), future::pending::<()>(), future::pending::<()>()]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
 
     let mut iter = stream.iter();
     assert_eq!(iter.len(), 3);

--- a/futures/tests/inspect.rs
+++ b/futures/tests/inspect.rs
@@ -6,7 +6,9 @@ fn smoke() {
     let mut counter = 0;
 
     {
-        let work = future::ready::<i32>(40).inspect(|val| { counter += *val; });
+        let work = future::ready::<i32>(40).inspect(|val| {
+            counter += *val;
+        });
         assert_eq!(block_on(work), 40);
     }
 

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -1,7 +1,7 @@
 macro_rules! run_fill_buf {
     ($reader:expr) => {{
-        use futures_test::task::noop_context;
         use futures::task::Poll;
+        use futures_test::task::noop_context;
         use std::pin::Pin;
 
         let mut cx = noop_context();
@@ -16,9 +16,9 @@ macro_rules! run_fill_buf {
 mod util {
     use futures::future::Future;
     pub fn run<F: Future + Unpin>(mut f: F) -> F::Output {
-        use futures_test::task::noop_context;
-        use futures::task::Poll;
         use futures::future::FutureExt;
+        use futures::task::Poll;
+        use futures_test::task::noop_context;
 
         let mut cx = noop_context();
         loop {
@@ -30,10 +30,10 @@ mod util {
 }
 
 mod maybe_pending {
-    use futures::task::{Context,Poll};
-    use std::{cmp,io};
+    use futures::io::{AsyncBufRead, AsyncRead};
+    use futures::task::{Context, Poll};
     use std::pin::Pin;
-    use futures::io::{AsyncRead,AsyncBufRead};
+    use std::{cmp, io};
 
     pub struct MaybePending<'a> {
         inner: &'a [u8],
@@ -43,14 +43,20 @@ mod maybe_pending {
 
     impl<'a> MaybePending<'a> {
         pub fn new(inner: &'a [u8]) -> Self {
-            Self { inner, ready_read: false, ready_fill_buf: false }
+            Self {
+                inner,
+                ready_read: false,
+                ready_fill_buf: false,
+            }
         }
     }
 
     impl AsyncRead for MaybePending<'_> {
-        fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
             if self.ready_read {
                 self.ready_read = false;
                 Pin::new(&mut self.inner).poll_read(cx, buf)
@@ -62,12 +68,12 @@ mod maybe_pending {
     }
 
     impl AsyncBufRead for MaybePending<'_> {
-        fn poll_fill_buf(mut self: Pin<&mut Self>, _: &mut Context<'_>)
-            -> Poll<io::Result<&[u8]>>
-        {
+        fn poll_fill_buf(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
             if self.ready_fill_buf {
                 self.ready_fill_buf = false;
-                if self.inner.is_empty() { return Poll::Ready(Ok(&[])) }
+                if self.inner.is_empty() {
+                    return Poll::Ready(Ok(&[]));
+                }
                 let len = cmp::min(2, self.inner.len());
                 Poll::Ready(Ok(&self.inner[0..len]))
             } else {
@@ -125,7 +131,7 @@ fn test_buffered_reader() {
 #[test]
 fn test_buffered_reader_seek() {
     use futures::executor::block_on;
-    use futures::io::{AsyncSeekExt, AsyncBufRead, BufReader, Cursor, SeekFrom};
+    use futures::io::{AsyncBufRead, AsyncSeekExt, BufReader, Cursor, SeekFrom};
     use std::pin::Pin;
     use util::run;
 
@@ -134,7 +140,10 @@ fn test_buffered_reader_seek() {
 
     assert_eq!(block_on(reader.seek(SeekFrom::Start(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
+    assert_eq!(
+        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
+        None
+    );
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(block_on(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));
@@ -145,12 +154,12 @@ fn test_buffered_reader_seek() {
 #[test]
 fn test_buffered_reader_seek_underflow() {
     use futures::executor::block_on;
-    use futures::io::{AsyncSeekExt, AsyncBufRead, AllowStdIo, BufReader, SeekFrom};
+    use futures::io::{AllowStdIo, AsyncBufRead, AsyncSeekExt, BufReader, SeekFrom};
     use std::io;
 
     // gimmick reader that yields its position modulo 256 for each byte
     struct PositionReader {
-        pos: u64
+        pos: u64,
     }
     impl io::Read for PositionReader {
         fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -181,21 +190,30 @@ fn test_buffered_reader_seek_underflow() {
 
     let mut reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1, 2, 3, 4][..]));
-    assert_eq!(block_on(reader.seek(SeekFrom::End(-5))).ok(), Some(u64::max_value()-5));
+    assert_eq!(
+        block_on(reader.seek(SeekFrom::End(-5))).ok(),
+        Some(u64::max_value() - 5)
+    );
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // the following seek will require two underlying seeks
     let expected = 9_223_372_036_854_775_802;
-    assert_eq!(block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), Some(expected));
+    assert_eq!(
+        block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
+        Some(expected)
+    );
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // seeking to 0 should empty the buffer.
-    assert_eq!(block_on(reader.seek(SeekFrom::Current(0))).ok(), Some(expected));
+    assert_eq!(
+        block_on(reader.seek(SeekFrom::Current(0))).ok(),
+        Some(expected)
+    );
     assert_eq!(reader.get_ref().get_ref().pos, expected);
 }
 
 #[test]
 fn test_short_reads() {
     use futures::executor::block_on;
-    use futures::io::{AsyncReadExt, AllowStdIo, BufReader};
+    use futures::io::{AllowStdIo, AsyncReadExt, BufReader};
     use std::io;
 
     /// A dummy reader intended at testing short-reads propagation.
@@ -213,7 +231,9 @@ fn test_short_reads() {
         }
     }
 
-    let inner = ShortReader { lengths: vec![0, 1, 2, 0, 1, 0] };
+    let inner = ShortReader {
+        lengths: vec![0, 1, 2, 0, 1, 0],
+    };
     let mut reader = BufReader::new(AllowStdIo::new(inner));
     let mut buf = [0, 0];
     assert_eq!(block_on(reader.read(&mut buf)).unwrap(), 0);
@@ -228,8 +248,8 @@ fn test_short_reads() {
 #[test]
 fn maybe_pending() {
     use futures::io::{AsyncReadExt, BufReader};
-    use util::run;
     use maybe_pending::MaybePending;
+    use util::run;
 
     let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
     let mut reader = BufReader::with_capacity(2, MaybePending::new(inner));
@@ -269,8 +289,8 @@ fn maybe_pending() {
 #[test]
 fn maybe_pending_buf_read() {
     use futures::io::{AsyncBufReadExt, BufReader};
-    use util::run;
     use maybe_pending::MaybePending;
+    use util::run;
 
     let inner = MaybePending::new(&[0, 1, 2, 3, 1, 0]);
     let mut reader = BufReader::with_capacity(2, inner);
@@ -291,10 +311,10 @@ fn maybe_pending_buf_read() {
 // https://github.com/rust-lang/futures-rs/pull/1573#discussion_r281162309
 #[test]
 fn maybe_pending_seek() {
-    use futures::io::{AsyncBufRead, AsyncSeek, AsyncSeekExt, AsyncRead, BufReader,
-        Cursor, SeekFrom
+    use futures::io::{
+        AsyncBufRead, AsyncRead, AsyncSeek, AsyncSeekExt, BufReader, Cursor, SeekFrom,
     };
-    use futures::task::{Context,Poll};
+    use futures::task::{Context, Poll};
     use std::io;
     use std::pin::Pin;
     use util::run;
@@ -305,22 +325,28 @@ fn maybe_pending_seek() {
 
     impl<'a> MaybePendingSeek<'a> {
         pub fn new(inner: &'a [u8]) -> Self {
-            Self { inner: Cursor::new(inner), ready: true }
+            Self {
+                inner: Cursor::new(inner),
+                ready: true,
+            }
         }
     }
 
     impl AsyncRead for MaybePendingSeek<'_> {
-        fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
             Pin::new(&mut self.inner).poll_read(cx, buf)
         }
     }
 
     impl AsyncBufRead for MaybePendingSeek<'_> {
-        fn poll_fill_buf(mut self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<io::Result<&[u8]>>
-        {
+        fn poll_fill_buf(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<io::Result<&[u8]>> {
             let this: *mut Self = &mut *self as *mut _;
             Pin::new(&mut unsafe { &mut *this }.inner).poll_fill_buf(cx)
         }
@@ -331,9 +357,11 @@ fn maybe_pending_seek() {
     }
 
     impl AsyncSeek for MaybePendingSeek<'_> {
-        fn poll_seek(mut self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<io::Result<u64>>
-        {
+        fn poll_seek(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<io::Result<u64>> {
             if self.ready {
                 self.ready = false;
                 Pin::new(&mut self.inner).poll_seek(cx, pos)
@@ -349,7 +377,10 @@ fn maybe_pending_seek() {
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
+    assert_eq!(
+        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
+        None
+    );
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(run(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -43,11 +43,7 @@ mod maybe_pending {
 
     impl<'a> MaybePending<'a> {
         pub fn new(inner: &'a [u8]) -> Self {
-            Self {
-                inner,
-                ready_read: false,
-                ready_fill_buf: false,
-            }
+            Self { inner, ready_read: false, ready_fill_buf: false }
         }
     }
 
@@ -140,10 +136,7 @@ fn test_buffered_reader_seek() {
 
     assert_eq!(block_on(reader.seek(SeekFrom::Start(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(
-        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        None
-    );
+    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(block_on(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));
@@ -190,23 +183,14 @@ fn test_buffered_reader_seek_underflow() {
 
     let mut reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1, 2, 3, 4][..]));
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::End(-5))).ok(),
-        Some(u64::max_value() - 5)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::End(-5))).ok(), Some(u64::max_value() - 5));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // the following seek will require two underlying seeks
     let expected = 9_223_372_036_854_775_802;
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        Some(expected)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), Some(expected));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // seeking to 0 should empty the buffer.
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::Current(0))).ok(),
-        Some(expected)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::Current(0))).ok(), Some(expected));
     assert_eq!(reader.get_ref().get_ref().pos, expected);
 }
 
@@ -231,9 +215,7 @@ fn test_short_reads() {
         }
     }
 
-    let inner = ShortReader {
-        lengths: vec![0, 1, 2, 0, 1, 0],
-    };
+    let inner = ShortReader { lengths: vec![0, 1, 2, 0, 1, 0] };
     let mut reader = BufReader::new(AllowStdIo::new(inner));
     let mut buf = [0, 0];
     assert_eq!(block_on(reader.read(&mut buf)).unwrap(), 0);
@@ -325,10 +307,7 @@ fn maybe_pending_seek() {
 
     impl<'a> MaybePendingSeek<'a> {
         pub fn new(inner: &'a [u8]) -> Self {
-            Self {
-                inner: Cursor::new(inner),
-                ready: true,
-            }
+            Self { inner: Cursor::new(inner), ready: true }
         }
     }
 
@@ -377,10 +356,7 @@ fn maybe_pending_seek() {
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(
-        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        None
-    );
+    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(run(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));

--- a/futures/tests/io_buf_writer.rs
+++ b/futures/tests/io_buf_writer.rs
@@ -11,7 +11,10 @@ mod maybe_pending {
 
     impl MaybePending {
         pub fn new(inner: Vec<u8>) -> Self {
-            Self { inner, ready: false }
+            Self {
+                inner,
+                ready: false,
+            }
         }
     }
 
@@ -173,11 +176,17 @@ fn maybe_pending_buf_writer() {
 
     run(writer.write(&[9, 10, 11])).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    assert_eq!(
+        writer.get_ref().inner,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    );
 
     run(writer.flush()).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(&writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    assert_eq!(
+        &writer.get_ref().inner,
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    );
 }
 
 #[test]
@@ -197,7 +206,9 @@ fn maybe_pending_buf_writer_inner_flushes() {
 
 #[test]
 fn maybe_pending_buf_writer_seek() {
-    use futures::io::{AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter, Cursor, SeekFrom};
+    use futures::io::{
+        AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, BufWriter, Cursor, SeekFrom,
+    };
     use futures::task::{Context, Poll};
     use std::io;
     use std::pin::Pin;
@@ -212,7 +223,11 @@ fn maybe_pending_buf_writer_seek() {
 
     impl MaybePendingSeek {
         fn new(inner: Vec<u8>) -> Self {
-            Self { inner: Cursor::new(inner), ready_write: false, ready_seek: false }
+            Self {
+                inner: Cursor::new(inner),
+                ready_write: false,
+                ready_seek: false,
+            }
         }
     }
 
@@ -241,9 +256,11 @@ fn maybe_pending_buf_writer_seek() {
     }
 
     impl AsyncSeek for MaybePendingSeek {
-        fn poll_seek(mut self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<io::Result<u64>>
-        {
+        fn poll_seek(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<io::Result<u64>> {
             if self.ready_seek {
                 self.ready_seek = false;
                 Pin::new(&mut self.inner).poll_seek(cx, pos)
@@ -260,9 +277,15 @@ fn maybe_pending_buf_writer_seek() {
     run(w.write_all(&[0, 1, 2, 3, 4, 5])).unwrap();
     run(w.write_all(&[6, 7])).unwrap();
     assert_eq!(run(w.seek(SeekFrom::Current(0))).ok(), Some(8));
-    assert_eq!(&w.get_ref().inner.get_ref()[..], &[0, 1, 2, 3, 4, 5, 6, 7][..]);
+    assert_eq!(
+        &w.get_ref().inner.get_ref()[..],
+        &[0, 1, 2, 3, 4, 5, 6, 7][..]
+    );
     assert_eq!(run(w.seek(SeekFrom::Start(2))).ok(), Some(2));
     run(w.write_all(&[8, 9])).unwrap();
     run(w.flush()).unwrap();
-    assert_eq!(&w.into_inner().inner.into_inner()[..], &[0, 1, 8, 9, 4, 5, 6, 7]);
+    assert_eq!(
+        &w.into_inner().inner.into_inner()[..],
+        &[0, 1, 8, 9, 4, 5, 6, 7]
+    );
 }

--- a/futures/tests/io_buf_writer.rs
+++ b/futures/tests/io_buf_writer.rs
@@ -11,10 +11,7 @@ mod maybe_pending {
 
     impl MaybePending {
         pub fn new(inner: Vec<u8>) -> Self {
-            Self {
-                inner,
-                ready: false,
-            }
+            Self { inner, ready: false }
         }
     }
 
@@ -176,17 +173,11 @@ fn maybe_pending_buf_writer() {
 
     run(writer.write(&[9, 10, 11])).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(
-        writer.get_ref().inner,
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    );
+    assert_eq!(writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     run(writer.flush()).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(
-        &writer.get_ref().inner,
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    );
+    assert_eq!(&writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 }
 
 #[test]
@@ -223,11 +214,7 @@ fn maybe_pending_buf_writer_seek() {
 
     impl MaybePendingSeek {
         fn new(inner: Vec<u8>) -> Self {
-            Self {
-                inner: Cursor::new(inner),
-                ready_write: false,
-                ready_seek: false,
-            }
+            Self { inner: Cursor::new(inner), ready_write: false, ready_seek: false }
         }
     }
 
@@ -277,15 +264,9 @@ fn maybe_pending_buf_writer_seek() {
     run(w.write_all(&[0, 1, 2, 3, 4, 5])).unwrap();
     run(w.write_all(&[6, 7])).unwrap();
     assert_eq!(run(w.seek(SeekFrom::Current(0))).ok(), Some(8));
-    assert_eq!(
-        &w.get_ref().inner.get_ref()[..],
-        &[0, 1, 2, 3, 4, 5, 6, 7][..]
-    );
+    assert_eq!(&w.get_ref().inner.get_ref()[..], &[0, 1, 2, 3, 4, 5, 6, 7][..]);
     assert_eq!(run(w.seek(SeekFrom::Start(2))).ok(), Some(2));
     run(w.write_all(&[8, 9])).unwrap();
     run(w.flush()).unwrap();
-    assert_eq!(
-        &w.into_inner().inner.into_inner()[..],
-        &[0, 1, 8, 9, 4, 5, 6, 7]
-    );
+    assert_eq!(&w.into_inner().inner.into_inner()[..], &[0, 1, 8, 9, 4, 5, 6, 7]);
 }

--- a/futures/tests/io_cursor.rs
+++ b/futures/tests/io_cursor.rs
@@ -8,22 +8,10 @@ fn cursor_asyncwrite_vec() {
 
     let mut cursor = Cursor::new(vec![0; 5]);
     futures::executor::block_on(lazy(|cx| {
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
-            Poll::Ready(Ok(2))
-        );
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(2)));
     }));
     assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5, 6, 6, 7]);
 }
@@ -38,22 +26,10 @@ fn cursor_asyncwrite_box() {
 
     let mut cursor = Cursor::new(vec![0; 5].into_boxed_slice());
     futures::executor::block_on(lazy(|cx| {
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
-            Poll::Ready(Ok(1))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
-            Poll::Ready(Ok(0))
-        );
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(1)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(0)));
     }));
     assert_eq!(&*cursor.into_inner(), [1, 2, 3, 4, 5]);
 }

--- a/futures/tests/io_cursor.rs
+++ b/futures/tests/io_cursor.rs
@@ -8,10 +8,22 @@ fn cursor_asyncwrite_vec() {
 
     let mut cursor = Cursor::new(vec![0; 5]);
     futures::executor::block_on(lazy(|cx| {
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(2)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(2)));
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
+            Poll::Ready(Ok(2))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
+            Poll::Ready(Ok(2))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
+            Poll::Ready(Ok(2))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
+            Poll::Ready(Ok(2))
+        );
     }));
     assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5, 6, 6, 7]);
 }
@@ -26,10 +38,22 @@ fn cursor_asyncwrite_box() {
 
     let mut cursor = Cursor::new(vec![0; 5].into_boxed_slice());
     futures::executor::block_on(lazy(|cx| {
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(1)));
-        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(0)));
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
+            Poll::Ready(Ok(2))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
+            Poll::Ready(Ok(2))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
+            Poll::Ready(Ok(1))
+        );
+        assert_matches!(
+            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
+            Poll::Ready(Ok(0))
+        );
     }));
     assert_eq!(&*cursor.into_inner(), [1, 2, 3, 4, 5]);
 }

--- a/futures/tests/io_lines.rs
+++ b/futures/tests/io_lines.rs
@@ -53,10 +53,8 @@ fn maybe_pending() {
         };
     }
 
-    let buf = stream::iter(vec![&b"12"[..], &b"\r"[..]])
-        .map(Ok)
-        .into_async_read()
-        .interleave_pending();
+    let buf =
+        stream::iter(vec![&b"12"[..], &b"\r"[..]]).map(Ok).into_async_read().interleave_pending();
     let mut s = buf.lines();
     assert_eq!(run_next!(s), "12\r".to_string());
     assert!(run(s.next()).is_none());

--- a/futures/tests/io_lines.rs
+++ b/futures/tests/io_lines.rs
@@ -2,9 +2,9 @@ mod util {
     use futures::future::Future;
 
     pub fn run<F: Future + Unpin>(mut f: F) -> F::Output {
-        use futures_test::task::noop_context;
-        use futures::task::Poll;
         use futures::future::FutureExt;
+        use futures::task::Poll;
+        use futures_test::task::noop_context;
 
         let mut cx = noop_context();
         loop {
@@ -18,8 +18,8 @@ mod util {
 #[test]
 fn lines() {
     use futures::executor::block_on;
-    use futures::stream::StreamExt;
     use futures::io::{AsyncBufReadExt, Cursor};
+    use futures::stream::StreamExt;
 
     macro_rules! block_on_next {
         ($expr:expr) => {
@@ -41,8 +41,8 @@ fn lines() {
 
 #[test]
 fn maybe_pending() {
-    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures::io::AsyncBufReadExt;
+    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures_test::io::AsyncReadTestExt;
 
     use util::run;

--- a/futures/tests/io_read.rs
+++ b/futures/tests/io_read.rs
@@ -18,7 +18,7 @@ mod mock_reader {
         fn poll_read(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
-            buf: &mut [u8]
+            buf: &mut [u8],
         ) -> Poll<io::Result<usize>> {
             (self.get_mut().fun)(buf)
         }

--- a/futures/tests/io_read_exact.rs
+++ b/futures/tests/io_read_exact.rs
@@ -8,7 +8,7 @@ fn read_exact() {
 
     let res = block_on(reader.read_exact(&mut out)); // read 3 bytes out
     assert!(res.is_ok());
-    assert_eq!(out, [1,2,3]);
+    assert_eq!(out, [1, 2, 3]);
     assert_eq!(reader.len(), 2);
 
     let res = block_on(reader.read_exact(&mut out)); // read another 3 bytes, but only 2 bytes left

--- a/futures/tests/io_read_line.rs
+++ b/futures/tests/io_read_line.rs
@@ -46,10 +46,8 @@ fn maybe_pending() {
     assert_eq!(run(buf.read_line(&mut v)).unwrap(), 2);
     assert_eq!(v, "12");
 
-    let mut buf = stream::iter(vec![&b"12"[..], &b"\n\n"[..]])
-        .map(Ok)
-        .into_async_read()
-        .interleave_pending();
+    let mut buf =
+        stream::iter(vec![&b"12"[..], &b"\n\n"[..]]).map(Ok).into_async_read().interleave_pending();
     let mut v = String::new();
     assert_eq!(run(buf.read_line(&mut v)).unwrap(), 3);
     assert_eq!(v, "12\n");

--- a/futures/tests/io_read_line.rs
+++ b/futures/tests/io_read_line.rs
@@ -37,8 +37,8 @@ fn maybe_pending() {
         }
     }
 
-    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures::io::AsyncBufReadExt;
+    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures_test::io::AsyncReadTestExt;
 
     let mut buf = b"12".interleave_pending();

--- a/futures/tests/io_read_to_string.rs
+++ b/futures/tests/io_read_to_string.rs
@@ -21,14 +21,14 @@ fn read_to_string() {
 #[test]
 fn interleave_pending() {
     use futures::future::Future;
-    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures::io::AsyncReadExt;
+    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures_test::io::AsyncReadTestExt;
 
     fn run<F: Future + Unpin>(mut f: F) -> F::Output {
         use futures::future::FutureExt;
-        use futures_test::task::noop_context;
         use futures::task::Poll;
+        use futures_test::task::noop_context;
 
         let mut cx = noop_context();
         loop {

--- a/futures/tests/io_read_until.rs
+++ b/futures/tests/io_read_until.rs
@@ -26,8 +26,8 @@ fn maybe_pending() {
 
     fn run<F: Future + Unpin>(mut f: F) -> F::Output {
         use futures::future::FutureExt;
-        use futures_test::task::noop_context;
         use futures::task::Poll;
+        use futures_test::task::noop_context;
 
         let mut cx = noop_context();
         loop {
@@ -37,8 +37,8 @@ fn maybe_pending() {
         }
     }
 
-    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures::io::AsyncBufReadExt;
+    use futures::stream::{self, StreamExt, TryStreamExt};
     use futures_test::io::AsyncReadTestExt;
 
     let mut buf = b"12".interleave_pending();

--- a/futures/tests/io_write.rs
+++ b/futures/tests/io_write.rs
@@ -74,11 +74,7 @@ fn write_vectored_first_non_empty() {
         Poll::Ready(Ok(4))
     });
     let cx = &mut panic_context();
-    let bufs = &mut [
-        io::IoSlice::new(&[]),
-        io::IoSlice::new(&[]),
-        io::IoSlice::new(b"four"),
-    ];
+    let bufs = &mut [io::IoSlice::new(&[]), io::IoSlice::new(&[]), io::IoSlice::new(b"four")];
 
     let res = Pin::new(&mut writer).poll_write_vectored(cx, bufs);
     let res = res.map_err(|e| e.kind());

--- a/futures/tests/io_write.rs
+++ b/futures/tests/io_write.rs
@@ -77,7 +77,7 @@ fn write_vectored_first_non_empty() {
     let bufs = &mut [
         io::IoSlice::new(&[]),
         io::IoSlice::new(&[]),
-        io::IoSlice::new(b"four")
+        io::IoSlice::new(b"four"),
     ];
 
     let res = Pin::new(&mut writer).poll_write_vectored(cx, bufs);

--- a/futures/tests/join_all.rs
+++ b/futures/tests/join_all.rs
@@ -1,6 +1,6 @@
 mod util {
-    use std::future::Future;
     use std::fmt::Debug;
+    use std::future::Future;
 
     pub fn assert_done<T, F>(actual_fut: F, expected: T)
     where
@@ -16,7 +16,7 @@ mod util {
 
 #[test]
 fn collect_collects() {
-    use futures_util::future::{join_all,ready};
+    use futures_util::future::{join_all, ready};
 
     util::assert_done(|| Box::new(join_all(vec![ready(1), ready(2)])), vec![1, 2]);
     util::assert_done(|| Box::new(join_all(vec![ready(1)])), vec![1]);
@@ -28,7 +28,7 @@ fn collect_collects() {
 
 #[test]
 fn join_all_iter_lifetime() {
-    use futures_util::future::{join_all,ready};
+    use futures_util::future::{join_all, ready};
     use std::future::Future;
     // In futures-rs version 0.1, this function would fail to typecheck due to an overly
     // conservative type parameterization of `JoinAll`.
@@ -37,12 +37,12 @@ fn join_all_iter_lifetime() {
         Box::new(join_all(iter))
     }
 
-    util::assert_done(|| sizes(vec![&[1,2,3], &[], &[0]]), vec![3_usize, 0, 1]);
+    util::assert_done(|| sizes(vec![&[1, 2, 3], &[], &[0]]), vec![3_usize, 0, 1]);
 }
 
 #[test]
 fn join_all_from_iter() {
-    use futures_util::future::{JoinAll,ready};
+    use futures_util::future::{ready, JoinAll};
 
     util::assert_done(
         || Box::new(vec![ready(1), ready(2)].into_iter().collect::<JoinAll<_>>()),

--- a/futures/tests/macro-reexport/src/lib.rs
+++ b/futures/tests/macro-reexport/src/lib.rs
@@ -1,8 +1,7 @@
 // normal reexport
-pub use futures03::{join, try_join, select, select_biased};
+pub use futures03::{join, select, select_biased, try_join};
 
 // reexport + rename
 pub use futures03::{
-    join as join2, try_join as try_join2,
-    select as select2, select_biased as select_biased2,
+    join as join2, select as select2, select_biased as select_biased2, try_join as try_join2,
 };

--- a/futures/tests/macro-tests/src/main.rs
+++ b/futures/tests/macro-tests/src/main.rs
@@ -65,5 +65,4 @@ fn main() {
             _ = b => unreachable!(),
         };
     });
-
 }

--- a/futures/tests/macro_comma_support.rs
+++ b/futures/tests/macro_comma_support.rs
@@ -1,11 +1,6 @@
 #[test]
 fn ready() {
-    use futures::{
-        executor::block_on,
-        future,
-        task::Poll,
-        ready,
-    };
+    use futures::{executor::block_on, future, ready, task::Poll};
 
     block_on(future::poll_fn(|_| {
         ready!(Poll::Ready(()),);
@@ -15,11 +10,7 @@ fn ready() {
 
 #[test]
 fn poll() {
-    use futures::{
-        executor::block_on,
-        future::FutureExt,
-        poll,
-    };
+    use futures::{executor::block_on, future::FutureExt, poll};
 
     block_on(async {
         let _ = poll!(async {}.boxed(),);
@@ -28,10 +19,7 @@ fn poll() {
 
 #[test]
 fn join() {
-    use futures::{
-        executor::block_on,
-        join
-    };
+    use futures::{executor::block_on, join};
 
     block_on(async {
         let future1 = async { 1 };
@@ -42,11 +30,7 @@ fn join() {
 
 #[test]
 fn try_join() {
-    use futures::{
-        executor::block_on,
-        future::FutureExt,
-        try_join,
-    };
+    use futures::{executor::block_on, future::FutureExt, try_join};
 
     block_on(async {
         let future1 = async { 1 }.never_error();

--- a/futures/tests/mutex.rs
+++ b/futures/tests/mutex.rs
@@ -45,10 +45,7 @@ fn mutex_contested() {
     use std::sync::Arc;
 
     let (tx, mut rx) = mpsc::unbounded();
-    let pool = futures::executor::ThreadPool::builder()
-        .pool_size(16)
-        .create()
-        .unwrap();
+    let pool = futures::executor::ThreadPool::builder().pool_size(16).create().unwrap();
 
     let tx = Arc::new(tx);
     let mutex = Arc::new(Mutex::new(0));

--- a/futures/tests/oneshot.rs
+++ b/futures/tests/oneshot.rs
@@ -27,8 +27,7 @@ fn oneshot_send2() {
     let (tx2, rx2) = mpsc::channel();
 
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
-    rx1.map_ok(move |x| tx2.send(x).unwrap())
-        .run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
     assert_eq!(1, rx2.recv().unwrap());
 }
 
@@ -43,8 +42,7 @@ fn oneshot_send3() {
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (tx2, rx2) = mpsc::channel();
 
-    rx1.map_ok(move |x| tx2.send(x).unwrap())
-        .run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
     assert_eq!(1, rx2.recv().unwrap());
 }
@@ -60,8 +58,7 @@ fn oneshot_drop_tx1() {
     let (tx2, rx2) = mpsc::channel();
 
     drop(tx1);
-    rx1.map(move |result| tx2.send(result).unwrap())
-        .run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());
 }
@@ -78,8 +75,7 @@ fn oneshot_drop_tx2() {
     let (tx2, rx2) = mpsc::channel();
 
     let t = thread::spawn(|| drop(tx1));
-    rx1.map(move |result| tx2.send(result).unwrap())
-        .run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
     t.join().unwrap();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());

--- a/futures/tests/oneshot.rs
+++ b/futures/tests/oneshot.rs
@@ -27,7 +27,8 @@ fn oneshot_send2() {
     let (tx2, rx2) = mpsc::channel();
 
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
-    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap())
+        .run_in_background();
     assert_eq!(1, rx2.recv().unwrap());
 }
 
@@ -42,7 +43,8 @@ fn oneshot_send3() {
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (tx2, rx2) = mpsc::channel();
 
-    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap())
+        .run_in_background();
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
     assert_eq!(1, rx2.recv().unwrap());
 }
@@ -58,7 +60,8 @@ fn oneshot_drop_tx1() {
     let (tx2, rx2) = mpsc::channel();
 
     drop(tx1);
-    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap())
+        .run_in_background();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());
 }
@@ -75,7 +78,8 @@ fn oneshot_drop_tx2() {
     let (tx2, rx2) = mpsc::channel();
 
     let t = thread::spawn(|| drop(tx1));
-    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap())
+        .run_in_background();
     t.join().unwrap();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -61,19 +61,13 @@ fn resolving_errors() {
 
         drop(tx2);
 
-        assert_eq!(
-            Poll::Ready(Some(Err(oneshot::Canceled))),
-            queue.poll_next_unpin(cx)
-        );
+        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
         assert!(!queue.poll_next_unpin(cx).is_ready());
 
         drop(tx1);
         tx3.send("world2").unwrap();
 
-        assert_eq!(
-            Poll::Ready(Some(Err(oneshot::Canceled))),
-            queue.poll_next_unpin(cx)
-        );
+        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
         assert_eq!(Poll::Ready(Some(Ok("world2"))), queue.poll_next_unpin(cx));
         assert_eq!(Poll::Ready(None), queue.poll_next_unpin(cx));
     }));

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -61,13 +61,19 @@ fn resolving_errors() {
 
         drop(tx2);
 
-        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
+        assert_eq!(
+            Poll::Ready(Some(Err(oneshot::Canceled))),
+            queue.poll_next_unpin(cx)
+        );
         assert!(!queue.poll_next_unpin(cx).is_ready());
 
         drop(tx1);
         tx3.send("world2").unwrap();
 
-        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
+        assert_eq!(
+            Poll::Ready(Some(Err(oneshot::Canceled))),
+            queue.poll_next_unpin(cx)
+        );
         assert_eq!(Poll::Ready(Some(Ok("world2"))), queue.poll_next_unpin(cx));
         assert_eq!(Poll::Ready(None), queue.poll_next_unpin(cx));
     }));

--- a/futures/tests/recurse.rs
+++ b/futures/tests/recurse.rs
@@ -1,7 +1,7 @@
 #[test]
 fn lots() {
     use futures::executor::block_on;
-    use futures::future::{self, FutureExt, BoxFuture};
+    use futures::future::{self, BoxFuture, FutureExt};
     use std::sync::mpsc;
     use std::thread;
 
@@ -20,8 +20,6 @@ fn lots() {
     }
 
     let (tx, rx) = mpsc::channel();
-    thread::spawn(|| {
-        block_on(do_it((N, 0)).map(move |x| tx.send(x).unwrap()))
-    });
+    thread::spawn(|| block_on(do_it((N, 0)).map(move |x| tx.send(x).unwrap())));
     assert_eq!((0..=N).sum::<i32>(), rx.recv().unwrap());
 }

--- a/futures/tests/select_all.rs
+++ b/futures/tests/select_all.rs
@@ -4,11 +4,7 @@ fn smoke() {
     use futures::future::{ready, select_all};
     use std::collections::HashSet;
 
-    let v = vec![
-        ready(1),
-        ready(2),
-        ready(3),
-    ];
+    let v = vec![ready(1), ready(2), ready(3)];
 
     let mut c = vec![1, 2, 3].into_iter().collect::<HashSet<_>>();
 

--- a/futures/tests/select_ok.rs
+++ b/futures/tests/select_ok.rs
@@ -3,12 +3,7 @@ fn ignore_err() {
     use futures::executor::block_on;
     use futures::future::{err, ok, select_ok};
 
-    let v = vec![
-        err(1),
-        err(2),
-        ok(3),
-        ok(4),
-    ];
+    let v = vec![err(1), err(2), ok(3), ok(4)];
 
     let (i, v) = block_on(select_ok(v)).ok().unwrap();
     assert_eq!(i, 3);
@@ -26,11 +21,7 @@ fn last_err() {
     use futures::executor::block_on;
     use futures::future::{err, ok, select_ok};
 
-    let v = vec![
-        ok(1),
-        err(2),
-        err(3),
-    ];
+    let v = vec![ok(1), err(2), err(3)];
 
     let (i, v) = block_on(select_ok(v)).ok().unwrap();
     assert_eq!(i, 1);

--- a/futures/tests/shared.rs
+++ b/futures/tests/shared.rs
@@ -134,9 +134,7 @@ fn peek() {
     }
 
     // Once the Shared has been polled, the value is peekable on the clone.
-    spawn
-        .spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ()))))
-        .unwrap();
+    spawn.spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ())))).unwrap();
     local_pool.run();
     for _ in 0..2 {
         assert_eq!(*f2.peek().unwrap(), Ok(42));
@@ -233,8 +231,5 @@ fn shared_future_that_wakes_itself_until_pending_is_returned() {
 
     // The join future can only complete if the second future gets a chance to run after the first
     // has returned pending
-    assert_eq!(
-        block_on(futures::future::join(fut, async { proceed.set(true) })),
-        ((), ())
-    );
+    assert_eq!(block_on(futures::future::join(fut, async { proceed.set(true) })), ((), ()));
 }

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -148,10 +148,7 @@ mod manual_flush {
 
     impl<T: Unpin> ManualFlush<T> {
         pub fn new() -> Self {
-            Self {
-                data: Vec::new(),
-                waiting_tasks: Vec::new(),
-            }
+            Self { data: Vec::new(), waiting_tasks: Vec::new() }
         }
 
         pub fn force_flush(&mut self) -> Vec<T> {
@@ -182,10 +179,7 @@ mod allowance {
 
     impl Allow {
         pub fn new() -> Self {
-            Self {
-                flag: Cell::new(false),
-                tasks: RefCell::new(Vec::new()),
-            }
+            Self { flag: Cell::new(false), tasks: RefCell::new(Vec::new()) }
         }
 
         pub fn check(&self, cx: &mut Context<'_>) -> bool {
@@ -233,10 +227,7 @@ mod allowance {
 
     pub fn manual_allow<T: Unpin>() -> (ManualAllow<T>, Rc<Allow>) {
         let allow = Rc::new(Allow::new());
-        let manual_allow = ManualAllow {
-            data: Vec::new(),
-            allow: allow.clone(),
-        };
+        let manual_allow = ManualAllow { data: Vec::new(), allow: allow.clone() };
         (manual_allow, allow)
     }
 }
@@ -247,11 +238,8 @@ fn either_sink() {
     use std::collections::VecDeque;
     use std::pin::Pin;
 
-    let mut s = if true {
-        Vec::<i32>::new().left_sink()
-    } else {
-        VecDeque::<i32>::new().right_sink()
-    };
+    let mut s =
+        if true { Vec::<i32>::new().left_sink() } else { VecDeque::<i32>::new().right_sink() };
 
     Pin::new(&mut s).start_send(0).unwrap();
 }
@@ -497,13 +485,10 @@ fn with_implements_clone() {
     let (mut tx, rx) = mpsc::channel(5);
 
     {
-        let mut is_positive = tx
-            .clone()
-            .with(|item| future::ok::<bool, mpsc::SendError>(item > 0));
+        let mut is_positive = tx.clone().with(|item| future::ok::<bool, mpsc::SendError>(item > 0));
 
-        let mut is_long = tx
-            .clone()
-            .with(|item: &str| future::ok::<bool, mpsc::SendError>(item.len() > 5));
+        let mut is_long =
+            tx.clone().with(|item: &str| future::ok::<bool, mpsc::SendError>(item.len() > 5));
 
         block_on(is_positive.clone().send(-1)).unwrap();
         block_on(is_long.clone().send("123456")).unwrap();
@@ -515,10 +500,7 @@ fn with_implements_clone() {
 
     block_on(tx.close()).unwrap();
 
-    assert_eq!(
-        block_on(rx.collect::<Vec<_>>()),
-        vec![false, true, false, true, false]
-    );
+    assert_eq!(block_on(rx.collect::<Vec<_>>()), vec![false, true, false, true, false]);
 }
 
 // test that a buffer is a no-nop around a sink that always accepts sends
@@ -642,10 +624,7 @@ fn sink_map_err() {
     }
 
     let tx = mpsc::channel(0).0;
-    assert_eq!(
-        Pin::new(&mut tx.sink_map_err(|_| ())).start_send(()),
-        Err(())
-    );
+    assert_eq!(Pin::new(&mut tx.sink_map_err(|_| ())).start_send(()), Err(()));
 }
 
 #[test]
@@ -712,8 +691,5 @@ fn err_into() {
     }
 
     let tx = mpsc::channel(0).0;
-    assert_eq!(
-        Pin::new(&mut tx.sink_err_into()).start_send(()),
-        Err(ErrIntoTest)
-    );
+    assert_eq!(Pin::new(&mut tx.sink_err_into()).start_send(()), Err(ErrIntoTest));
 }

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -32,8 +32,8 @@ mod unwrap {
 
 mod flag_cx {
     use futures::task::{self, ArcWake, Context};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     // An Unpark struct that records unpark events for inspection
     pub struct Flag(AtomicBool);
@@ -129,7 +129,10 @@ mod manual_flush {
             Ok(())
         }
 
-        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             if self.data.is_empty() {
                 Poll::Ready(Ok(()))
             } else {
@@ -325,9 +328,9 @@ fn mpsc_blocking_start_send() {
     use futures::executor::block_on;
     use futures::future::{self, FutureExt};
 
-    use start_send_fut::StartSendFut;
     use flag_cx::flag_cx;
     use sassert_next::sassert_next;
+    use start_send_fut::StartSendFut;
     use unwrap::unwrap;
 
     let (mut tx, mut rx) = mpsc::channel::<i32>(0);
@@ -461,8 +464,8 @@ fn with_flush_propagate() {
     use futures::sink::{Sink, SinkExt};
     use std::pin::Pin;
 
-    use manual_flush::ManualFlush;
     use flag_cx::flag_cx;
+    use manual_flush::ManualFlush;
     use unwrap::unwrap;
 
     let mut sink = ManualFlush::new().with(future::ok::<Option<i32>, ()>);
@@ -543,10 +546,10 @@ fn buffer() {
     use futures::future::FutureExt;
     use futures::sink::SinkExt;
 
-    use start_send_fut::StartSendFut;
-    use flag_cx::flag_cx;
-    use unwrap::unwrap;
     use allowance::manual_allow;
+    use flag_cx::flag_cx;
+    use start_send_fut::StartSendFut;
+    use unwrap::unwrap;
 
     let (sink, allow) = manual_allow::<i32>();
     let sink = sink.buffer(2);
@@ -588,8 +591,8 @@ fn fanout_backpressure() {
     use futures::sink::SinkExt;
     use futures::stream::StreamExt;
 
-    use start_send_fut::StartSendFut;
     use flag_cx::flag_cx;
+    use start_send_fut::StartSendFut;
     use unwrap::unwrap;
 
     let (left_send, mut left_recv) = mpsc::channel(0);

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -45,10 +45,7 @@ fn test_split() {
 
     let mut dest: Vec<i32> = Vec::new();
     {
-        let join = Join {
-            stream: stream::iter(vec![10, 20, 30]),
-            sink: &mut dest,
-        };
+        let join = Join { stream: stream::iter(vec![10, 20, 30]), sink: &mut dest };
 
         let (sink, stream) = join.split();
         let join = sink.reunite(stream).expect("test_split: reunite error");

--- a/futures/tests/split.rs
+++ b/futures/tests/split.rs
@@ -18,10 +18,7 @@ fn test_split() {
     impl<T: Stream, U> Stream for Join<T, U> {
         type Item = T::Item;
 
-        fn poll_next(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Option<T::Item>> {
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T::Item>> {
             self.project().stream.poll_next(cx)
         }
     }
@@ -29,40 +26,28 @@ fn test_split() {
     impl<T, U: Sink<Item>, Item> Sink<Item> for Join<T, U> {
         type Error = U::Error;
 
-        fn poll_ready(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             self.project().sink.poll_ready(cx)
         }
 
-        fn start_send(
-            self: Pin<&mut Self>,
-            item: Item,
-        ) -> Result<(), Self::Error> {
+        fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
             self.project().sink.start_send(item)
         }
 
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             self.project().sink.poll_flush(cx)
         }
 
-        fn poll_close(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), Self::Error>> {
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             self.project().sink.poll_close(cx)
         }
     }
 
     let mut dest: Vec<i32> = Vec::new();
     {
-       let join = Join {
+        let join = Join {
             stream: stream::iter(vec![10, 20, 30]),
-            sink: &mut dest
+            sink: &mut dest,
         };
 
         let (sink, stream) = join.split();

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -20,16 +20,11 @@ fn flat_map() {
     use futures::stream::{self, StreamExt};
 
     futures::executor::block_on(async {
-        let st = stream::iter(vec![
-            stream::iter(0..=4u8),
-            stream::iter(6..=10),
-            stream::iter(0..=2),
-        ]);
+        let st =
+            stream::iter(vec![stream::iter(0..=4u8), stream::iter(6..=10), stream::iter(0..=2)]);
 
-        let values: Vec<_> = st
-            .flat_map(|s| s.filter(|v| futures::future::ready(v % 2 == 0)))
-            .collect()
-            .await;
+        let values: Vec<_> =
+            st.flat_map(|s| s.filter(|v| futures::future::ready(v % 2 == 0))).collect().await;
 
         assert_eq!(values, vec![0, 2, 4, 6, 8, 10, 0, 2]);
     });

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -135,8 +135,8 @@ fn ready_chunks_panic_on_cap_zero() {
 #[test]
 fn ready_chunks() {
     use futures::channel::mpsc;
-    use futures::stream::StreamExt;
     use futures::sink::SinkExt;
+    use futures::stream::StreamExt;
     use futures::FutureExt;
     use futures_test::task::noop_context;
 
@@ -154,7 +154,7 @@ fn ready_chunks() {
         tx.send(2).await.unwrap();
         tx.send(3).await.unwrap();
         tx.send(4).await.unwrap();
-        assert_eq!(s.next().await.unwrap(), vec![2,3]);
+        assert_eq!(s.next().await.unwrap(), vec![2, 3]);
         assert_eq!(s.next().await.unwrap(), vec![4]);
     });
 }

--- a/futures/tests/stream_into_async_read.rs
+++ b/futures/tests/stream_into_async_read.rs
@@ -4,7 +4,7 @@ fn test_into_async_read() {
     use futures::io::AsyncRead;
     use futures::stream::{self, TryStreamExt};
     use futures::task::Poll;
-    use futures_test::{task::noop_context, stream::StreamTestExt};
+    use futures_test::{stream::StreamTestExt, task::noop_context};
 
     macro_rules! assert_read {
         ($reader:expr, $buf:expr, $item:expr) => {
@@ -57,7 +57,7 @@ fn test_into_async_bufread() {
     use futures::io::AsyncBufRead;
     use futures::stream::{self, TryStreamExt};
     use futures::task::Poll;
-    use futures_test::{task::noop_context, stream::StreamTestExt};
+    use futures_test::{stream::StreamTestExt, task::noop_context};
 
     macro_rules! assert_fill_buf {
         ($reader:expr, $buf:expr) => {

--- a/futures/tests/stream_select_next_some.rs
+++ b/futures/tests/stream_select_next_some.rs
@@ -30,8 +30,8 @@ fn is_terminated() {
 
 #[test]
 fn select() {
-    use futures::{future, select};
     use futures::stream::{FuturesUnordered, StreamExt};
+    use futures::{future, select};
     use futures_test::future::FutureTestExt;
 
     // Checks that even though `async_tasks` will yield a `None` and return

--- a/futures/tests/try_join.rs
+++ b/futures/tests/try_join.rs
@@ -1,6 +1,6 @@
 #![deny(unreachable_code)]
 
-use futures::{try_join, executor::block_on};
+use futures::{executor::block_on, try_join};
 
 // TODO: This abuses https://github.com/rust-lang/rust/issues/58733 in order to
 // test behaviour of the `try_join!` macro with the never type before it is
@@ -13,7 +13,6 @@ impl<T> MyTrait for fn() -> T {
     type Output = T;
 }
 type Never = <fn() -> ! as MyTrait>::Output;
-
 
 #[test]
 fn try_join_never_error() {

--- a/futures/tests/try_join_all.rs
+++ b/futures/tests/try_join_all.rs
@@ -19,15 +19,9 @@ fn collect_collects() {
 
     use util::assert_done;
 
-    assert_done(
-        || Box::new(try_join_all(vec![ok(1), ok(2)])),
-        Ok::<_, usize>(vec![1, 2]),
-    );
+    assert_done(|| Box::new(try_join_all(vec![ok(1), ok(2)])), Ok::<_, usize>(vec![1, 2]));
     assert_done(|| Box::new(try_join_all(vec![ok(1), err(2)])), Err(2));
-    assert_done(
-        || Box::new(try_join_all(vec![ok(1)])),
-        Ok::<_, usize>(vec![1]),
-    );
+    assert_done(|| Box::new(try_join_all(vec![ok(1)])), Ok::<_, usize>(vec![1]));
     // REVIEW: should this be implemented?
     // assert_done(|| Box::new(try_join_all(Vec::<i32>::new())), Ok(vec![]));
 
@@ -48,10 +42,7 @@ fn try_join_all_iter_lifetime() {
         Box::new(try_join_all(iter))
     }
 
-    assert_done(
-        || sizes(vec![&[1, 2, 3], &[], &[0]]),
-        Ok(vec![3_usize, 0, 1]),
-    );
+    assert_done(|| sizes(vec![&[1, 2, 3], &[], &[0]]), Ok(vec![3_usize, 0, 1]));
 }
 
 #[test]

--- a/futures/tests/try_join_all.rs
+++ b/futures/tests/try_join_all.rs
@@ -1,7 +1,7 @@
 mod util {
-    use std::future::Future;
     use futures::executor::block_on;
     use std::fmt::Debug;
+    use std::future::Future;
 
     pub fn assert_done<T, F>(actual_fut: F, expected: T)
     where
@@ -19,9 +19,15 @@ fn collect_collects() {
 
     use util::assert_done;
 
-    assert_done(|| Box::new(try_join_all(vec![ok(1), ok(2)])), Ok::<_, usize>(vec![1, 2]));
+    assert_done(
+        || Box::new(try_join_all(vec![ok(1), ok(2)])),
+        Ok::<_, usize>(vec![1, 2]),
+    );
     assert_done(|| Box::new(try_join_all(vec![ok(1), err(2)])), Err(2));
-    assert_done(|| Box::new(try_join_all(vec![ok(1)])), Ok::<_, usize>(vec![1]));
+    assert_done(
+        || Box::new(try_join_all(vec![ok(1)])),
+        Ok::<_, usize>(vec![1]),
+    );
     // REVIEW: should this be implemented?
     // assert_done(|| Box::new(try_join_all(Vec::<i32>::new())), Ok(vec![]));
 
@@ -42,7 +48,10 @@ fn try_join_all_iter_lifetime() {
         Box::new(try_join_all(iter))
     }
 
-    assert_done(|| sizes(vec![&[1,2,3], &[], &[0]]), Ok(vec![3_usize, 0, 1]));
+    assert_done(
+        || sizes(vec![&[1, 2, 3], &[], &[0]]),
+        Ok(vec![3_usize, 0, 1]),
+    );
 }
 
 #[test]

--- a/futures/tests/unfold.rs
+++ b/futures/tests/unfold.rs
@@ -2,9 +2,7 @@ use futures::future;
 use futures::stream;
 
 use futures_test::future::FutureTestExt;
-use futures_test::{
-    assert_stream_done, assert_stream_next, assert_stream_pending,
-};
+use futures_test::{assert_stream_done, assert_stream_next, assert_stream_pending};
 
 #[test]
 fn unfold1() {


### PR DESCRIPTION
This formats the following crates with rustfmt.

- futures
- futures-core
- futures-executor
- futures-io
- futures-macro
- futures-sink
- futures-task
- futures-test
- examples

futures-util and futures-channel conflicts with many of other PRs and will not be formatted in this PR.
futures-executor also have some PR, but I plan to close them (I'll describe in detail when closing them).