### PR TITLE
tests: cfg-ignore compat tests if there is no compat feature

### DIFF
--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "compat")]
+
 //! Assert Send/Sync/Unpin for all public types.
 
 use futures::{

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "compat")]
+
 use tokio::timer::Delay;
 use tokio::runtime::Runtime;
 use std::time::Instant;


### PR DESCRIPTION
I realise that `cargo test` is meant to be run using `--all-features`, however, this is not obvious the first time one runs tests because the error about the missing `compat` module happens first, and the helpful message about  `--all-features` never gets output. With this change, we get far enough into compilation that you get to see the helpful error message, not the unhelpful ones. I believe this is an improvement to a contributors first experience (it would have saved me some time, for sure) and that outweighs the small noise of having the additional `cfg` lines.