### PR TITLE
Move type/trait aliases to futures-util

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -2,19 +2,9 @@
 
 use core::ops::DerefMut;
 use core::pin::Pin;
-use core::task::{Context, Poll};
 
 #[doc(no_inline)]
 pub use core::future::Future;
-
-/// An owned dynamically typed [`Future`] for use in cases where you can't
-/// statically type your result or need to add some indirection.
-#[cfg(feature = "alloc")]
-pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
-
-/// `BoxFuture`, but without the `Send` requirement.
-#[cfg(feature = "alloc")]
-pub type LocalBoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
 
 /// A future which tracks whether or not the underlying future
 /// should no longer be polled.
@@ -42,46 +32,6 @@ where
 {
     fn is_terminated(&self) -> bool {
         <P::Target as FusedFuture>::is_terminated(&**self)
-    }
-}
-
-mod private_try_future {
-    use super::Future;
-
-    pub trait Sealed {}
-
-    impl<F, T, E> Sealed for F where F: ?Sized + Future<Output = Result<T, E>> {}
-}
-
-/// A convenience for futures that return `Result` values that includes
-/// a variety of adapters tailored to such futures.
-pub trait TryFuture: Future + private_try_future::Sealed {
-    /// The type of successful values yielded by this future
-    type Ok;
-
-    /// The type of failures yielded by this future
-    type Error;
-
-    /// Poll this `TryFuture` as if it were a `Future`.
-    ///
-    /// This method is a stopgap for a compiler limitation that prevents us from
-    /// directly inheriting from the `Future` trait; in the future it won't be
-    /// needed.
-    fn try_poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Self::Ok, Self::Error>>;
-}
-
-impl<F, T, E> TryFuture for F
-    where F: ?Sized + Future<Output = Result<T, E>>
-{
-    type Ok = T;
-    type Error = E;
-
-    #[inline]
-    fn try_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.poll(cx)
     }
 }
 

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -17,10 +17,10 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 extern crate alloc;
 
 pub mod future;
-#[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};
+#[doc(hidden)] pub use self::future::{Future, FusedFuture};
 
 pub mod stream;
-#[doc(hidden)] pub use self::stream::{Stream, FusedStream, TryStream};
+#[doc(hidden)] pub use self::stream::{Stream, FusedStream};
 
 #[macro_use]
 pub mod task;

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -6,7 +6,7 @@ use futures_01::{
 use futures_01::{
     AsyncSink as AsyncSink01, Sink as Sink01, StartSend as StartSend01,
 };
-use futures_core::{
+use crate::{
     task::{RawWaker, RawWakerVTable},
     future::TryFuture as TryFuture03,
     stream::TryStream as TryStream03,
@@ -27,8 +27,8 @@ use std::{
     task::Context,
 };
 
-/// Converts a futures 0.3 [`TryFuture`](futures_core::future::TryFuture) or
-/// [`TryStream`](futures_core::stream::TryStream) into a futures 0.1
+/// Converts a futures 0.3 [`TryFuture`](crate::future::TryFuture) or
+/// [`TryStream`](crate::stream::TryStream) into a futures 0.1
 /// [`Future`](futures_01::future::Future) or
 /// [`Stream`](futures_01::stream::Stream).
 #[derive(Debug, Clone, Copy)]

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -12,7 +12,7 @@ use crate::future::{assert_future, Either};
 use crate::never::Never;
 use crate::stream::assert_stream;
 #[cfg(feature = "alloc")]
-use futures_core::future::{BoxFuture, LocalBoxFuture};
+use crate::future::{BoxFuture, LocalBoxFuture};
 use futures_core::{
     future::Future,
     stream::Stream,
@@ -537,7 +537,7 @@ pub trait FutureExt: Future {
     }
 
     /// Turns a [`Future<Output = T>`](Future) into a
-    /// [`TryFuture<Ok = T, Error = ()`>](futures_core::future::TryFuture).
+    /// [`TryFuture<Ok = T, Error = ()`>](crate::future::TryFuture).
     fn unit_error(self) -> UnitError<Self>
     where
         Self: Sized,
@@ -546,7 +546,7 @@ pub trait FutureExt: Future {
     }
 
     /// Turns a [`Future<Output = T>`](Future) into a
-    /// [`TryFuture<Ok = T, Error = Never`>](futures_core::future::TryFuture).
+    /// [`TryFuture<Ok = T, Error = Never`>](crate::future::TryFuture).
     fn never_error(self) -> NeverError<Self>
     where
         Self: Sized,

--- a/futures-util/src/future/select_ok.rs
+++ b/futures-util/src/future/select_ok.rs
@@ -1,10 +1,9 @@
 use super::assert_future;
-use crate::future::TryFutureExt;
+use crate::future::{Future, TryFuture, TryFutureExt};
 use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
 use alloc::vec::Vec;
-use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
 
 /// Future for the [`select_ok`] function.

--- a/futures-util/src/future/try_future/into_future.rs
+++ b/futures-util/src/future/try_future/into_future.rs
@@ -1,5 +1,5 @@
+use crate::future::{FusedFuture, Future, TryFuture};
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -5,12 +5,12 @@
 
 #[cfg(feature = "compat")]
 use crate::compat::Compat;
-use core::pin::Pin;
-use futures_core::{
+use crate::{
     future::TryFuture,
     stream::TryStream,
     task::{Context, Poll},
 };
+use core::pin::Pin;
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 

--- a/futures-util/src/future/try_future/try_flatten.rs
+++ b/futures-util/src/future/try_future/try_flatten.rs
@@ -1,7 +1,7 @@
+use crate::future::{FusedFuture, Future, TryFuture};
+use crate::stream::{FusedStream, Stream, TryStream};
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
-use futures_core::stream::{FusedStream, Stream, TryStream};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use futures_core::task::{Context, Poll};

--- a/futures-util/src/future/try_future/try_flatten_err.rs
+++ b/futures-util/src/future/try_future/try_flatten_err.rs
@@ -1,5 +1,5 @@
+use crate::future::{FusedFuture, Future, TryFuture};
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;

--- a/futures-util/src/future/try_join.rs
+++ b/futures-util/src/future/try_join.rs
@@ -1,9 +1,8 @@
 #![allow(non_snake_case)]
 
-use crate::future::{assert_future, try_maybe_done, TryMaybeDone};
+use crate::future::{assert_future, try_maybe_done, Future, TryFuture, TryMaybeDone};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -1,9 +1,8 @@
 //! Definition of the TryMaybeDone combinator
 
-use super::assert_future;
+use crate::future::{assert_future, FusedFuture, Future, TryFuture};
 use core::mem;
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 

--- a/futures-util/src/future/try_select.rs
+++ b/futures-util/src/future/try_select.rs
@@ -1,7 +1,6 @@
+use crate::future::{Either, Future, TryFuture, TryFutureExt};
 use core::pin::Pin;
-use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use crate::future::{Either, TryFutureExt};
 
 /// Future for the [`try_select()`] function.
 #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -6,10 +6,9 @@
 //! - The [`SinkExt`] trait, which provides adapters for chaining and composing
 //!   sinks.
 
-use crate::future::{assert_future, Either};
+use crate::future::{assert_future, Either, Future};
+use crate::stream::{Stream, TryStream};
 use core::pin::Pin;
-use futures_core::future::Future;
-use futures_core::stream::{Stream, TryStream};
 use futures_core::task::{Context, Poll};
 
 #[cfg(feature = "compat")]

--- a/futures-util/src/sink/send_all.rs
+++ b/futures-util/src/sink/send_all.rs
@@ -1,9 +1,8 @@
-use crate::stream::{StreamExt, TryStreamExt, Fuse};
+use crate::future::Future;
+use crate::stream::{Fuse, Stream, StreamExt, TryStream, TryStreamExt};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::{TryStream, Stream};
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -9,9 +9,60 @@
 //! - Top-level stream constructors like [`iter`](iter()) which creates a
 //!   stream from an iterator.
 
+use core::pin::Pin;
+use futures_core::task::{Poll, Context};
 #[cfg(feature = "alloc")]
-pub use futures_core::stream::{BoxStream, LocalBoxStream};
-pub use futures_core::stream::{FusedStream, Stream, TryStream};
+use alloc::boxed::Box;
+
+pub use futures_core::stream::{FusedStream, Stream};
+
+/// An owned dynamically typed [`Stream`] for use in cases where you can't
+/// statically type your result or need to add some indirection.
+#[cfg(feature = "alloc")]
+pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+
+/// `BoxStream`, but without the `Send` requirement.
+#[cfg(feature = "alloc")]
+pub type LocalBoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + 'a>>;
+
+mod private_try_stream {
+    use super::Stream;
+
+    pub trait Sealed {}
+
+    impl<S, T, E> Sealed for S where S: ?Sized + Stream<Item = Result<T, E>> {}
+}
+
+/// A convenience for streams that return `Result` values that includes
+/// a variety of adapters tailored to such futures.
+pub trait TryStream: Stream + private_try_stream::Sealed {
+    /// The type of successful values yielded by this future
+    type Ok;
+
+    /// The type of failures yielded by this future
+    type Error;
+
+    /// Poll this `TryStream` as if it were a `Stream`.
+    ///
+    /// This method is a stopgap for a compiler limitation that prevents us from
+    /// directly inheriting from the `Stream` trait; in the future it won't be
+    /// needed.
+    fn try_poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Option<Result<Self::Ok, Self::Error>>>;
+}
+
+impl<S, T, E> TryStream for S
+    where S: ?Sized + Stream<Item = Result<T, E>>
+{
+    type Ok = T;
+    type Error = E;
+
+    fn try_poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>)
+        -> Poll<Option<Result<Self::Ok, Self::Error>>>
+    {
+        self.poll_next(cx)
+    }
+}
 
 // Extension traits and combinators
 

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -3,22 +3,18 @@
 //! This module contains a number of functions for working with `Stream`s,
 //! including the `StreamExt` trait which adds methods to `Stream` types.
 
-use crate::future::{assert_future, Either};
-use crate::stream::assert_stream;
+use crate::future::{assert_future, Either, Future};
+use crate::stream::{assert_stream, FusedStream, Stream};
+#[cfg(feature = "alloc")]
+use crate::stream::{BoxStream, LocalBoxStream};
+#[cfg(feature = "sink")]
+use crate::stream::TryStream;
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::pin::Pin;
-#[cfg(feature = "sink")]
-use futures_core::stream::TryStream;
-#[cfg(feature = "alloc")]
-use futures_core::stream::{BoxStream, LocalBoxStream};
-use futures_core::{
-    future::Future,
-    stream::{FusedStream, Stream},
-    task::{Context, Poll},
-};
+use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 

--- a/futures-util/src/stream/try_stream/and_then.rs
+++ b/futures-util/src/stream/try_stream/and_then.rs
@@ -1,8 +1,8 @@
+use crate::future::TryFuture;
+use crate::stream::{Stream, TryStream, FusedStream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/into_async_read.rs
+++ b/futures-util/src/stream/try_stream/into_async_read.rs
@@ -1,7 +1,6 @@
-use crate::stream::TryStreamExt;
+use crate::stream::{TryStream, TryStreamExt};
 use core::pin::Pin;
 use futures_core::ready;
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use futures_io::{AsyncRead, AsyncWrite, AsyncBufRead};
 use std::cmp;

--- a/futures-util/src/stream/try_stream/into_stream.rs
+++ b/futures-util/src/stream/try_stream/into_stream.rs
@@ -1,5 +1,5 @@
+use crate::stream::{FusedStream, Stream, TryStream};
 use core::pin::Pin;
-use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -5,18 +5,15 @@
 
 #[cfg(feature = "compat")]
 use crate::compat::Compat;
-use core::pin::Pin;
-use futures_core::{
-    future::{Future, TryFuture},
-    stream::TryStream,
+use crate::{
+    future::{assert_future, Future, TryFuture},
+    stream::{assert_stream, Map, Inspect, TryStream},
     task::{Context, Poll},
 };
 use crate::fns::{
     InspectOkFn, inspect_ok_fn, InspectErrFn, inspect_err_fn, MapErrFn, map_err_fn, IntoFn, into_fn, MapOkFn, map_ok_fn,
 };
-use crate::future::assert_future;
-use crate::stream::{Map, Inspect};
-use crate::stream::assert_stream;
+use core::pin::Pin;
 
 mod and_then;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
@@ -275,7 +272,7 @@ pub trait TryStreamExt: TryStream {
     /// Any successful values produced by this stream will not be passed to the
     /// closure, and will be passed through.
     ///
-    /// The returned value of the closure must implement the [`TryFuture`](futures_core::future::TryFuture) trait
+    /// The returned value of the closure must implement the [`TryFuture`](crate::future::TryFuture) trait
     /// and can represent some more work to be done before the composed stream
     /// is finished.
     ///
@@ -781,7 +778,7 @@ pub trait TryStreamExt: TryStream {
 
     /// Attempt to execute several futures from a stream concurrently (unordered).
     ///
-    /// This stream's `Ok` type must be a [`TryFuture`](futures_core::future::TryFuture) with an `Error` type
+    /// This stream's `Ok` type must be a [`TryFuture`](crate::future::TryFuture) with an `Error` type
     /// that matches the stream's `Error` type.
     ///
     /// This adaptor will buffer up to `n` futures and then return their
@@ -850,7 +847,7 @@ pub trait TryStreamExt: TryStream {
 
     /// Attempt to execute several futures from a stream concurrently.
     ///
-    /// This stream's `Ok` type must be a [`TryFuture`](futures_core::future::TryFuture) with an `Error` type
+    /// This stream's `Ok` type must be a [`TryFuture`](crate::future::TryFuture) with an `Error` type
     /// that matches the stream's `Error` type.
     ///
     /// This adaptor will buffer up to `n` futures and then return their

--- a/futures-util/src/stream/try_stream/or_else.rs
+++ b/futures-util/src/stream/try_stream/or_else.rs
@@ -1,8 +1,8 @@
+use crate::future::TryFuture;
+use crate::stream::{Stream, TryStream, FusedStream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_buffer_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_buffer_unordered.rs
@@ -1,7 +1,5 @@
-use crate::stream::{Fuse, FuturesUnordered, StreamExt, IntoStream};
-use crate::future::{IntoFuture, TryFutureExt};
-use futures_core::future::TryFuture;
-use futures_core::stream::{Stream, TryStream};
+use crate::stream::{Fuse, FuturesUnordered, Stream, StreamExt, IntoStream, TryStream};
+use crate::future::{IntoFuture, TryFuture, TryFutureExt};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_buffered.rs
+++ b/futures-util/src/stream/try_stream/try_buffered.rs
@@ -1,7 +1,5 @@
-use crate::stream::{Fuse, FuturesOrdered, StreamExt, IntoStream};
-use crate::future::{IntoFuture, TryFutureExt};
-use futures_core::future::TryFuture;
-use futures_core::stream::{Stream, TryStream};
+use crate::stream::{Fuse, FuturesOrdered, Stream, StreamExt, IntoStream, TryStream};
+use crate::future::{IntoFuture, TryFuture, TryFutureExt};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -1,8 +1,8 @@
+use crate::future::{FusedFuture, Future};
+use crate::stream::{FusedStream, TryStream};
 use core::mem;
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
-use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -1,7 +1,7 @@
+use crate::stream::TryStream;
+use crate::future::Future;
 use core::pin::Pin;
-use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -1,8 +1,8 @@
+use crate::stream::{Stream, TryStream, FusedStream};
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -1,8 +1,8 @@
+use crate::future::{TryFuture};
+use crate::stream::{Stream, TryStream, FusedStream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{TryFuture};
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_flatten.rs
+++ b/futures-util/src/stream/try_stream/try_flatten.rs
@@ -1,6 +1,6 @@
+use crate::stream::{FusedStream, Stream, TryStream};
 use core::pin::Pin;
 use futures_core::ready;
-use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_fold.rs
+++ b/futures-util/src/stream/try_stream/try_fold.rs
@@ -1,8 +1,8 @@
+use crate::future::{FusedFuture, Future, TryFuture};
+use crate::stream::TryStream;
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/try_stream/try_for_each.rs
+++ b/futures-util/src/stream/try_stream/try_for_each.rs
@@ -1,8 +1,8 @@
+use crate::future::{Future, TryFuture};
+use crate::stream::TryStream;
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{Future, TryFuture};
 use futures_core::ready;
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
+++ b/futures-util/src/stream/try_stream/try_for_each_concurrent.rs
@@ -1,10 +1,9 @@
-use crate::stream::{FuturesUnordered, StreamExt};
+use crate::future::{FusedFuture, Future};
+use crate::stream::{FuturesUnordered, StreamExt, TryStream};
 use core::fmt;
 use core::mem;
 use core::pin::Pin;
 use core::num::NonZeroUsize;
-use futures_core::future::{FusedFuture, Future};
-use futures_core::stream::TryStream;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/try_stream/try_next.rs
+++ b/futures-util/src/stream/try_stream/try_next.rs
@@ -1,7 +1,6 @@
-use crate::stream::TryStreamExt;
+use crate::future::{FusedFuture, Future};
+use crate::stream::{FusedStream, TryStream, TryStreamExt};
 use core::pin::Pin;
-use futures_core::future::{FusedFuture, Future};
-use futures_core::stream::{FusedStream, TryStream};
 use futures_core::task::{Context, Poll};
 
 /// Future for the [`try_next`](super::TryStreamExt::try_next) method.

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -1,8 +1,8 @@
+use crate::future::TryFuture;
+use crate::stream::{Stream, TryStream, FusedStream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -1,8 +1,8 @@
+use crate::future::TryFuture;
+use crate::stream::{FusedStream, Stream, TryStream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;

--- a/futures-util/src/stream/try_stream/try_unfold.rs
+++ b/futures-util/src/stream/try_stream/try_unfold.rs
@@ -1,9 +1,8 @@
-use super::assert_stream;
+use crate::future::TryFuture;
+use crate::stream::{assert_stream, Stream};
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -101,14 +101,14 @@ compile_error!("The `bilock` feature requires the `unstable` feature as an expli
 compile_error!("The `read-initializer` feature requires the `unstable` feature as an explicit opt-in to unstable features");
 
 #[doc(hidden)]
-pub use futures_core::future::{Future, TryFuture};
+pub use futures_core::future::Future;
 #[doc(hidden)]
-pub use futures_util::future::{FutureExt, TryFutureExt};
+pub use futures_util::future::{FutureExt, TryFuture, TryFutureExt};
 
 #[doc(hidden)]
-pub use futures_core::stream::{Stream, TryStream};
+pub use futures_core::stream::Stream;
 #[doc(hidden)]
-pub use futures_util::stream::{StreamExt, TryStreamExt};
+pub use futures_util::stream::{StreamExt, TryStream, TryStreamExt};
 
 #[doc(hidden)]
 pub use futures_sink::Sink;


### PR DESCRIPTION
This moves type aliases (BoxFuture, LocalBoxFuture, BoxStream, LocalBoxStream) and Trait aliases (TryFuture, TryStream) to futures-util.

part of #2207

> - Type aliases (BoxFuture, LocalBoxFuture, BoxStream, LocalBoxStream)
>   - Move to futures-util.
>   - They are just type aliases of Pin<Box>ed future/stream.
> - Trait aliases (TryFuture, TryStream)
>   - Move to futures-util.
>   - They are just trait aliases of future/stream that return Result, but the real trait aliases are not yet stable, so they have some limitations. See #2200 for one of the limitations.

~~This PR is marked as a draft because based on #2335.
See the second commit for actual changes in this PR.~~