### PR TITLE
Fix clippy::manual_map warning

### DIFF
--- a/futures-util/src/stream/stream/skip.rs
+++ b/futures-util/src/stream/stream/skip.rs
@@ -57,11 +57,8 @@ impl<St: Stream> Stream for Skip<St> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.stream.size_hint();
 
-        let lower = lower.saturating_sub(self.remaining as usize);
-        let upper = match upper {
-            Some(x) => Some(x.saturating_sub(self.remaining as usize)),
-            None => None,
-        };
+        let lower = lower.saturating_sub(self.remaining);
+        let upper = upper.map(|x| x.saturating_sub(self.remaining));
 
         (lower, upper)
     }


### PR DESCRIPTION
I wonder why this wasn't caught in today's scheduled CI...

today's scheduled CI: https://github.com/rust-lang/futures-rs/actions/runs/601342421
CI that caught this: https://github.com/rust-lang/futures-rs/runs/1984798948?check_suite_focus=true