### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.rs]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Add `.editorconfig` with sensible defaults.

Many editors understand editorconfig, and the most important one
here is IntelliJ IDEA which does not insert file trailing newline
by default, but does it out of box this provided `.editorconfig`.