### PR TITLE
Expose implementable Fn-trait API variants for futures-util

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -22,6 +22,7 @@ io-compat = ["io", "compat", "tokio-io"]
 sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
+fntraits = []
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures-util/src/fns.rs
+++ b/futures-util/src/fns.rs
@@ -297,6 +297,35 @@ pub trait FnRef1<A>: for<'a> Fn1<&'a A, Output = ()> + FnMutRef1<A> {}
 #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<A, F: for<'a> Fn1<&'a A, Output = ()>> FnRef1<A> for F {}
 
+mod futures_test {
+    // needed by futures test at futures/tests/auto_traits.rs
+    use super::{FnOnce1, FnMut1, Fn1};
+
+    macro_rules! dummy_impl {
+        ($($type:ty),*) => {
+            $(
+                impl<'a, A> FnOnce1<&'a A> for $type {
+                    type Output = ();
+                    fn call_once(self, _: &'a A) -> Self::Output {
+                        ()
+                    }
+                }
+                impl<'a, A> FnMut1<&'a A> for $type {
+                    fn call_mut(&mut self, _: &'a A) -> Self::Output {
+                        ()
+                    }
+                }
+                impl<'a, A> Fn1<&'a A> for $type {
+                    fn call(&self, _: &'a A) -> Self::Output {
+                        ()
+                    }
+                }
+            )*
+        };
+    }
+
+    dummy_impl!{ (), *const (), core::marker::PhantomPinned }
+}
 //--------------------------------------
 #[doc(hidden)]
 #[derive(Debug, Copy, Clone, Default)]
@@ -597,7 +626,8 @@ pub mod future {
         poll_fn_fns as poll_fs,
     };
 }
-#[cfg(feature = "fntraits")]
+#[cfg(all(feature = "fntraits", feature = "sink"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub mod sink {
     //! Adaptations for [`sink`](crate::sink) module using fn-trait wrappers.
     #[doc(inline)]

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -23,6 +23,10 @@ mod future;
 pub use self::future::{
     Flatten, Fuse, FutureExt, Inspect, IntoStream, Map, NeverError, Then, UnitError, MapInto,
 };
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::future::FutureExtFns;
 
 #[deprecated(note = "This is now an alias for [Flatten](Flatten)")]
 pub use self::future::FlattenStream;
@@ -43,6 +47,10 @@ pub use self::try_future::{
     AndThen, ErrInto, OkInto, InspectErr, InspectOk, IntoFuture, MapErr, MapOk, OrElse, TryFlattenStream,
     TryFutureExt, UnwrapOrElse, MapOkOrElse, TryFlatten,
 };
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::try_future::TryFutureExtFns;
 
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
@@ -52,6 +60,10 @@ pub use self::try_future::FlattenSink;
 
 mod lazy;
 pub use self::lazy::{lazy, Lazy};
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use lazy::lazy_fns;
 
 mod pending;
 pub use self::pending::{pending, Pending};
@@ -67,6 +79,10 @@ pub use self::option::OptionFuture;
 
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use poll_fn::poll_fn_fns;
 
 mod ready;
 pub use self::ready::{err, ok, ready, Ready};

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -1,6 +1,7 @@
 //! Definition of the `PollFn` adapter combinator
 
 use super::assert_future;
+use crate::fns::FnMut1;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
@@ -40,18 +41,47 @@ where
     assert_future::<T, _>(PollFn { f })
 }
 
+/// See [`poll_fn`].
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures_util::future::poll_fn_fns;
+/// use futures::task::{Context, Poll};
+///
+/// fn read_line(_cx: &mut Context<'_>) -> Poll<String> {
+///     Poll::Ready("Hello, World!".into())
+/// }
+///
+/// let read_future = poll_fn_fns(read_line);
+/// assert_eq!(read_future.await, "Hello, World!".to_owned());
+/// # });
+/// ```
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
+pub fn poll_fn_fns<T, F>(f: F) -> PollFn<F>
+where
+    F: for<'a, 'b> FnMut1<&'a mut Context<'b>, Output = Poll<T>>
+{
+    assert_future::<T, _>(PollFn { f })
+}
+
 impl<F> fmt::Debug for PollFn<F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PollFn").finish()
     }
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<T, F> Future for PollFn<F>
-    where F: FnMut(&mut Context<'_>) -> Poll<T>,
+where
+    F: for<'a, 'b> FnMut1<&'a mut Context<'b>, Output = Poll<T>>,
 {
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        (&mut self.f)(cx)
+        self.f.call_mut(cx)
     }
 }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -342,5 +342,10 @@ pub use crate::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 #[cfg(feature = "alloc")]
 pub mod lock;
 
+#[cfg(not(feature = "fntraits"))]
 mod fns;
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+pub mod fns;
+
 mod unfold_state;

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -22,6 +22,10 @@ pub use self::stream::{
     Fuse, Inspect, Map, Next, Peek, Peekable, Scan, SelectNextSome, Skip, SkipWhile, StreamExt,
     StreamFuture, Take, TakeUntil, TakeWhile, Then, Unzip, Zip,
 };
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::stream::StreamExtFns;
 
 #[cfg(feature = "std")]
 pub use self::stream::CatchUnwind;
@@ -52,6 +56,10 @@ pub use self::try_stream::{
     TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryFold, TryForEach, TryNext,
     TrySkipWhile, TryStreamExt, TryTakeWhile, TryUnfold,
 };
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::try_stream::{try_unfold_fns, TryStreamExtFns};
 
 #[cfg(feature = "io")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io")))]
@@ -72,6 +80,10 @@ pub use self::repeat::{repeat, Repeat};
 
 mod repeat_with;
 pub use self::repeat_with::{repeat_with, RepeatWith};
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::repeat_with::repeat_with_fns;
 
 mod empty;
 pub use self::empty::{empty, Empty};
@@ -84,12 +96,20 @@ pub use self::pending::{pending, Pending};
 
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::poll_fn::poll_fn_fns;
 
 mod select;
 pub use self::select::{select, Select};
 
 mod unfold;
 pub use self::unfold::{unfold, Unfold};
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+#[doc(hidden)]
+pub use self::unfold::unfold_fns;
 
 cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]

--- a/futures-util/src/stream/repeat_with.rs
+++ b/futures-util/src/stream/repeat_with.rs
@@ -1,4 +1,5 @@
 use super::assert_stream;
+use crate::fns::FnMut0;
 use core::pin::Pin;
 use futures_core::stream::{Stream, FusedStream};
 use futures_core::task::{Context, Poll};
@@ -14,13 +15,13 @@ pub struct RepeatWith<F> {
     repeater: F,
 }
 
-impl<A, F: FnMut() -> A> Unpin for RepeatWith<F> {}
+impl<A, F: FnMut0<Output = A>> Unpin for RepeatWith<F> {}
 
-impl<A, F: FnMut() -> A> Stream for RepeatWith<F> {
+impl<A, F: FnMut0<Output = A>> Stream for RepeatWith<F> {
     type Item = A;
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Poll::Ready(Some((&mut self.repeater)()))
+        Poll::Ready(Some(self.repeater.call_mut()))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -28,8 +29,7 @@ impl<A, F: FnMut() -> A> Stream for RepeatWith<F> {
     }
 }
 
-impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F>
-{
+impl<A, F: FnMut0<Output = A>> FusedStream for RepeatWith<F> {
     fn is_terminated(&self) -> bool {
         false
     }
@@ -90,5 +90,55 @@ impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F>
 /// # });
 /// ```
 pub fn repeat_with<A, F: FnMut() -> A>(repeater: F) -> RepeatWith<F> {
+    assert_stream::<A, _>(RepeatWith { repeater })
+}
+
+/// See [`repeat_with`].
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures_util::stream::{self, StreamExt};
+///
+/// // let's assume we have some value of a type that is not `Clone`
+/// // or which don't want to have in memory just yet because it is expensive:
+/// #[derive(PartialEq, Debug)]
+/// struct Expensive;
+///
+/// // a particular value forever:
+/// let mut things = stream::repeat_with_fns(|| Expensive);
+///
+/// assert_eq!(Some(Expensive), things.next().await);
+/// assert_eq!(Some(Expensive), things.next().await);
+/// assert_eq!(Some(Expensive), things.next().await);
+/// # });
+/// ```
+///
+/// Using mutation and going finite:
+///
+/// ```rust
+/// # futures::executor::block_on(async {
+/// use futures_util::stream::{self, StreamExt};
+///
+/// // From the zeroth to the third power of two:
+/// let mut curr = 1;
+/// let mut pow2 = stream::repeat_with_fns(|| { let tmp = curr; curr *= 2; tmp })
+///                     .take(4);
+///
+/// assert_eq!(Some(1), pow2.next().await);
+/// assert_eq!(Some(2), pow2.next().await);
+/// assert_eq!(Some(4), pow2.next().await);
+/// assert_eq!(Some(8), pow2.next().await);
+///
+/// // ... and now we're done
+/// assert_eq!(None, pow2.next().await);
+/// # });
+/// ```
+#[cfg(feature = "fntraits")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fntraits")))]
+pub fn repeat_with_fns<A, F: FnMut0<Output = A>>(repeater: F) -> RepeatWith<F> {
     assert_stream::<A, _>(RepeatWith { repeater })
 }

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -35,9 +35,10 @@ where
 }
 
 impl<St, Fut, F> FilterMap<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future,
+where
+    St: Stream,
+    F: FnMut1<St::Item, Output = Fut>,
+    Fut: Future,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, f, pending: None }

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -1,3 +1,4 @@
+use crate::fns::FnMut1;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
@@ -42,10 +43,11 @@ where
     }
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<St, Fut, F> TryTakeWhile<St, Fut, F>
 where
     St: TryStream,
-    F: FnMut(&St::Ok) -> Fut,
+    F: for<'a> FnMut1<&'a St::Ok, Output = Fut>,
     Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
@@ -61,10 +63,11 @@ where
     delegate_access_inner!(stream, St, ());
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<St, Fut, F> Stream for TryTakeWhile<St, Fut, F>
 where
     St: TryStream,
-    F: FnMut(&St::Ok) -> Fut,
+    F: for<'a> FnMut1<&'a St::Ok, Output = Fut>,
     Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     type Item = Result<St::Ok, St::Error>;
@@ -89,7 +92,7 @@ where
                     break None;
                 }
             } else if let Some(item) = ready!(this.stream.as_mut().try_poll_next(cx)?) {
-                this.pending_fut.set(Some((this.f)(&item)));
+                this.pending_fut.set(Some(this.f.call_mut(&item)));
                 *this.pending_item = Some(item);
             } else {
                 break None;
@@ -112,10 +115,11 @@ where
     }
 }
 
+#[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<St, Fut, F> FusedStream for TryTakeWhile<St, Fut, F>
 where
     St: TryStream + FusedStream,
-    F: FnMut(&St::Ok) -> Fut,
+    F: for<'a> FnMut1<&'a St::Ok, Output = Fut>,
     Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     fn is_terminated(&self) -> bool {

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -8,6 +8,7 @@ use futures::{
     stream::Stream,
     task::{Context, Poll},
 };
+
 use static_assertions::{assert_impl_all as assert_impl, assert_not_impl_all as assert_not_impl};
 use std::marker::PhantomPinned;
 use std::{marker::PhantomData, pin::Pin};
@@ -312,25 +313,25 @@ pub mod future {
     assert_not_impl!(Inspect<SyncFuture, *const ()>: Sync);
     assert_not_impl!(Inspect<LocalFuture, ()>: Sync);
     assert_impl!(Inspect<UnpinFuture, PhantomPinned>: Unpin);
-    assert_not_impl!(Inspect<PhantomPinned, PhantomPinned>: Unpin);
+    assert_not_impl!(Inspect<PinnedFuture, PhantomPinned>: Unpin);
 
-    assert_impl!(InspectErr<SendFuture, ()>: Send);
-    assert_not_impl!(InspectErr<SendFuture, *const ()>: Send);
-    assert_not_impl!(InspectErr<LocalFuture, ()>: Send);
-    assert_impl!(InspectErr<SyncFuture, ()>: Sync);
-    assert_not_impl!(InspectErr<SyncFuture, *const ()>: Sync);
-    assert_not_impl!(InspectErr<LocalFuture, ()>: Sync);
-    assert_impl!(InspectErr<UnpinFuture, PhantomPinned>: Unpin);
-    assert_not_impl!(InspectErr<PhantomPinned, PhantomPinned>: Unpin);
+    assert_impl!(InspectErr<SendTryFuture, ()>: Send);
+    assert_not_impl!(InspectErr<SendTryFuture, *const ()>: Send);
+    assert_not_impl!(InspectErr<LocalTryFuture, ()>: Send);
+    assert_impl!(InspectErr<SyncTryFuture, ()>: Sync);
+    assert_not_impl!(InspectErr<SyncTryFuture, *const ()>: Sync);
+    assert_not_impl!(InspectErr<LocalTryFuture, ()>: Sync);
+    assert_impl!(InspectErr<UnpinTryFuture, PhantomPinned>: Unpin);
+    assert_not_impl!(InspectErr<PinnedTryFuture, PhantomPinned>: Unpin);
 
-    assert_impl!(InspectOk<SendFuture, ()>: Send);
-    assert_not_impl!(InspectOk<SendFuture, *const ()>: Send);
-    assert_not_impl!(InspectOk<LocalFuture, ()>: Send);
-    assert_impl!(InspectOk<SyncFuture, ()>: Sync);
-    assert_not_impl!(InspectOk<SyncFuture, *const ()>: Sync);
-    assert_not_impl!(InspectOk<LocalFuture, ()>: Sync);
-    assert_impl!(InspectOk<UnpinFuture, PhantomPinned>: Unpin);
-    assert_not_impl!(InspectOk<PhantomPinned, PhantomPinned>: Unpin);
+    assert_impl!(InspectOk<SendTryFuture, ()>: Send);
+    assert_not_impl!(InspectOk<SendTryFuture, *const ()>: Send);
+    assert_not_impl!(InspectOk<LocalTryFuture, ()>: Send);
+    assert_impl!(InspectOk<SyncTryFuture, ()>: Sync);
+    assert_not_impl!(InspectOk<SyncTryFuture, *const ()>: Sync);
+    assert_not_impl!(InspectOk<LocalTryFuture, ()>: Sync);
+    assert_impl!(InspectOk<UnpinTryFuture, PhantomPinned>: Unpin);
+    assert_not_impl!(InspectOk<PinnedTryFuture, PhantomPinned>: Unpin);
 
     assert_impl!(IntoFuture<SendFuture>: Send);
     assert_not_impl!(IntoFuture<LocalFuture>: Send);
@@ -1301,32 +1302,39 @@ pub mod stream {
     assert_not_impl!(FuturesUnordered<*const ()>: Sync);
     assert_impl!(FuturesUnordered<PhantomPinned>: Unpin);
 
-    assert_impl!(Inspect<(), ()>: Send);
-    assert_not_impl!(Inspect<*const (), ()>: Send);
-    assert_not_impl!(Inspect<(), *const ()>: Send);
-    assert_impl!(Inspect<(), ()>: Sync);
-    assert_not_impl!(Inspect<*const (), ()>: Sync);
-    assert_not_impl!(Inspect<(), *const ()>: Sync);
-    assert_impl!(Inspect<(), PhantomPinned>: Unpin);
-    assert_not_impl!(Inspect<PhantomPinned, ()>: Unpin);
+    assert_impl!(Inspect<SendStream, ()>: Send);
+    assert_not_impl!(Inspect<LocalStream, ()>: Send);
+    assert_not_impl!(Inspect<SendStream, *const ()>: Send);
+    assert_impl!(Inspect<SyncStream, ()>: Sync);
+    assert_not_impl!(Inspect<SendStream, ()>: Sync);
+    assert_not_impl!(Inspect<LocalStream, ()>: Sync);
+    assert_not_impl!(Inspect<SyncStream, *const ()>: Sync);
+    assert_impl!(Inspect<SendStream, PhantomPinned>: Unpin);
+    assert_impl!(Inspect<SyncStream, PhantomPinned>: Unpin);
+    assert_impl!(Inspect<LocalStream, PhantomPinned>: Unpin);
+    assert_not_impl!(Inspect<PinnedStream, ()>: Unpin);
 
-    assert_impl!(InspectErr<(), ()>: Send);
-    assert_not_impl!(InspectErr<*const (), ()>: Send);
-    assert_not_impl!(InspectErr<(), *const ()>: Send);
-    assert_impl!(InspectErr<(), ()>: Sync);
-    assert_not_impl!(InspectErr<*const (), ()>: Sync);
-    assert_not_impl!(InspectErr<(), *const ()>: Sync);
-    assert_impl!(InspectErr<(), PhantomPinned>: Unpin);
-    assert_not_impl!(InspectErr<PhantomPinned, ()>: Unpin);
+    assert_impl!(InspectErr<SendTryStream, ()>: Send);
+    assert_not_impl!(InspectErr<LocalTryStream, ()>: Send);
+    assert_not_impl!(InspectErr<SendTryStream, *const ()>: Send);
+    assert_impl!(InspectErr<SyncTryStream, ()>: Sync);
+    assert_not_impl!(InspectErr<LocalTryStream, ()>: Sync);
+    assert_not_impl!(InspectErr<SyncTryStream, *const ()>: Sync);
+    assert_impl!(InspectErr<SendTryStream, PhantomPinned>: Unpin);
+    assert_impl!(InspectErr<SyncTryStream, PhantomPinned>: Unpin);
+    assert_impl!(InspectErr<LocalTryStream, PhantomPinned>: Unpin);
+    assert_not_impl!(InspectErr<PinnedTryStream, ()>: Unpin);
 
-    assert_impl!(InspectOk<(), ()>: Send);
-    assert_not_impl!(InspectOk<*const (), ()>: Send);
-    assert_not_impl!(InspectOk<(), *const ()>: Send);
-    assert_impl!(InspectOk<(), ()>: Sync);
-    assert_not_impl!(InspectOk<*const (), ()>: Sync);
-    assert_not_impl!(InspectOk<(), *const ()>: Sync);
-    assert_impl!(InspectOk<(), PhantomPinned>: Unpin);
-    assert_not_impl!(InspectOk<PhantomPinned, ()>: Unpin);
+    assert_impl!(InspectOk<SendTryStream, ()>: Send);
+    assert_not_impl!(InspectOk<LocalTryStream, ()>: Send);
+    assert_not_impl!(InspectOk<SendTryStream, *const ()>: Send);
+    assert_impl!(InspectOk<SyncTryStream, ()>: Sync);
+    assert_not_impl!(InspectOk<LocalTryStream, ()>: Sync);
+    assert_not_impl!(InspectOk<SyncTryStream, *const ()>: Sync);
+    assert_impl!(InspectOk<SendTryStream, PhantomPinned>: Unpin);
+    assert_impl!(InspectOk<SyncTryStream, PhantomPinned>: Unpin);
+    assert_impl!(InspectOk<LocalTryStream, PhantomPinned>: Unpin);
+    assert_not_impl!(InspectOk<PinnedTryStream, ()>: Unpin);
 
     assert_impl!(IntoAsyncRead<SendTryStream<Vec<u8>, io::Error>>: Send);
     assert_not_impl!(IntoAsyncRead<LocalTryStream<Vec<u8>, io::Error>>: Send);


### PR DESCRIPTION
**Consider this a proof of concept, or sketch how to close #2349.**

Expand the existing `Fn(Once|Mut)?1`-traits for zero and two arguments. These and dual API using these instead of `Fn(..) ->` is exposed publicly gated by the `fntraits` feature in futures-util.

Modify all internal structures for which the enriched API is present (see modules of `futures_util::fns`) to use Fn-traits from `fns`.
Since existing public API might break for a drop-in replacement, expose a dual API. There where problems, at least for `inspect*`-variants, requiring type annotated closures (this would be a breaking change,
which is avoided by the dual API use).

Possibly the feature should be named differently to your liking, also I'm not sure if is better included under unstable features.