### PR TITLE
small change in `select` example.

### DIFF
--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -40,7 +40,7 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 /// 
 /// // These two futures have different types even though their outputs have the same type.
 /// let future1 = async {
-///     let () = future::pending().await; // will never finish
+///     future::pending::<()>().await; // will never finish
 ///     1
 /// };
 /// let future2 = async { 

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -52,10 +52,10 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 /// pin_mut!(future2);
 ///
 /// let value = match future::select(future1, future2).await {
-///     Either::Left((value1, _)) => value1, // `value1` is resolved from `future1`
-///     // `_` represents `future2`
+///     Either::Left((value1, _)) => value1,  // `value1` is resolved from `future1`
+///                                           // `_` represents `future2`
 ///     Either::Right((value2, _)) => value2, // `value2` is resolved from `future2`
-///     // `_` represents `future1`
+///                                           // `_` represents `future1`
 /// };
 ///
 /// assert!(value == 2);

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -32,12 +32,20 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 ///
 /// ```
 /// # futures::executor::block_on(async {
-/// use futures::future::{self, Either};
-/// use futures::pin_mut;
-///
-/// // These two futures have different types even though their outputs have the same type
-/// let future1 = async { 1 };
-/// let future2 = async { 2 };
+/// use futures::{
+///     pin_mut,
+///     future::Either,
+///     future::self,
+/// };
+/// 
+/// // These two futures have different types even though their outputs have the same type.
+/// let future1 = async {
+///     let () = future::pending().await; // will never finish
+///     1
+/// };
+/// let future2 = async { 
+///     future::ready(2).await
+/// };
 ///
 /// // 'select' requires Future + Unpin bounds
 /// pin_mut!(future1);
@@ -45,12 +53,12 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 ///
 /// let value = match future::select(future1, future2).await {
 ///     Either::Left((value1, _)) => value1, // `value1` is resolved from `future1`
-///                                          // `_` represents `future2`
+///     // `_` represents `future2`
 ///     Either::Right((value2, _)) => value2, // `value2` is resolved from `future2`
-///                                           // `_` represents `future1`
+///     // `_` represents `future1`
 /// };
 ///
-/// assert!(value == 1 || value == 2);
+/// assert!(value == 2);
 /// # });
 /// ```
 ///


### PR DESCRIPTION
In the previous example one future always finished first (because of implementation details), possibly confusing users about what `select` does.

This commit resolves the issue by being explicit about one future finishing before the other.

Closes #2334