### PR TITLE
Mention StreamExt::next in documentation of the poll!(..) macro

### DIFF
--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -9,6 +9,10 @@ use futures_core::task::{Context, Poll};
 /// This macro is only usable inside of `async` functions, closures, and blocks.
 /// It is also gated behind the `async-await` feature of this library, which is
 /// activated by default.
+///
+/// If you need the result of polling a [`Stream`](crate::stream::Stream),
+/// you can use this macro with the [`next`](crate::stream::StreamExt::next) method:
+/// `poll!(stream.next())`.
 #[macro_export]
 macro_rules! poll {
     ($x:expr $(,)?) => {


### PR DESCRIPTION
Closes #2356 