### PR TITLE
Fix some typos in doc-comments

### DIFF
--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -8,7 +8,7 @@ macro_rules! document_join_macro {
         /// of all results once complete.
         ///
         /// While `join!(a, b)` is similar to `(a.await, b.await)`,
-        /// `join!` polls both futures concurrently and therefore is more efficent.
+        /// `join!` polls both futures concurrently and therefore is more efficient.
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
         /// It is also gated behind the `async-await` feature of this library, which is

--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -539,7 +539,7 @@ pub trait TryFutureExt: TryFuture {
         ))
     }
 
-    /// Unwraps this future's ouput, producing a future with this future's
+    /// Unwraps this future's output, producing a future with this future's
     /// [`Ok`](TryFuture::Ok) type as its
     /// [`Output`](std::future::Future::Output) type.
     ///
@@ -569,8 +569,8 @@ pub trait TryFutureExt: TryFuture {
         assert_future::<Self::Ok, _>(UnwrapOrElse::new(self, f))
     }
 
-    /// Wraps a [`TryFuture`] into a future compatable with libraries using
-    /// futures 0.1 future definitons. Requires the `compat` feature to enable.
+    /// Wraps a [`TryFuture`] into a future compatible with libraries using
+    /// futures 0.1 future definitions. Requires the `compat` feature to enable.
     #[cfg(feature = "compat")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
     fn compat(self) -> Compat<Self>

--- a/futures-util/src/future/try_join.rs
+++ b/futures-util/src/future/try_join.rs
@@ -108,7 +108,7 @@ generate! {
 ///
 /// This function will return a new future which awaits both futures to
 /// complete. If successful, the returned future will finish with a tuple of
-/// both results. If unsuccesful, it will complete with the first error
+/// both results. If unsuccessful, it will complete with the first error
 /// encountered.
 ///
 /// Note that this function consumes the passed futures and returns a

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -16,7 +16,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Close<'_, Si, Item> {}
 
 /// A future that completes when the sink has finished closing.
 ///
-/// The sink itself is returned after closeing is complete.
+/// The sink itself is returned after closing is complete.
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Close<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si) -> Self {
         Self {

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -795,7 +795,7 @@ pub trait StreamExt: Stream {
     /// this stream combinator will always return that the stream is done.
     ///
     /// The stopping future may return any type. Once the stream is stopped
-    /// the result of the stopping future may be aceessed with `TakeUntil::take_result()`.
+    /// the result of the stopping future may be accessed with `TakeUntil::take_result()`.
     /// The stream may also be resumed with `TakeUntil::take_future()`.
     /// See the documentation of [`TakeUntil`] for more information.
     ///


### PR DESCRIPTION
This resulted from spellchecking in futures-util.