### PR TITLE
Format all code with `cargo fmt`

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-disable_all_formatting = true
+use_small_heuristics = "Max"

--- a/examples/functional/src/main.rs
+++ b/examples/functional/src/main.rs
@@ -30,9 +30,7 @@ fn main() {
         // responsible for transmission
         pool.spawn_ok(fut_tx_result);
 
-        let fut_values = rx
-            .map(|v| v * 2)
-            .collect();
+        let fut_values = rx.map(|v| v * 2).collect();
 
         // Use the executor provided to this async block to wait for the
         // future to complete.

--- a/examples/imperative/src/main.rs
+++ b/examples/imperative/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         // of the stream to be available.
         while let Some(v) = rx.next().await {
             pending.push(v * 2);
-        };
+        }
 
         pending
     };

--- a/futures-channel/benches/sync_mpsc.rs
+++ b/futures-channel/benches/sync_mpsc.rs
@@ -7,8 +7,8 @@ use {
     futures::{
         channel::mpsc::{self, Sender, UnboundedSender},
         ready,
-        stream::{Stream, StreamExt},
         sink::Sink,
+        stream::{Stream, StreamExt},
         task::{Context, Poll},
     },
     futures_test::task::noop_context,
@@ -25,7 +25,6 @@ fn unbounded_1_tx(b: &mut Bencher) {
         // 1000 iterations to avoid measuring overhead of initialization
         // Result should be divided by 1000
         for i in 0..1000 {
-
             // Poll, not ready, park
             assert_eq!(Poll::Pending, rx.poll_next_unpin(&mut cx));
 
@@ -73,7 +72,6 @@ fn unbounded_uncontended(b: &mut Bencher) {
     })
 }
 
-
 /// A Stream that continuously sends incrementing number of the queue
 struct TestSender {
     tx: Sender<u32>,
@@ -84,9 +82,7 @@ struct TestSender {
 impl Stream for TestSender {
     type Item = u32;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>)
-        -> Poll<Option<Self::Item>>
-    {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
         let mut tx = Pin::new(&mut this.tx);
 
@@ -123,12 +119,7 @@ fn bounded_100_tx(b: &mut Bencher) {
         // Each sender can send one item after specified capacity
         let (tx, mut rx) = mpsc::channel(0);
 
-        let mut tx: Vec<_> = (0..100).map(|_| {
-            TestSender {
-                tx: tx.clone(),
-                last: 0
-            }
-        }).collect();
+        let mut tx: Vec<_> = (0..100).map(|_| TestSender { tx: tx.clone(), last: 0 }).collect();
 
         for i in 0..10 {
             for x in &mut tx {

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -12,9 +12,7 @@
 //! library is activated, and it is activated by default.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]

--- a/futures-channel/tests/channel.rs
+++ b/futures-channel/tests/channel.rs
@@ -1,8 +1,8 @@
 use futures::channel::mpsc;
 use futures::executor::block_on;
 use futures::future::poll_fn;
-use futures::stream::StreamExt;
 use futures::sink::SinkExt;
+use futures::stream::StreamExt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
@@ -11,9 +11,7 @@ fn sequence() {
     let (tx, rx) = mpsc::channel(1);
 
     let amt = 20;
-    let t = thread::spawn(move || {
-        block_on(send_sequence(amt, tx))
-    });
+    let t = thread::spawn(move || block_on(send_sequence(amt, tx)));
     let list: Vec<_> = block_on(rx.collect());
     let mut list = list.into_iter();
     for i in (1..=amt).rev() {
@@ -34,9 +32,7 @@ async fn send_sequence(n: u32, mut sender: mpsc::Sender<u32>) {
 fn drop_sender() {
     let (tx, mut rx) = mpsc::channel::<u32>(1);
     drop(tx);
-    let f = poll_fn(|cx| {
-        rx.poll_next_unpin(cx)
-    });
+    let f = poll_fn(|cx| rx.poll_next_unpin(cx));
     assert_eq!(block_on(f), None)
 }
 

--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -13,9 +13,7 @@ use std::time::{Duration, Instant};
 fn smoke() {
     let (mut sender, receiver) = mpsc::channel(1);
 
-    let t = thread::spawn(move || {
-        while let Ok(()) = block_on(sender.send(42)) {}
-    });
+    let t = thread::spawn(move || while let Ok(()) = block_on(sender.send(42)) {});
 
     // `receiver` needs to be dropped for `sender` to stop sending and therefore before the join.
     block_on(receiver.take(3).for_each(|_| futures::future::ready(())));
@@ -166,7 +164,7 @@ fn stress_try_send_as_receiver_closes() {
     struct TestRx {
         rx: mpsc::Receiver<Arc<()>>,
         // The number of times to query `rx` before dropping it.
-        poll_count: usize
+        poll_count: usize,
     }
     struct TestTask {
         command_rx: mpsc::Receiver<TestRx>,
@@ -190,14 +188,11 @@ fn stress_try_send_as_receiver_closes() {
     impl Future for TestTask {
         type Output = ();
 
-        fn poll(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Self::Output> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             // Poll the test channel, if one is present.
             if let Some(rx) = &mut self.test_rx {
                 if let Poll::Ready(v) = rx.poll_next_unpin(cx) {
-                   let _ = v.expect("test finished unexpectedly!");
+                    let _ = v.expect("test finished unexpectedly!");
                 }
                 self.countdown -= 1;
                 // Busy-poll until the countdown is finished.
@@ -209,9 +204,9 @@ fn stress_try_send_as_receiver_closes() {
                     self.test_rx = Some(rx);
                     self.countdown = poll_count;
                     cx.waker().wake_by_ref();
-                },
+                }
                 Poll::Ready(None) => return Poll::Ready(()),
-                Poll::Pending => {},
+                Poll::Pending => {}
             }
             if self.countdown == 0 {
                 // Countdown complete -- drop the Receiver.
@@ -255,10 +250,14 @@ fn stress_try_send_as_receiver_closes() {
                                 if prev_weak.upgrade().is_none() {
                                     break;
                                 }
-                                assert!(t0.elapsed() < Duration::from_secs(SPIN_TIMEOUT_S),
+                                assert!(
+                                    t0.elapsed() < Duration::from_secs(SPIN_TIMEOUT_S),
                                     "item not dropped on iteration {} after \
                                      {} sends ({} successful). spin=({})",
-                                    i, attempted_sends, successful_sends, spins
+                                    i,
+                                    attempted_sends,
+                                    successful_sends,
+                                    spins
                                 );
                                 spins += 1;
                                 thread::sleep(Duration::from_millis(SPIN_SLEEP_MS));
@@ -273,8 +272,7 @@ fn stress_try_send_as_receiver_closes() {
         }
     }
     drop(cmd_tx);
-    bg.join()
-        .expect("background thread join");
+    bg.join().expect("background thread join");
 }
 
 #[test]

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,13 +1,13 @@
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
-use futures::future::{FutureExt, poll_fn};
-use futures::stream::{Stream, StreamExt};
-use futures::sink::{Sink, SinkExt};
-use futures::task::{Context, Poll};
+use futures::future::{poll_fn, FutureExt};
 use futures::pin_mut;
+use futures::sink::{Sink, SinkExt};
+use futures::stream::{Stream, StreamExt};
+use futures::task::{Context, Poll};
 use futures_test::task::{new_count_waker, noop_context};
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 trait AssertSend: Send {}
@@ -77,7 +77,7 @@ fn send_shared_recv() {
 fn send_recv_threads() {
     let (mut tx, rx) = mpsc::channel::<i32>(16);
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         block_on(tx.send(1)).unwrap();
     });
 
@@ -204,7 +204,7 @@ fn stress_shared_unbounded() {
     const NTHREADS: u32 = 8;
     let (tx, rx) = mpsc::unbounded::<i32>();
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let result: Vec<_> = block_on(rx.collect());
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
@@ -215,7 +215,7 @@ fn stress_shared_unbounded() {
     for _ in 0..NTHREADS {
         let tx = tx.clone();
 
-        thread::spawn(move|| {
+        thread::spawn(move || {
             for _ in 0..AMT {
                 tx.unbounded_send(1).unwrap();
             }
@@ -233,7 +233,7 @@ fn stress_shared_bounded_hard() {
     const NTHREADS: u32 = 8;
     let (tx, rx) = mpsc::channel::<i32>(0);
 
-    let t = thread::spawn(move|| {
+    let t = thread::spawn(move || {
         let result: Vec<_> = block_on(rx.collect());
         assert_eq!(result.len(), (AMT * NTHREADS) as usize);
         for item in result {
@@ -297,9 +297,9 @@ fn stress_receiver_multi_task_bounded_hard() {
                             }
                             Poll::Ready(None) => {
                                 *rx_opt = None;
-                                break
-                            },
-                            Poll::Pending => {},
+                                break;
+                            }
+                            Poll::Pending => {}
                         }
                     }
                 } else {
@@ -310,7 +310,6 @@ fn stress_receiver_multi_task_bounded_hard() {
 
         th.push(t);
     }
-
 
     for i in 0..AMT {
         block_on(tx.send(i)).unwrap();
@@ -328,7 +327,7 @@ fn stress_receiver_multi_task_bounded_hard() {
 /// after sender dropped.
 #[test]
 fn stress_drop_sender() {
-    fn list() -> impl Stream<Item=i32> {
+    fn list() -> impl Stream<Item = i32> {
         let (tx, rx) = mpsc::channel(1);
         thread::spawn(move || {
             block_on(send_one_two_three(tx));
@@ -407,9 +406,7 @@ fn stress_poll_ready() {
         let mut threads = Vec::new();
         for _ in 0..NTHREADS {
             let sender = tx.clone();
-            threads.push(thread::spawn(move || {
-                block_on(stress_poll_ready_sender(sender, AMT))
-            }));
+            threads.push(thread::spawn(move || block_on(stress_poll_ready_sender(sender, AMT))));
         }
         drop(tx);
 
@@ -436,7 +433,7 @@ fn try_send_1() {
         for i in 0..N {
             loop {
                 if tx.try_send(i).is_ok() {
-                    break
+                    break;
                 }
             }
         }
@@ -542,8 +539,8 @@ fn is_connected_to() {
 
 #[test]
 fn hash_receiver() {
-    use std::hash::Hasher;
     use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
 
     let mut hasher_a1 = DefaultHasher::new();
     let mut hasher_a2 = DefaultHasher::new();

--- a/futures-channel/tests/oneshot.rs
+++ b/futures-channel/tests/oneshot.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot::{self, Sender};
 use futures::executor::block_on;
-use futures::future::{FutureExt, poll_fn};
+use futures::future::{poll_fn, FutureExt};
 use futures::task::{Context, Poll};
 use futures_test::task::panic_waker_ref;
 use std::sync::mpsc;
@@ -70,7 +70,7 @@ fn close() {
     rx.close();
     block_on(poll_fn(|cx| {
         match rx.poll_unpin(cx) {
-            Poll::Ready(Err(_)) => {},
+            Poll::Ready(Err(_)) => {}
             _ => panic!(),
         };
         assert!(tx.poll_canceled(cx).is_ready());

--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -67,14 +67,12 @@ pub trait TryFuture: Future + private_try_future::Sealed {
     /// This method is a stopgap for a compiler limitation that prevents us from
     /// directly inheriting from the `Future` trait; in the future it won't be
     /// needed.
-    fn try_poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Self::Ok, Self::Error>>;
+    fn try_poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Self::Ok, Self::Error>>;
 }
 
 impl<F, T, E> TryFuture for F
-    where F: ?Sized + Future<Output = Result<T, E>>
+where
+    F: ?Sized + Future<Output = Result<T, E>>,
 {
     type Ok = T;
     type Error = E;
@@ -87,8 +85,8 @@ impl<F, T, E> TryFuture for F
 
 #[cfg(feature = "alloc")]
 mod if_alloc {
-    use alloc::boxed::Box;
     use super::*;
+    use alloc::boxed::Box;
 
     impl<F: FusedFuture + ?Sized + Unpin> FusedFuture for Box<F> {
         fn is_terminated(&self) -> bool {

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -1,9 +1,7 @@
 //! Core traits and types for asynchronous operations in Rust.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
@@ -17,10 +15,12 @@ compile_error!("The `cfg-target-has-atomic` feature requires the `unstable` feat
 extern crate alloc;
 
 pub mod future;
-#[doc(hidden)] pub use self::future::{Future, FusedFuture, TryFuture};
+#[doc(hidden)]
+pub use self::future::{FusedFuture, Future, TryFuture};
 
 pub mod stream;
-#[doc(hidden)] pub use self::stream::{Stream, FusedStream, TryStream};
+#[doc(hidden)]
+pub use self::stream::{FusedStream, Stream, TryStream};
 
 #[macro_use]
 pub mod task;

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -1,7 +1,7 @@
 use core::cell::UnsafeCell;
 use core::fmt;
 use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{Acquire, Release, AcqRel};
+use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
 
 /// A synchronization primitive for task wakeup.
@@ -202,10 +202,7 @@ impl AtomicWaker {
         trait AssertSync: Sync {}
         impl AssertSync for Waker {}
 
-        Self {
-            state: AtomicUsize::new(WAITING),
-            waker: UnsafeCell::new(None),
-        }
+        Self { state: AtomicUsize::new(WAITING), waker: UnsafeCell::new(None) }
     }
 
     /// Registers the waker to be notified on calls to `wake`.
@@ -279,8 +276,7 @@ impl AtomicWaker {
                     // nothing to acquire, only release. In case of concurrent
                     // wakers, we need to acquire their releases, so success needs
                     // to do both.
-                    let res = self.state.compare_exchange(
-                        REGISTERING, WAITING, AcqRel, Acquire);
+                    let res = self.state.compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
 
                     match res {
                         Ok(_) => {
@@ -344,9 +340,7 @@ impl AtomicWaker {
                 //
                 // We just want to maintain memory safety. It is ok to drop the
                 // call to `register`.
-                debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | WAKING);
+                debug_assert!(state == REGISTERING || state == REGISTERING | WAKING);
             }
         }
     }
@@ -391,9 +385,8 @@ impl AtomicWaker {
                 // not.
                 //
                 debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | WAKING ||
-                    state == WAKING);
+                    state == REGISTERING || state == REGISTERING | WAKING || state == WAKING
+                );
                 None
             }
         }

--- a/futures-core/src/task/mod.rs
+++ b/futures-core/src/task/mod.rs
@@ -7,4 +7,4 @@ mod poll;
 pub mod __internal;
 
 #[doc(no_inline)]
-pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -3,9 +3,10 @@
 /// This macro bakes in propagation of `Pending` signals by returning early.
 #[macro_export]
 macro_rules! ready {
-    ($e:expr $(,)?) => (match $e {
-        $crate::__private::Poll::Ready(t) => t,
-        $crate::__private::Poll::Pending =>
-            return $crate::__private::Poll::Pending,
-    })
+    ($e:expr $(,)?) => {
+        match $e {
+            $crate::__private::Poll::Ready(t) => t,
+            $crate::__private::Poll::Pending => return $crate::__private::Poll::Pending,
+        }
+    };
 }

--- a/futures-executor/benches/thread_notify.rs
+++ b/futures-executor/benches/thread_notify.rs
@@ -102,10 +102,7 @@ fn thread_yield_multi_thread(b: &mut Bencher) {
     });
 
     b.iter(move || {
-        let y = Yield {
-            rem: NUM,
-            tx: tx.clone(),
-        };
+        let y = Yield { rem: NUM, tx: tx.clone() };
 
         block_on(y);
     });

--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -37,13 +37,11 @@
 //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
@@ -52,12 +50,12 @@ mod local_pool;
 pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
 
 #[cfg(feature = "thread-pool")]
-#[cfg(feature = "std")]
-mod unpark_mutex;
-#[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]
 mod thread_pool;
+#[cfg(feature = "thread-pool")]
+#[cfg(feature = "std")]
+mod unpark_mutex;
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]
 #[cfg(feature = "std")]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -10,7 +10,10 @@ use futures_util::stream::StreamExt;
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::rc::{Rc, Weak};
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread::{self, Thread};
 
 /// A single-threaded task pool for polling futures to completion.
@@ -119,17 +122,12 @@ fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
 impl LocalPool {
     /// Create a new, empty pool of tasks.
     pub fn new() -> Self {
-        Self {
-            pool: FuturesUnordered::new(),
-            incoming: Default::default(),
-        }
+        Self { pool: FuturesUnordered::new(), incoming: Default::default() }
     }
 
     /// Get a clonable handle to the pool as a [`Spawn`].
     pub fn spawner(&self) -> LocalSpawner {
-        LocalSpawner {
-            incoming: Rc::downgrade(&self.incoming),
-        }
+        LocalSpawner { incoming: Rc::downgrade(&self.incoming) }
     }
 
     /// Run all tasks in the pool to completion.

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -2,8 +2,8 @@ use crate::enter;
 use crate::unpark_mutex::UnparkMutex;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
+use futures_task::{waker_ref, ArcWake};
 use futures_task::{FutureObj, Spawn, SpawnError};
-use futures_task::{ArcWake, waker_ref};
 use futures_util::future::FutureExt;
 use std::cmp;
 use std::fmt;
@@ -54,9 +54,7 @@ struct PoolState {
 
 impl fmt::Debug for ThreadPool {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("ThreadPool")
-            .field("size", &self.state.size)
-            .finish()
+        f.debug_struct("ThreadPool").field("size", &self.state.size).finish()
     }
 }
 
@@ -100,10 +98,7 @@ impl ThreadPool {
     pub fn spawn_obj_ok(&self, future: FutureObj<'static, ()>) {
         let task = Task {
             future,
-            wake_handle: Arc::new(WakeHandle {
-                exec: self.clone(),
-                mutex: UnparkMutex::new(),
-            }),
+            wake_handle: Arc::new(WakeHandle { exec: self.clone(), mutex: UnparkMutex::new() }),
             exec: self.clone(),
         };
         self.state.send(Message::Run(task));
@@ -132,10 +127,7 @@ impl ThreadPool {
 }
 
 impl Spawn for ThreadPool {
-    fn spawn_obj(
-        &self,
-        future: FutureObj<'static, ()>,
-    ) -> Result<(), SpawnError> {
+    fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         self.spawn_obj_ok(future);
         Ok(())
     }
@@ -146,10 +138,12 @@ impl PoolState {
         self.tx.lock().unwrap().send(msg).unwrap();
     }
 
-    fn work(&self,
-            idx: usize,
-            after_start: Option<Arc<dyn Fn(usize) + Send + Sync>>,
-            before_stop: Option<Arc<dyn Fn(usize) + Send + Sync>>) {
+    fn work(
+        &self,
+        idx: usize,
+        after_start: Option<Arc<dyn Fn(usize) + Send + Sync>>,
+        before_stop: Option<Arc<dyn Fn(usize) + Send + Sync>>,
+    ) {
         let _scope = enter().unwrap();
         if let Some(after_start) = after_start {
             after_start(idx);
@@ -241,7 +235,8 @@ impl ThreadPoolBuilder {
     /// The closure provided will receive an index corresponding to the worker
     /// thread it's running on.
     pub fn after_start<F>(&mut self, f: F) -> &mut Self
-        where F: Fn(usize) + Send + Sync + 'static
+    where
+        F: Fn(usize) + Send + Sync + 'static,
     {
         self.after_start = Some(Arc::new(f));
         self
@@ -256,7 +251,8 @@ impl ThreadPoolBuilder {
     /// The closure provided will receive an index corresponding to the worker
     /// thread it's running on.
     pub fn before_stop<F>(&mut self, f: F) -> &mut Self
-        where F: Fn(usize) + Send + Sync + 'static
+    where
+        F: Fn(usize) + Send + Sync + 'static,
     {
         self.before_stop = Some(Arc::new(f));
         self
@@ -328,14 +324,11 @@ impl Task {
                     Poll::Pending => {}
                     Poll::Ready(()) => return wake_handle.mutex.complete(),
                 }
-                let task = Self {
-                    future,
-                    wake_handle: wake_handle.clone(),
-                    exec,
-                };
+                let task = Self { future, wake_handle: wake_handle.clone(), exec };
                 match wake_handle.mutex.wait(task) {
                     Ok(()) => return, // we've waited
-                    Err(task) => { // someone's notified us
+                    Err(task) => {
+                        // someone's notified us
                         future = task.future;
                         exec = task.exec;
                     }
@@ -347,9 +340,7 @@ impl Task {
 
 impl fmt::Debug for Task {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Task")
-            .field("contents", &"...")
-            .finish()
+        f.debug_struct("Task").field("contents", &"...").finish()
     }
 }
 
@@ -372,7 +363,9 @@ mod tests {
         let (tx, rx) = mpsc::sync_channel(2);
         let _cpu_pool = ThreadPoolBuilder::new()
             .pool_size(2)
-            .after_start(move |_| tx.send(1).unwrap()).create().unwrap();
+            .after_start(move |_| tx.send(1).unwrap())
+            .create()
+            .unwrap();
 
         // After ThreadPoolBuilder is deconstructed, the tx should be droped
         // so that we can use rx as an iterator.

--- a/futures-executor/src/unpark_mutex.rs
+++ b/futures-executor/src/unpark_mutex.rs
@@ -29,25 +29,22 @@ unsafe impl<D: Send> Sync for UnparkMutex<D> {}
 // transitions:
 
 // The task is blocked, waiting on an event
-const WAITING: usize = 0;       // --> POLLING
+const WAITING: usize = 0; // --> POLLING
 
 // The task is actively being polled by a thread; arrival of additional events
 // of interest should move it to the REPOLL state
-const POLLING: usize = 1;       // --> WAITING, REPOLL, or COMPLETE
+const POLLING: usize = 1; // --> WAITING, REPOLL, or COMPLETE
 
 // The task is actively being polled, but will need to be re-polled upon
 // completion to ensure that all events were observed.
-const REPOLL: usize = 2;        // --> POLLING
+const REPOLL: usize = 2; // --> POLLING
 
 // The task has finished executing (either successfully or with an error/panic)
-const COMPLETE: usize = 3;      // No transitions out
+const COMPLETE: usize = 3; // No transitions out
 
 impl<D> UnparkMutex<D> {
     pub(crate) fn new() -> Self {
-        Self {
-            status: AtomicUsize::new(WAITING),
-            inner: UnsafeCell::new(None),
-        }
+        Self { status: AtomicUsize::new(WAITING), inner: UnsafeCell::new(None) }
     }
 
     /// Attempt to "notify" the mutex that a poll should occur.
@@ -62,8 +59,7 @@ impl<D> UnparkMutex<D> {
             match status {
                 // The task is idle, so try to run it immediately.
                 WAITING => {
-                    match self.status.compare_exchange(WAITING, POLLING,
-                                                       SeqCst, SeqCst) {
+                    match self.status.compare_exchange(WAITING, POLLING, SeqCst, SeqCst) {
                         Ok(_) => {
                             let data = unsafe {
                                 // SAFETY: we've ensured mutual exclusion via
@@ -82,13 +78,10 @@ impl<D> UnparkMutex<D> {
 
                 // The task is being polled, so we need to record that it should
                 // be *repolled* when complete.
-                POLLING => {
-                    match self.status.compare_exchange(POLLING, REPOLL,
-                                                       SeqCst, SeqCst) {
-                        Ok(_) => return Err(()),
-                        Err(cur) => status = cur,
-                    }
-                }
+                POLLING => match self.status.compare_exchange(POLLING, REPOLL, SeqCst, SeqCst) {
+                    Ok(_) => return Err(()),
+                    Err(cur) => status = cur,
+                },
 
                 // The task is already scheduled for polling, or is complete, so
                 // we've got nothing to do.

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -9,15 +9,12 @@
 //! library is activated, and it is activated by default.
 
 #![cfg_attr(all(feature = "read-initializer", feature = "std"), feature(read_initializer))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "read-initializer", not(feature = "unstable")))]
@@ -32,14 +29,14 @@ mod if_std {
 
     // Re-export some types from `std::io` so that users don't have to deal
     // with conflicts when `use`ing `futures::io` and `std::io`.
-    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-    #[doc(no_inline)]
-    pub use io::{Error, ErrorKind, Result, IoSlice, IoSliceMut, SeekFrom};
     #[cfg(feature = "read-initializer")]
     #[cfg_attr(docsrs, doc(cfg(feature = "read-initializer")))]
     #[doc(no_inline)]
     #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
     pub use io::Initializer;
+    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+    #[doc(no_inline)]
+    pub use io::{Error, ErrorKind, IoSlice, IoSliceMut, Result, SeekFrom};
 
     /// Read bytes asynchronously.
     ///
@@ -85,8 +82,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<Result<usize>>;
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>>;
 
         /// Attempt to read from the `AsyncRead` into `bufs` using vectored
         /// IO operations.
@@ -110,9 +110,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
             for b in bufs {
                 if !b.is_empty() {
                     return self.poll_read(cx, b);
@@ -149,8 +151,11 @@ mod if_std {
         ///
         /// `poll_write` must try to make progress by flushing the underlying object if
         /// that is the only way the underlying object can become writable again.
-        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-            -> Poll<Result<usize>>;
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>>;
 
         /// Attempt to write bytes from `bufs` into the object using vectored
         /// IO operations.
@@ -175,9 +180,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
             for b in bufs {
                 if !b.is_empty() {
                     return self.poll_write(cx, b);
@@ -252,8 +259,11 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<Result<u64>>;
+        fn poll_seek(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<Result<u64>>;
     }
 
     /// Read bytes asynchronously.
@@ -292,8 +302,7 @@ mod if_std {
         /// `Interrupted`.  Implementations must convert `WouldBlock` into
         /// `Poll::Pending` and either internally retry or convert
         /// `Interrupted` into another error kind.
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&[u8]>>;
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>>;
 
         /// Tells this buffer that `amt` bytes have been consumed from the buffer,
         /// so they should no longer be returned in calls to [`poll_read`].
@@ -320,18 +329,22 @@ mod if_std {
                 (**self).initializer()
             }
 
-            fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &mut [u8],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_read(cx, buf)
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read_vectored(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                bufs: &mut [IoSliceMut<'_>],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_read_vectored(cx, bufs)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for Box<T> {
@@ -352,15 +365,19 @@ mod if_std {
             (**self).initializer()
         }
 
-        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_read(cx, buf)
         }
 
-        fn poll_read_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_read_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_read_vectored(cx, bufs)
         }
     }
@@ -372,18 +389,22 @@ mod if_std {
                 io::Read::initializer(self)
             }
 
-            fn poll_read(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &mut [u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                buf: &mut [u8],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Read::read(&mut *self, buf))
             }
 
-            fn poll_read_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &mut [IoSliceMut<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_read_vectored(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                bufs: &mut [IoSliceMut<'_>],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Read::read_vectored(&mut *self, bufs))
             }
-        }
+        };
     }
 
     impl AsyncRead for &[u8] {
@@ -392,15 +413,19 @@ mod if_std {
 
     macro_rules! deref_async_write {
         () => {
-            fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_write(cx, buf)
             }
 
-            fn poll_write_vectored(mut self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write_vectored(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                bufs: &[IoSlice<'_>],
+            ) -> Poll<Result<usize>> {
                 Pin::new(&mut **self).poll_write_vectored(cx, bufs)
             }
 
@@ -411,7 +436,7 @@ mod if_std {
             fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
                 Pin::new(&mut **self).poll_close(cx)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for Box<T> {
@@ -427,15 +452,19 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncWrite,
     {
-        fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_write(cx, buf)
         }
 
-        fn poll_write_vectored(self: Pin<&mut Self>, cx: &mut Context<'_>, bufs: &[IoSlice<'_>])
-            -> Poll<Result<usize>>
-        {
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
             self.get_mut().as_mut().poll_write_vectored(cx, bufs)
         }
 
@@ -450,15 +479,19 @@ mod if_std {
 
     macro_rules! delegate_async_write_to_stdio {
         () => {
-            fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                buf: &[u8],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Write::write(&mut *self, buf))
             }
 
-            fn poll_write_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &[IoSlice<'_>])
-                -> Poll<Result<usize>>
-            {
+            fn poll_write_vectored(
+                mut self: Pin<&mut Self>,
+                _: &mut Context<'_>,
+                bufs: &[IoSlice<'_>],
+            ) -> Poll<Result<usize>> {
                 Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
             }
 
@@ -469,7 +502,7 @@ mod if_std {
             fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
                 self.poll_flush(cx)
             }
-        }
+        };
     }
 
     impl AsyncWrite for Vec<u8> {
@@ -478,12 +511,14 @@ mod if_std {
 
     macro_rules! deref_async_seek {
         () => {
-            fn poll_seek(mut self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-                -> Poll<Result<u64>>
-            {
+            fn poll_seek(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                pos: SeekFrom,
+            ) -> Poll<Result<u64>> {
                 Pin::new(&mut **self).poll_seek(cx, pos)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for Box<T> {
@@ -499,25 +534,25 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncSeek,
     {
-        fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, pos: SeekFrom)
-            -> Poll<Result<u64>>
-        {
+        fn poll_seek(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            pos: SeekFrom,
+        ) -> Poll<Result<u64>> {
             self.get_mut().as_mut().poll_seek(cx, pos)
         }
     }
 
     macro_rules! deref_async_buf_read {
         () => {
-            fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-                -> Poll<Result<&[u8]>>
-            {
+            fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
                 Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
             }
 
             fn consume(mut self: Pin<&mut Self>, amt: usize) {
                 Pin::new(&mut **self).consume(amt)
             }
-        }
+        };
     }
 
     impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
@@ -533,9 +568,7 @@ mod if_std {
         P: DerefMut + Unpin,
         P::Target: AsyncBufRead,
     {
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<Result<&[u8]>>
-        {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
             self.get_mut().as_mut().poll_fill_buf(cx)
         }
 
@@ -546,16 +579,14 @@ mod if_std {
 
     macro_rules! delegate_async_buf_read_to_stdio {
         () => {
-            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>)
-                -> Poll<Result<&[u8]>>
-            {
+            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
                 Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
             }
 
             fn consume(self: Pin<&mut Self>, amt: usize) {
                 io::BufRead::consume(self.get_mut(), amt)
             }
-        }
+        };
     }
 
     impl AsyncBufRead for &[u8] {

--- a/futures-macro/src/join.rs
+++ b/futures-macro/src/join.rs
@@ -27,10 +27,7 @@ impl Parse for Join {
     }
 }
 
-fn bind_futures(
-    fut_exprs: Vec<Expr>,
-    span: Span,
-) -> (Vec<TokenStream2>, Vec<Ident>) {
+fn bind_futures(fut_exprs: Vec<Expr>, span: Span) -> (Vec<TokenStream2>, Vec<Ident>) {
     let mut future_let_bindings = Vec::with_capacity(fut_exprs.len());
     let future_names: Vec<_> = fut_exprs
         .into_iter()

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -3,8 +3,8 @@
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::{parse_quote, Expr, Ident, Pat, Token};
 use syn::parse::{Parse, ParseStream};
+use syn::{parse_quote, Expr, Ident, Pat, Token};
 
 mod kw {
     syn::custom_keyword!(complete);
@@ -63,7 +63,10 @@ impl Parse for Select {
 
             // Commas after the expression are only optional if it's a `Block`
             // or it is the last branch in the `match`.
-            let is_block = match expr { Expr::Block(_) => true, _ => false };
+            let is_block = match expr {
+                Expr::Block(_) => true,
+                _ => false,
+            };
             if is_block || input.is_empty() {
                 input.parse::<Option<Token![,]>>()?;
             } else {
@@ -76,7 +79,7 @@ impl Parse for Select {
                 CaseKind::Normal(pat, fut_expr) => {
                     select.normal_fut_exprs.push(fut_expr);
                     select.normal_fut_handlers.push((pat, expr));
-                },
+                }
             }
         }
 
@@ -92,22 +95,16 @@ fn declare_result_enum(
     result_ident: Ident,
     variants: usize,
     complete: bool,
-    span: Span
+    span: Span,
 ) -> (Vec<Ident>, syn::ItemEnum) {
     // "_0", "_1", "_2"
     let variant_names: Vec<Ident> =
-        (0..variants)
-            .map(|num| format_ident!("_{}", num, span = span))
-            .collect();
+        (0..variants).map(|num| format_ident!("_{}", num, span = span)).collect();
 
     let type_parameters = &variant_names;
     let variants = &variant_names;
 
-    let complete_variant = if complete {
-        Some(quote!(Complete))
-    } else {
-        None
-    };
+    let complete_variant = if complete { Some(quote!(Complete)) } else { None };
 
     let enum_item = parse_quote! {
         enum #result_ident<#(#type_parameters,)*> {
@@ -148,7 +145,9 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
 
     // bind non-`Ident` future exprs w/ `let`
     let mut future_let_bindings = Vec::with_capacity(parsed.normal_fut_exprs.len());
-    let bound_future_names: Vec<_> = parsed.normal_fut_exprs.into_iter()
+    let bound_future_names: Vec<_> = parsed
+        .normal_fut_exprs
+        .into_iter()
         .zip(variant_names.iter())
         .map(|(expr, variant_name)| {
             match expr {
@@ -164,7 +163,7 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                         __futures_crate::async_await::assert_unpin(&#path);
                     });
                     path
-                },
+                }
                 _ => {
                     // Bind and pin the resulting Future on the stack. This is
                     // necessary to support direct select! calls on !Unpin
@@ -188,8 +187,8 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
 
     // For each future, make an `&mut dyn FnMut(&mut Context<'_>) -> Option<Poll<__PrivResult<...>>`
     // to use for polling that individual future. These will then be put in an array.
-    let poll_functions = bound_future_names.iter().zip(variant_names.iter())
-        .map(|(bound_future_name, variant_name)| {
+    let poll_functions = bound_future_names.iter().zip(variant_names.iter()).map(
+        |(bound_future_name, variant_name)| {
             // Below we lazily create the Pin on the Future below.
             // This is done in order to avoid allocating memory in the generator
             // for the Pin variable.
@@ -216,7 +215,8 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
                     &mut __futures_crate::task::Context<'_>
                 ) -> __futures_crate::Option<__futures_crate::task::Poll<_>> = &mut #variant_name;
             }
-        });
+        },
+    );
 
     let none_polled = if parsed.complete.is_some() {
         quote! {
@@ -229,13 +229,13 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
         }
     };
 
-    let branches = parsed.normal_fut_handlers.into_iter()
-        .zip(variant_names.iter())
-        .map(|((pat, expr), variant_name)| {
+    let branches = parsed.normal_fut_handlers.into_iter().zip(variant_names.iter()).map(
+        |((pat, expr), variant_name)| {
             quote! {
                 #enum_ident::#variant_name(#pat) => { #expr },
             }
-        });
+        },
+    );
     let branches = quote! { #( #branches )* };
 
     let complete_branch = parsed.complete.map(|complete_expr| {

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -207,7 +207,10 @@ mod if_alloc {
     impl<S: ?Sized + Sink<Item> + Unpin, Item> Sink<Item> for alloc::boxed::Box<S> {
         type Error = S::Error;
 
-        fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_ready(cx)
         }
 
@@ -215,11 +218,17 @@ mod if_alloc {
             Pin::new(&mut **self).start_send(item)
         }
 
-        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_flush(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_flush(cx)
         }
 
-        fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_close(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
             Pin::new(&mut **self).poll_close(cx)
         }
     }

--- a/futures-task/src/future_obj.rs
+++ b/futures-task/src/future_obj.rs
@@ -1,8 +1,8 @@
 use core::{
-    mem,
     fmt,
     future::Future,
     marker::PhantomData,
+    mem,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -26,16 +26,16 @@ impl<T> Unpin for LocalFutureObj<'_, T> {}
 
 #[allow(single_use_lifetimes)]
 #[allow(clippy::transmute_ptr_to_ptr)]
-unsafe fn remove_future_lifetime<'a, T>(ptr: *mut (dyn Future<Output = T> + 'a))
-    -> *mut (dyn Future<Output = T> + 'static)
-{
+unsafe fn remove_future_lifetime<'a, T>(
+    ptr: *mut (dyn Future<Output = T> + 'a),
+) -> *mut (dyn Future<Output = T> + 'static) {
     mem::transmute(ptr)
 }
 
 #[allow(single_use_lifetimes)]
-unsafe fn remove_drop_lifetime<'a, T>(ptr: unsafe fn (*mut (dyn Future<Output = T> + 'a)))
-    -> unsafe fn(*mut (dyn Future<Output = T> + 'static))
-{
+unsafe fn remove_drop_lifetime<'a, T>(
+    ptr: unsafe fn(*mut (dyn Future<Output = T> + 'a)),
+) -> unsafe fn(*mut (dyn Future<Output = T> + 'static)) {
     mem::transmute(ptr)
 }
 
@@ -65,8 +65,7 @@ impl<'a, T> LocalFutureObj<'a, T> {
 
 impl<T> fmt::Debug for LocalFutureObj<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("LocalFutureObj")
-            .finish()
+        f.debug_struct("LocalFutureObj").finish()
     }
 }
 
@@ -82,17 +81,13 @@ impl<T> Future for LocalFutureObj<'_, T> {
 
     #[inline]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        unsafe {
-            Pin::new_unchecked(&mut *self.future).poll(cx)
-        }
+        unsafe { Pin::new_unchecked(&mut *self.future).poll(cx) }
     }
 }
 
 impl<T> Drop for LocalFutureObj<'_, T> {
     fn drop(&mut self) {
-        unsafe {
-            (self.drop_fn)(self.future)
-        }
+        unsafe { (self.drop_fn)(self.future) }
     }
 }
 
@@ -120,8 +115,7 @@ impl<'a, T> FutureObj<'a, T> {
 
 impl<T> fmt::Debug for FutureObj<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("FutureObj")
-            .finish()
+        f.debug_struct("FutureObj").finish()
     }
 }
 
@@ -130,7 +124,7 @@ impl<T> Future for FutureObj<'_, T> {
 
     #[inline]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        Pin::new( &mut self.0 ).poll(cx)
+        Pin::new(&mut self.0).poll(cx)
     }
 }
 
@@ -180,7 +174,7 @@ pub unsafe trait UnsafeFutureObj<'a, T>: 'a {
 
 unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for &'a mut F
 where
-    F: Future<Output = T> + Unpin + 'a
+    F: Future<Output = T> + Unpin + 'a,
 {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         self as *mut dyn Future<Output = T>
@@ -189,8 +183,7 @@ where
     unsafe fn drop(_ptr: *mut (dyn Future<Output = T> + 'a)) {}
 }
 
-unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + Unpin + 'a)
-{
+unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + Unpin + 'a) {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         self as *mut dyn Future<Output = T>
     }
@@ -200,7 +193,7 @@ unsafe impl<'a, T> UnsafeFutureObj<'a, T> for &'a mut (dyn Future<Output = T> + 
 
 unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Pin<&'a mut F>
 where
-    F: Future<Output = T> + 'a
+    F: Future<Output = T> + 'a,
 {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         unsafe { self.get_unchecked_mut() as *mut dyn Future<Output = T> }
@@ -209,8 +202,7 @@ where
     unsafe fn drop(_ptr: *mut (dyn Future<Output = T> + 'a)) {}
 }
 
-unsafe impl<'a, T> UnsafeFutureObj<'a, T> for Pin<&'a mut (dyn Future<Output = T> + 'a)>
-{
+unsafe impl<'a, T> UnsafeFutureObj<'a, T> for Pin<&'a mut (dyn Future<Output = T> + 'a)> {
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
         unsafe { self.get_unchecked_mut() as *mut dyn Future<Output = T> }
     }
@@ -224,7 +216,8 @@ mod if_alloc {
     use alloc::boxed::Box;
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Box<F>
-        where F: Future<Output = T> + 'a
+    where
+        F: Future<Output = T> + 'a,
     {
         fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a) {
             Box::into_raw(self)
@@ -257,7 +250,7 @@ mod if_alloc {
 
     unsafe impl<'a, T, F> UnsafeFutureObj<'a, T> for Pin<Box<F>>
     where
-        F: Future<Output = T> + 'a
+        F: Future<Output = T> + 'a,
     {
         fn into_raw(mut self) -> *mut (dyn Future<Output = T> + 'a) {
             let ptr = unsafe { self.as_mut().get_unchecked_mut() as *mut _ };

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -1,9 +1,7 @@
 //! Tools for working with tasks.
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
@@ -24,7 +22,7 @@ macro_rules! cfg_target_has_atomic {
 }
 
 mod spawn;
-pub use crate::spawn::{Spawn, SpawnError, LocalSpawn};
+pub use crate::spawn::{LocalSpawn, Spawn, SpawnError};
 
 cfg_target_has_atomic! {
     #[cfg(feature = "alloc")]
@@ -51,4 +49,4 @@ pub use crate::noop_waker::noop_waker;
 pub use crate::noop_waker::noop_waker_ref;
 
 #[doc(no_inline)]
-pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};

--- a/futures-task/src/spawn.rs
+++ b/futures-task/src/spawn.rs
@@ -126,7 +126,7 @@ impl<Sp: ?Sized + LocalSpawn> LocalSpawn for &mut Sp {
 #[cfg(feature = "alloc")]
 mod if_alloc {
     use super::*;
-    use alloc::{ boxed::Box, rc::Rc };
+    use alloc::{boxed::Box, rc::Rc};
 
     impl<Sp: ?Sized + Spawn> Spawn for Box<Sp> {
         fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {

--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -30,9 +30,7 @@ macro_rules! assert_stream_pending {
         $crate::__private::assert::assert_is_unpin_stream(stream);
         let stream = $crate::__private::Pin::new(stream);
         let mut cx = $crate::task::noop_context();
-        let poll = $crate::__private::stream::Stream::poll_next(
-            stream, &mut cx,
-        );
+        let poll = $crate::__private::stream::Stream::poll_next(stream, &mut cx);
         if poll.is_ready() {
             panic!("assertion failed: stream is not pending");
         }
@@ -71,13 +69,15 @@ macro_rules! assert_stream_next {
                 assert_eq!(x, $item);
             }
             $crate::__private::task::Poll::Ready($crate::__private::None) => {
-                panic!("assertion failed: expected stream to provide item but stream is at its end");
+                panic!(
+                    "assertion failed: expected stream to provide item but stream is at its end"
+                );
             }
             $crate::__private::task::Poll::Pending => {
                 panic!("assertion failed: expected stream to provide item but stream wasn't ready");
             }
         }
-    }}
+    }};
 }
 
 /// Assert that the next poll to the provided stream will return an empty
@@ -117,5 +117,5 @@ macro_rules! assert_stream_done {
                 panic!("assertion failed: expected stream to be done but was pending");
             }
         }
-    }}
+    }};
 }

--- a/futures-test/src/assert_unmoved.rs
+++ b/futures-test/src/assert_unmoved.rs
@@ -34,10 +34,7 @@ unsafe impl<T: Sync> Sync for AssertUnmoved<T> {}
 
 impl<T> AssertUnmoved<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            this_ptr: ptr::null(),
-        }
+        Self { inner, this_ptr: ptr::null() }
     }
 
     fn poll_with<'a, U>(mut self: Pin<&'a mut Self>, f: impl FnOnce(Pin<&'a mut T>) -> U) -> U {
@@ -46,10 +43,7 @@ impl<T> AssertUnmoved<T> {
             // First time being polled
             *self.as_mut().project().this_ptr = cur_this;
         } else {
-            assert_eq!(
-                self.this_ptr, cur_this,
-                "AssertUnmoved moved between poll calls"
-            );
+            assert_eq!(self.this_ptr, cur_this, "AssertUnmoved moved between poll calls");
         }
         f(self.project().inner)
     }

--- a/futures-test/src/future/pending_once.rs
+++ b/futures-test/src/future/pending_once.rs
@@ -1,7 +1,7 @@
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
-use std::pin::Pin;
 use pin_project::pin_project;
+use std::pin::Pin;
 
 /// Combinator that guarantees one [`Poll::Pending`] before polling its inner
 /// future.
@@ -20,20 +20,14 @@ pub struct PendingOnce<Fut> {
 
 impl<Fut: Future> PendingOnce<Fut> {
     pub(super) fn new(future: Fut) -> Self {
-        Self {
-            future,
-            polled_before: false,
-        }
+        Self { future, polled_before: false }
     }
 }
 
 impl<Fut: Future> Future for PendingOnce<Fut> {
     type Output = Fut::Output;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         if *this.polled_before {
             this.future.poll(cx)

--- a/futures-test/src/interleave_pending.rs
+++ b/futures-test/src/interleave_pending.rs
@@ -28,10 +28,7 @@ pub struct InterleavePending<T> {
 
 impl<T> InterleavePending<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            pended: false,
-        }
+        Self { inner, pended: false }
     }
 
     /// Acquires a reference to the underlying I/O object that this adaptor is

--- a/futures-test/src/io/limited.rs
+++ b/futures-test/src/io/limited.rs
@@ -59,17 +59,11 @@ impl<W: AsyncWrite> AsyncWrite for Limited<W> {
         this.io.poll_write(cx, &buf[..cmp::min(*this.limit, buf.len())])
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project().io.poll_flush(cx)
     }
 
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project().io.poll_close(cx)
     }
 }
@@ -87,10 +81,7 @@ impl<R: AsyncRead> AsyncRead for Limited<R> {
 }
 
 impl<R: AsyncBufRead> AsyncBufRead for Limited<R> {
-    fn poll_fill_buf(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&[u8]>> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         self.project().io.poll_fill_buf(cx)
     }
 

--- a/futures-test/src/lib.rs
+++ b/futures-test/src/lib.rs
@@ -7,18 +7,20 @@
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
 
 #[cfg(not(feature = "std"))]
-compile_error!("`futures-test` must have the `std` feature activated, this is a default-active feature");
+compile_error!(
+    "`futures-test` must have the `std` feature activated, this is a default-active feature"
+);
 
 // Not public API.
 #[doc(hidden)]
 #[cfg(feature = "std")]
 pub mod __private {
+    pub use futures_core::{future, stream, task};
     pub use std::{
-        option::Option::{Some, None},
+        option::Option::{None, Some},
         pin::Pin,
         result::Result::{Err, Ok},
     };
-    pub use futures_core::{future, stream, task};
 
     pub mod assert {
         pub use crate::assert::*;

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -1,4 +1,4 @@
-use crate::task::{panic_waker_ref, noop_waker_ref};
+use crate::task::{noop_waker_ref, panic_waker_ref};
 use futures_core::task::Context;
 
 /// Create a new [`Context`](core::task::Context) where the

--- a/futures-test/src/task/mod.rs
+++ b/futures-test/src/task/mod.rs
@@ -57,4 +57,4 @@ mod record_spawner;
 pub use self::record_spawner::RecordSpawner;
 
 mod wake_counter;
-pub use self::wake_counter::{AwokenCount, new_count_waker};
+pub use self::wake_counter::{new_count_waker, AwokenCount};

--- a/futures-test/src/task/wake_counter.rs
+++ b/futures-test/src/task/wake_counter.rs
@@ -1,7 +1,7 @@
 use futures_core::task::Waker;
 use futures_util::task::{self, ArcWake};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 /// Number of times the waker was awoken.
 ///

--- a/futures-test/src/track_closed.rs
+++ b/futures-test/src/track_closed.rs
@@ -21,10 +21,7 @@ pub struct TrackClosed<T> {
 
 impl<T> TrackClosed<T> {
     pub(crate) fn new(inner: T) -> Self {
-        Self {
-            inner,
-            closed: false,
-        }
+        Self { inner, closed: false }
     }
 
     /// Check whether this object has been closed.

--- a/futures-util/benches/futures_unordered.rs
+++ b/futures-util/benches/futures_unordered.rs
@@ -6,7 +6,7 @@ use crate::test::Bencher;
 use futures::channel::oneshot;
 use futures::executor::block_on;
 use futures::future;
-use futures::stream::{StreamExt, FuturesUnordered};
+use futures::stream::{FuturesUnordered, StreamExt};
 use futures::task::Poll;
 use std::collections::VecDeque;
 use std::thread;
@@ -34,7 +34,7 @@ fn oneshots(b: &mut Bencher) {
         block_on(future::poll_fn(move |cx| {
             loop {
                 if let Poll::Ready(None) = rxs.poll_next_unpin(cx) {
-                    break
+                    break;
                 }
             }
             Poll::Ready(())

--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -3,8 +3,8 @@
 //! This module contains a number of functions and combinators for working
 //! with `async`/`await` code.
 
-use futures_core::future::{Future, FusedFuture};
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::future::{FusedFuture, Future};
+use futures_core::stream::{FusedStream, Stream};
 
 #[macro_use]
 mod poll;

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -16,7 +16,7 @@ use futures_core::task::{Context, Poll};
 macro_rules! pending {
     () => {
         $crate::__private::async_await::pending_once().await
-    }
+    };
 }
 
 #[doc(hidden)]

--- a/futures-util/src/async_await/poll.rs
+++ b/futures-util/src/async_await/poll.rs
@@ -17,7 +17,7 @@ use futures_core::task::{Context, Poll};
 macro_rules! poll {
     ($x:expr $(,)?) => {
         $crate::__private::async_await::poll($x).await
-    }
+    };
 }
 
 #[doc(hidden)]

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -66,9 +66,7 @@ where
     fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError03> {
         let future = future.unit_error().compat();
 
-        self.executor01
-            .execute(future)
-            .map_err(|_| SpawnError03::shutdown())
+        self.executor01.execute(future).map_err(|_| SpawnError03::shutdown())
     }
 }
 

--- a/futures-util/src/compat/mod.rs
+++ b/futures-util/src/compat/mod.rs
@@ -4,16 +4,16 @@
 //! library is activated.
 
 mod executor;
-pub use self::executor::{Executor01CompatExt, Executor01Future, Executor01As03};
+pub use self::executor::{Executor01As03, Executor01CompatExt, Executor01Future};
 
 mod compat01as03;
+#[cfg(feature = "io-compat")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
+pub use self::compat01as03::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 pub use self::compat01as03::{Compat01As03, Future01CompatExt, Stream01CompatExt};
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::compat01as03::{Compat01As03Sink, Sink01CompatExt};
-#[cfg(feature = "io-compat")]
-#[cfg_attr(docsrs, doc(cfg(feature = "io-compat")))]
-pub use self::compat01as03::{AsyncRead01CompatExt, AsyncWrite01CompatExt};
 
 mod compat03as01;
 pub use self::compat03as01::Compat;

--- a/futures-util/src/fns.rs
+++ b/futures-util/src/fns.rs
@@ -1,5 +1,5 @@
-use core::marker::PhantomData;
 use core::fmt::{self, Debug};
+use core::marker::PhantomData;
 
 pub trait FnOnce1<A> {
     type Output;
@@ -8,7 +8,7 @@ pub trait FnOnce1<A> {
 
 impl<T, A, R> FnOnce1<A> for T
 where
-    T: FnOnce(A) -> R
+    T: FnOnce(A) -> R,
 {
     type Output = R;
     fn call_once(self, arg: A) -> R {
@@ -22,7 +22,7 @@ pub trait FnMut1<A>: FnOnce1<A> {
 
 impl<T, A, R> FnMut1<A> for T
 where
-    T: FnMut(A) -> R
+    T: FnMut(A) -> R,
 {
     fn call_mut(&mut self, arg: A) -> R {
         self(arg)
@@ -37,7 +37,7 @@ pub trait Fn1<A>: FnMut1<A> {
 
 impl<T, A, R> Fn1<A> for T
 where
-    T: Fn(A) -> R
+    T: Fn(A) -> R,
 {
     fn call(&self, arg: A) -> R {
         self(arg)
@@ -143,7 +143,7 @@ pub struct InspectFn<F>(F);
 #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> FnOnce1<A> for InspectFn<F>
 where
-    F: for<'a> FnOnce1<&'a A, Output=()>,
+    F: for<'a> FnOnce1<&'a A, Output = ()>,
 {
     type Output = A;
     fn call_once(self, arg: A) -> Self::Output {
@@ -154,7 +154,7 @@ where
 #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> FnMut1<A> for InspectFn<F>
 where
-    F: for<'a> FnMut1<&'a A, Output=()>,
+    F: for<'a> FnMut1<&'a A, Output = ()>,
 {
     fn call_mut(&mut self, arg: A) -> Self::Output {
         self.0.call_mut(&arg);
@@ -164,7 +164,7 @@ where
 #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
 impl<F, A> Fn1<A> for InspectFn<F>
 where
-    F: for<'a> Fn1<&'a A, Output=()>,
+    F: for<'a> Fn1<&'a A, Output = ()>,
 {
     fn call(&self, arg: A) -> Self::Output {
         self.0.call(&arg);
@@ -244,27 +244,33 @@ pub struct InspectOkFn<F>(F);
 
 impl<'a, F, T, E> FnOnce1<&'a Result<T, E>> for InspectOkFn<F>
 where
-    F: FnOnce1<&'a T, Output=()>
+    F: FnOnce1<&'a T, Output = ()>,
 {
     type Output = ();
     fn call_once(self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Ok(x) = arg { self.0.call_once(x) }
+        if let Ok(x) = arg {
+            self.0.call_once(x)
+        }
     }
 }
 impl<'a, F, T, E> FnMut1<&'a Result<T, E>> for InspectOkFn<F>
 where
-    F: FnMut1<&'a T, Output=()>,
+    F: FnMut1<&'a T, Output = ()>,
 {
     fn call_mut(&mut self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Ok(x) = arg { self.0.call_mut(x) }
+        if let Ok(x) = arg {
+            self.0.call_mut(x)
+        }
     }
 }
 impl<'a, F, T, E> Fn1<&'a Result<T, E>> for InspectOkFn<F>
 where
-    F: Fn1<&'a T, Output=()>,
+    F: Fn1<&'a T, Output = ()>,
 {
     fn call(&self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Ok(x) = arg { self.0.call(x) }
+        if let Ok(x) = arg {
+            self.0.call(x)
+        }
     }
 }
 pub(crate) fn inspect_ok_fn<F>(f: F) -> InspectOkFn<F> {
@@ -276,27 +282,33 @@ pub struct InspectErrFn<F>(F);
 
 impl<'a, F, T, E> FnOnce1<&'a Result<T, E>> for InspectErrFn<F>
 where
-    F: FnOnce1<&'a E, Output=()>
+    F: FnOnce1<&'a E, Output = ()>,
 {
     type Output = ();
     fn call_once(self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Err(x) = arg { self.0.call_once(x) }
+        if let Err(x) = arg {
+            self.0.call_once(x)
+        }
     }
 }
 impl<'a, F, T, E> FnMut1<&'a Result<T, E>> for InspectErrFn<F>
 where
-    F: FnMut1<&'a E, Output=()>,
+    F: FnMut1<&'a E, Output = ()>,
 {
     fn call_mut(&mut self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Err(x) = arg { self.0.call_mut(x) }
+        if let Err(x) = arg {
+            self.0.call_mut(x)
+        }
     }
 }
 impl<'a, F, T, E> Fn1<&'a Result<T, E>> for InspectErrFn<F>
 where
-    F: Fn1<&'a E, Output=()>,
+    F: Fn1<&'a E, Output = ()>,
 {
     fn call(&self, arg: &'a Result<T, E>) -> Self::Output {
-        if let Err(x) = arg { self.0.call(x) }
+        if let Err(x) = arg {
+            self.0.call(x)
+        }
     }
 }
 pub(crate) fn inspect_err_fn<F>(f: F) -> InspectErrFn<F> {
@@ -313,7 +325,7 @@ pub struct UnwrapOrElseFn<F>(F);
 
 impl<F, T, E> FnOnce1<Result<T, E>> for UnwrapOrElseFn<F>
 where
-    F: FnOnce1<E, Output=T>,
+    F: FnOnce1<E, Output = T>,
 {
     type Output = T;
     fn call_once(self, arg: Result<T, E>) -> Self::Output {
@@ -322,7 +334,7 @@ where
 }
 impl<F, T, E> FnMut1<Result<T, E>> for UnwrapOrElseFn<F>
 where
-    F: FnMut1<E, Output=T>,
+    F: FnMut1<E, Output = T>,
 {
     fn call_mut(&mut self, arg: Result<T, E>) -> Self::Output {
         arg.unwrap_or_else(|x| self.0.call_mut(x))
@@ -330,7 +342,7 @@ where
 }
 impl<F, T, E> Fn1<Result<T, E>> for UnwrapOrElseFn<F>
 where
-    F: Fn1<E, Output=T>,
+    F: Fn1<E, Output = T>,
 {
     fn call(&self, arg: Result<T, E>) -> Self::Output {
         arg.unwrap_or_else(|x| self.0.call(x))
@@ -347,7 +359,10 @@ impl<T> Default for IntoFn<T> {
         Self(PhantomData)
     }
 }
-impl<A, T> FnOnce1<A> for IntoFn<T> where A: Into<T> {
+impl<A, T> FnOnce1<A> for IntoFn<T>
+where
+    A: Into<T>,
+{
     type Output = T;
     fn call_once(self, arg: A) -> Self::Output {
         arg.into()

--- a/futures-util/src/future/future/catch_unwind.rs
+++ b/futures-util/src/future/future/catch_unwind.rs
@@ -1,6 +1,6 @@
 use core::any::Any;
 use core::pin::Pin;
-use std::panic::{catch_unwind, UnwindSafe, AssertUnwindSafe};
+use std::panic::{catch_unwind, AssertUnwindSafe, UnwindSafe};
 
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
@@ -16,14 +16,18 @@ pin_project! {
     }
 }
 
-impl<Fut> CatchUnwind<Fut> where Fut: Future + UnwindSafe {
+impl<Fut> CatchUnwind<Fut>
+where
+    Fut: Future + UnwindSafe,
+{
     pub(super) fn new(future: Fut) -> Self {
         Self { future }
     }
 }
 
 impl<Fut> Future for CatchUnwind<Fut>
-    where Fut: Future + UnwindSafe,
+where
+    Fut: Future + UnwindSafe,
 {
     type Output = Result<Fut::Output, Box<dyn Any + Send>>;
 

--- a/futures-util/src/future/future/flatten.rs
+++ b/futures-util/src/future/future/flatten.rs
@@ -2,9 +2,9 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
+use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -24,8 +24,9 @@ impl<Fut1, Fut2> Flatten<Fut1, Fut2> {
 }
 
 impl<Fut> FusedFuture for Flatten<Fut, Fut::Output>
-    where Fut: Future,
-          Fut::Output: Future,
+where
+    Fut: Future,
+    Fut::Output: Future,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -36,8 +37,9 @@ impl<Fut> FusedFuture for Flatten<Fut, Fut::Output>
 }
 
 impl<Fut> Future for Flatten<Fut, Fut::Output>
-    where Fut: Future,
-          Fut::Output: Future,
+where
+    Fut: Future,
+    Fut::Output: Future,
 {
     type Output = <Fut::Output as Future>::Output;
 
@@ -47,12 +49,12 @@ impl<Fut> Future for Flatten<Fut, Fut::Output>
                 FlattenProj::First { f } => {
                     let f = ready!(f.poll(cx));
                     self.set(Self::Second { f });
-                },
+                }
                 FlattenProj::Second { f } => {
                     let output = ready!(f.poll(cx));
                     self.set(Self::Empty);
                     break output;
-                },
+                }
                 FlattenProj::Empty => panic!("Flatten polled after completion"),
             }
         })
@@ -60,8 +62,9 @@ impl<Fut> Future for Flatten<Fut, Fut::Output>
 }
 
 impl<Fut> FusedStream for Flatten<Fut, Fut::Output>
-    where Fut: Future,
-          Fut::Output: Stream,
+where
+    Fut: Future,
+    Fut::Output: Stream,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -72,31 +75,31 @@ impl<Fut> FusedStream for Flatten<Fut, Fut::Output>
 }
 
 impl<Fut> Stream for Flatten<Fut, Fut::Output>
-    where Fut: Future,
-          Fut::Output: Stream,
+where
+    Fut: Future,
+    Fut::Output: Stream,
 {
     type Item = <Fut::Output as Stream>::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                FlattenProj::First { f }  => {
+                FlattenProj::First { f } => {
                     let f = ready!(f.poll(cx));
                     self.set(Self::Second { f });
-                },
+                }
                 FlattenProj::Second { f } => {
                     let output = ready!(f.poll_next(cx));
                     if output.is_none() {
                         self.set(Self::Empty);
                     }
                     break output;
-                },
+                }
                 FlattenProj::Empty => break None,
             }
         })
     }
 }
-
 
 #[cfg(feature = "sink")]
 impl<Fut, Item> Sink<Item> for Flatten<Fut, Fut::Output>
@@ -106,19 +109,16 @@ where
 {
     type Error = <Fut::Output as Sink<Item>>::Error;
 
-    fn poll_ready(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(loop {
             match self.as_mut().project() {
                 FlattenProj::First { f } => {
                     let f = ready!(f.poll(cx));
                     self.set(Self::Second { f });
-                },
+                }
                 FlattenProj::Second { f } => {
                     break ready!(f.poll_ready(cx));
-                },
+                }
                 FlattenProj::Empty => panic!("poll_ready called after eof"),
             }
         })
@@ -140,10 +140,7 @@ where
         }
     }
 
-    fn poll_close(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let res = match self.as_mut().project() {
             FlattenProj::Second { f } => f.poll_close(cx),
             _ => Poll::Ready(Ok(())),

--- a/futures-util/src/future/future/fuse.rs
+++ b/futures-util/src/future/future/fuse.rs
@@ -1,5 +1,5 @@
 use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
@@ -86,7 +86,7 @@ impl<Fut: Future> Future for Fuse<Fut> {
                 let output = ready!(fut.poll(cx));
                 self.project().inner.set(None);
                 output
-            },
+            }
             None => return Poll::Pending,
         })
     }

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -5,8 +5,8 @@
 
 #[cfg(feature = "alloc")]
 use alloc::boxed::Box;
-use core::pin::Pin;
 use core::convert::Infallible;
+use core::pin::Pin;
 
 use crate::fns::{inspect_fn, into_fn, ok_fn, InspectFn, IntoFn, OkFn};
 use crate::future::{assert_future, Either};

--- a/futures-util/src/future/future/remote_handle.rs
+++ b/futures-util/src/future/future/remote_handle.rs
@@ -1,23 +1,23 @@
 use {
     crate::future::{CatchUnwind, FutureExt},
-    futures_channel::oneshot::{self, Sender, Receiver},
+    futures_channel::oneshot::{self, Receiver, Sender},
     futures_core::{
         future::Future,
-        task::{Context, Poll},
         ready,
+        task::{Context, Poll},
     },
+    pin_project_lite::pin_project,
     std::{
         any::Any,
         fmt,
         panic::{self, AssertUnwindSafe},
         pin::Pin,
         sync::{
-            Arc,
             atomic::{AtomicBool, Ordering},
+            Arc,
         },
         thread,
     },
-    pin_project_lite::pin_project,
 };
 
 /// The handle to a remote future returned by
@@ -85,9 +85,7 @@ pin_project! {
 
 impl<Fut: Future + fmt::Debug> fmt::Debug for Remote<Fut> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Remote")
-            .field(&self.future)
-            .finish()
+        f.debug_tuple("Remote").field(&self.future).finish()
     }
 }
 

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -90,10 +90,7 @@ impl<Fut: Future> Shared<Fut> {
             }),
         };
 
-        Self {
-            inner: Some(Arc::new(inner)),
-            waker_key: NULL_WAKER_KEY,
-        }
+        Self { inner: Some(Arc::new(inner)), waker_key: NULL_WAKER_KEY }
     }
 }
 
@@ -223,10 +220,7 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
 
-        let inner = this
-            .inner
-            .take()
-            .expect("Shared future polled again after completion");
+        let inner = this.inner.take().expect("Shared future polled again after completion");
 
         // Fast path for when the wrapped future has already completed
         if inner.notifier.state.load(Acquire) == COMPLETE {
@@ -286,11 +280,7 @@ where
 
             match future.poll(&mut cx) {
                 Poll::Pending => {
-                    if inner
-                        .notifier
-                        .state
-                        .compare_exchange(POLLING, IDLE, SeqCst, SeqCst)
-                        .is_ok()
+                    if inner.notifier.state.compare_exchange(POLLING, IDLE, SeqCst, SeqCst).is_ok()
                     {
                         // Success
                         drop(_reset);
@@ -330,10 +320,7 @@ where
     Fut: Future,
 {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            waker_key: NULL_WAKER_KEY,
-        }
+        Self { inner: self.inner.clone(), waker_key: NULL_WAKER_KEY }
     }
 }
 
@@ -367,16 +354,12 @@ impl ArcWake for Notifier {
     }
 }
 
-impl<Fut: Future> WeakShared<Fut>
-{
+impl<Fut: Future> WeakShared<Fut> {
     /// Attempts to upgrade this [`WeakShared`] into a [`Shared`].
     ///
     /// Returns [`None`] if all clones of the [`Shared`] have been dropped or polled
     /// to completion.
     pub fn upgrade(&self) -> Option<Shared<Fut>> {
-        Some(Shared {
-            inner: Some(self.0.upgrade()?),
-            waker_key: NULL_WAKER_KEY,
-        })
+        Some(Shared { inner: Some(self.0.upgrade()?), waker_key: NULL_WAKER_KEY })
     }
 }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -1,24 +1,22 @@
 //! Definition of the `JoinAll` combinator, waiting for all of a list of futures
 //! to finish.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::fmt;
 use core::future::Future;
 use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 
-use super::{MaybeDone, assert_future};
+use super::{assert_future, MaybeDone};
 
 fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
     // invariants aren't required to transmit through slices. Otherwise this has
     // the same safety as a normal field pin projection.
-    unsafe { slice.get_unchecked_mut() }
-        .iter_mut()
-        .map(|t| unsafe { Pin::new_unchecked(t) })
+    unsafe { slice.get_unchecked_mut() }.iter_mut().map(|t| unsafe { Pin::new_unchecked(t) })
 }
 
 /// Future for the [`join_all`] function.
@@ -36,9 +34,7 @@ where
     F::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("JoinAll")
-            .field("elems", &self.elems)
-            .finish()
+        f.debug_struct("JoinAll").field("elems", &self.elems).finish()
     }
 }
 
@@ -105,9 +101,7 @@ where
 
         if all_done {
             let mut elems = mem::replace(&mut self.elems, Box::pin([]));
-            let result = iter_pin_mut(elems.as_mut())
-                .map(|e| e.take_output().unwrap())
-                .collect();
+            let result = iter_pin_mut(elems.as_mut()).map(|e| e.take_output().unwrap()).collect();
             Poll::Ready(result)
         } else {
             Poll::Pending

--- a/futures-util/src/future/lazy.rs
+++ b/futures-util/src/future/lazy.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Lazy<F> {
-    f: Option<F>
+    f: Option<F>,
 }
 
 // safe because we never generate `Pin<&mut F>`
@@ -33,19 +33,24 @@ impl<F> Unpin for Lazy<F> {}
 /// # });
 /// ```
 pub fn lazy<F, R>(f: F) -> Lazy<F>
-    where F: FnOnce(&mut Context<'_>) -> R,
+where
+    F: FnOnce(&mut Context<'_>) -> R,
 {
     assert_future::<R, _>(Lazy { f: Some(f) })
 }
 
 impl<F, R> FusedFuture for Lazy<F>
-    where F: FnOnce(&mut Context<'_>) -> R,
+where
+    F: FnOnce(&mut Context<'_>) -> R,
 {
-    fn is_terminated(&self) -> bool { self.f.is_none() }
+    fn is_terminated(&self) -> bool {
+        self.f.is_none()
+    }
 }
 
 impl<F, R> Future for Lazy<F>
-    where F: FnOnce(&mut Context<'_>) -> R,
+where
+    F: FnOnce(&mut Context<'_>) -> R,
 {
     type Output = R;
 

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -21,7 +21,7 @@ pub use futures_task::{FutureObj, LocalFutureObj, UnsafeFutureObj};
 #[allow(clippy::module_inception)]
 mod future;
 pub use self::future::{
-    Flatten, Fuse, FutureExt, Inspect, IntoStream, Map, NeverError, Then, UnitError, MapInto,
+    Flatten, Fuse, FutureExt, Inspect, IntoStream, Map, MapInto, NeverError, Then, UnitError,
 };
 
 #[deprecated(note = "This is now an alias for [Flatten](Flatten)")]
@@ -40,8 +40,8 @@ pub use self::future::{Shared, WeakShared};
 
 mod try_future;
 pub use self::try_future::{
-    AndThen, ErrInto, OkInto, InspectErr, InspectOk, IntoFuture, MapErr, MapOk, OrElse, TryFlattenStream,
-    TryFutureExt, UnwrapOrElse, MapOkOrElse, TryFlatten,
+    AndThen, ErrInto, InspectErr, InspectOk, IntoFuture, MapErr, MapOk, MapOkOrElse, OkInto,
+    OrElse, TryFlatten, TryFlattenStream, TryFutureExt, UnwrapOrElse,
 };
 
 #[cfg(feature = "sink")]

--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -1,7 +1,7 @@
 //! Definition of the `Option` (optional step) combinator
 
 use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
@@ -34,10 +34,7 @@ pin_project! {
 impl<F: Future> Future for OptionFuture<F> {
     type Output = Option<F::Output>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().inner.as_pin_mut() {
             Some(x) => x.poll(cx).map(Some),
             None => Poll::Ready(None),

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -34,9 +34,7 @@ impl<T> FusedFuture for Pending<T> {
 /// # });
 /// ```
 pub fn pending<T>() -> Pending<T> {
-    assert_future::<T, _>(Pending {
-        _data: marker::PhantomData,
-    })
+    assert_future::<T, _>(Pending { _data: marker::PhantomData })
 }
 
 impl<T> Future for Pending<T> {
@@ -47,8 +45,7 @@ impl<T> Future for Pending<T> {
     }
 }
 
-impl<T> Unpin for Pending<T> {
-}
+impl<T> Unpin for Pending<T> {}
 
 impl<T> Clone for Pending<T> {
     fn clone(&self) -> Self {

--- a/futures-util/src/future/poll_fn.rs
+++ b/futures-util/src/future/poll_fn.rs
@@ -35,7 +35,7 @@ impl<F> Unpin for PollFn<F> {}
 /// ```
 pub fn poll_fn<T, F>(f: F) -> PollFn<F>
 where
-    F: FnMut(&mut Context<'_>) -> Poll<T>
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
 {
     assert_future::<T, _>(PollFn { f })
 }
@@ -47,7 +47,8 @@ impl<F> fmt::Debug for PollFn<F> {
 }
 
 impl<T, F> Future for PollFn<F>
-    where F: FnMut(&mut Context<'_>) -> Poll<T>,
+where
+    F: FnMut(&mut Context<'_>) -> Poll<T>,
 {
     type Output = T;
 

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -1,8 +1,8 @@
 use super::assert_future;
-use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
-use futures_core::task::{Context, Poll};
 use crate::future::{Either, FutureExt};
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::task::{Context, Poll};
 
 /// Future for the [`select()`] function.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -37,13 +37,13 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 ///     future::Either,
 ///     future::self,
 /// };
-/// 
+///
 /// // These two futures have different types even though their outputs have the same type.
 /// let future1 = async {
 ///     future::pending::<()>().await; // will never finish
 ///     1
 /// };
-/// let future2 = async { 
+/// let future2 = async {
 ///     future::ready(2).await
 /// };
 ///
@@ -82,9 +82,13 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 /// }
 /// ```
 pub fn select<A, B>(future1: A, future2: B) -> Select<A, B>
-    where A: Future + Unpin, B: Future + Unpin
+where
+    A: Future + Unpin,
+    B: Future + Unpin,
 {
-    assert_future::<Either<(A::Output, B), (B::Output, A)>, _>(Select { inner: Some((future1, future2)) })
+    assert_future::<Either<(A::Output, B), (B::Output, A)>, _>(Select {
+        inner: Some((future1, future2)),
+    })
 }
 
 impl<A, B> Future for Select<A, B>
@@ -104,7 +108,7 @@ where
                     self.inner = Some((a, b));
                     Poll::Pending
                 }
-            }
+            },
         }
     }
 }

--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -1,9 +1,9 @@
 use super::assert_future;
 use crate::future::FutureExt;
+use alloc::vec::Vec;
 use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
-use alloc::vec::Vec;
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 
@@ -32,12 +32,11 @@ impl<Fut: Unpin> Unpin for SelectAll<Fut> {}
 ///
 /// This function will panic if the iterator specified contains no items.
 pub fn select_all<I>(iter: I) -> SelectAll<I::Item>
-    where I: IntoIterator,
-          I::Item: Future + Unpin,
+where
+    I: IntoIterator,
+    I::Item: Future + Unpin,
 {
-    let ret = SelectAll {
-        inner: iter.into_iter().collect()
-    };
+    let ret = SelectAll { inner: iter.into_iter().collect() };
     assert!(!ret.inner.is_empty());
     assert_future::<(<I::Item as Future>::Output, usize, Vec<I::Item>), _>(ret)
 }
@@ -53,11 +52,9 @@ impl<Fut: Future + Unpin> Future for SelectAll<Fut> {
     type Output = (Fut::Output, usize, Vec<Fut>);
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let item = self.inner.iter_mut().enumerate().find_map(|(i, f)| {
-            match f.poll_unpin(cx) {
-                Poll::Pending => None,
-                Poll::Ready(e) => Some((i, e)),
-            }
+        let item = self.inner.iter_mut().enumerate().find_map(|(i, f)| match f.poll_unpin(cx) {
+            Poll::Pending => None,
+            Poll::Ready(e) => Some((i, e)),
         });
         match item {
             Some((idx, res)) => {

--- a/futures-util/src/future/select_ok.rs
+++ b/futures-util/src/future/select_ok.rs
@@ -1,9 +1,9 @@
 use super::assert_future;
 use crate::future::TryFutureExt;
+use alloc::vec::Vec;
 use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
-use alloc::vec::Vec;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
 
@@ -30,14 +30,16 @@ impl<Fut: Unpin> Unpin for SelectOk<Fut> {}
 ///
 /// This function will panic if the iterator specified contains no items.
 pub fn select_ok<I>(iter: I) -> SelectOk<I::Item>
-    where I: IntoIterator,
-          I::Item: TryFuture + Unpin,
+where
+    I: IntoIterator,
+    I::Item: TryFuture + Unpin,
 {
-    let ret = SelectOk {
-        inner: iter.into_iter().collect()
-    };
+    let ret = SelectOk { inner: iter.into_iter().collect() };
     assert!(!ret.inner.is_empty(), "iterator provided to select_ok was empty");
-    assert_future::<Result<(<I::Item as TryFuture>::Ok, Vec<I::Item>), <I::Item as TryFuture>::Error>, _>(ret)
+    assert_future::<
+        Result<(<I::Item as TryFuture>::Ok, Vec<I::Item>), <I::Item as TryFuture>::Error>,
+        _,
+    >(ret)
 }
 
 impl<Fut: TryFuture + Unpin> Future for SelectOk<Fut> {
@@ -46,12 +48,11 @@ impl<Fut: TryFuture + Unpin> Future for SelectOk<Fut> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // loop until we've either exhausted all errors, a success was hit, or nothing is ready
         loop {
-            let item = self.inner.iter_mut().enumerate().find_map(|(i, f)| {
-                match f.try_poll_unpin(cx) {
+            let item =
+                self.inner.iter_mut().enumerate().find_map(|(i, f)| match f.try_poll_unpin(cx) {
                     Poll::Pending => None,
                     Poll::Ready(e) => Some((i, e)),
-                }
-            });
+                });
             match item {
                 Some((idx, res)) => {
                     // always remove Ok or Err, if it's not the last Err continue looping
@@ -59,18 +60,18 @@ impl<Fut: TryFuture + Unpin> Future for SelectOk<Fut> {
                     match res {
                         Ok(e) => {
                             let rest = mem::replace(&mut self.inner, Vec::new());
-                            return Poll::Ready(Ok((e, rest)))
+                            return Poll::Ready(Ok((e, rest)));
                         }
                         Err(e) => {
                             if self.inner.is_empty() {
-                                return Poll::Ready(Err(e))
+                                return Poll::Ready(Err(e));
                             }
                         }
                     }
                 }
                 None => {
                     // based on the filter above, nothing is ready, return
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }

--- a/futures-util/src/future/try_future/into_future.rs
+++ b/futures-util/src/future/try_future/into_future.rs
@@ -21,17 +21,16 @@ impl<Fut> IntoFuture<Fut> {
 }
 
 impl<Fut: TryFuture + FusedFuture> FusedFuture for IntoFuture<Fut> {
-    fn is_terminated(&self) -> bool { self.future.is_terminated() }
+    fn is_terminated(&self) -> bool {
+        self.future.is_terminated()
+    }
 }
 
 impl<Fut: TryFuture> Future for IntoFuture<Fut> {
     type Output = Result<Fut::Ok, Fut::Error>;
 
     #[inline]
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.project().future.try_poll(cx)
     }
 }

--- a/futures-util/src/future/try_future/try_flatten.rs
+++ b/futures-util/src/future/try_future/try_flatten.rs
@@ -2,9 +2,9 @@ use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future, TryFuture};
 use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream, TryStream};
+use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
-use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -24,8 +24,9 @@ impl<Fut1, Fut2> TryFlatten<Fut1, Fut2> {
 }
 
 impl<Fut> FusedFuture for TryFlatten<Fut, Fut::Ok>
-    where Fut: TryFuture,
-          Fut::Ok: TryFuture<Error=Fut::Error>,
+where
+    Fut: TryFuture,
+    Fut::Ok: TryFuture<Error = Fut::Error>,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -36,28 +37,27 @@ impl<Fut> FusedFuture for TryFlatten<Fut, Fut::Ok>
 }
 
 impl<Fut> Future for TryFlatten<Fut, Fut::Ok>
-    where Fut: TryFuture,
-          Fut::Ok: TryFuture<Error=Fut::Error>,
+where
+    Fut: TryFuture,
+    Fut::Ok: TryFuture<Error = Fut::Error>,
 {
     type Output = Result<<Fut::Ok as TryFuture>::Ok, Fut::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                TryFlattenProj::First { f } => {
-                    match ready!(f.try_poll(cx)) {
-                        Ok(f) => self.set(Self::Second { f }),
-                        Err(e) => {
-                            self.set(Self::Empty);
-                            break Err(e);
-                        }
+                TryFlattenProj::First { f } => match ready!(f.try_poll(cx)) {
+                    Ok(f) => self.set(Self::Second { f }),
+                    Err(e) => {
+                        self.set(Self::Empty);
+                        break Err(e);
                     }
                 },
                 TryFlattenProj::Second { f } => {
                     let output = ready!(f.try_poll(cx));
                     self.set(Self::Empty);
                     break output;
-                },
+                }
                 TryFlattenProj::Empty => panic!("TryFlatten polled after completion"),
             }
         })
@@ -65,8 +65,9 @@ impl<Fut> Future for TryFlatten<Fut, Fut::Ok>
 }
 
 impl<Fut> FusedStream for TryFlatten<Fut, Fut::Ok>
-    where Fut: TryFuture,
-          Fut::Ok: TryStream<Error=Fut::Error>,
+where
+    Fut: TryFuture,
+    Fut::Ok: TryStream<Error = Fut::Error>,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -77,21 +78,20 @@ impl<Fut> FusedStream for TryFlatten<Fut, Fut::Ok>
 }
 
 impl<Fut> Stream for TryFlatten<Fut, Fut::Ok>
-    where Fut: TryFuture,
-          Fut::Ok: TryStream<Error=Fut::Error>,
+where
+    Fut: TryFuture,
+    Fut::Ok: TryStream<Error = Fut::Error>,
 {
     type Item = Result<<Fut::Ok as TryStream>::Ok, Fut::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                TryFlattenProj::First { f } => {
-                    match ready!(f.try_poll(cx)) {
-                        Ok(f) => self.set(Self::Second { f }),
-                        Err(e) => {
-                            self.set(Self::Empty);
-                            break Some(Err(e));
-                        }
+                TryFlattenProj::First { f } => match ready!(f.try_poll(cx)) {
+                    Ok(f) => self.set(Self::Second { f }),
+                    Err(e) => {
+                        self.set(Self::Empty);
+                        break Some(Err(e));
                     }
                 },
                 TryFlattenProj::Second { f } => {
@@ -100,40 +100,34 @@ impl<Fut> Stream for TryFlatten<Fut, Fut::Ok>
                         self.set(Self::Empty);
                     }
                     break output;
-                },
+                }
                 TryFlattenProj::Empty => break None,
             }
         })
     }
 }
 
-
 #[cfg(feature = "sink")]
 impl<Fut, Item> Sink<Item> for TryFlatten<Fut, Fut::Ok>
 where
     Fut: TryFuture,
-    Fut::Ok: Sink<Item, Error=Fut::Error>,
+    Fut::Ok: Sink<Item, Error = Fut::Error>,
 {
     type Error = Fut::Error;
 
-    fn poll_ready(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                TryFlattenProj::First { f } => {
-                    match ready!(f.try_poll(cx)) {
-                        Ok(f) => self.set(Self::Second { f }),
-                        Err(e) => {
-                            self.set(Self::Empty);
-                            break Err(e);
-                        }
+                TryFlattenProj::First { f } => match ready!(f.try_poll(cx)) {
+                    Ok(f) => self.set(Self::Second { f }),
+                    Err(e) => {
+                        self.set(Self::Empty);
+                        break Err(e);
                     }
                 },
                 TryFlattenProj::Second { f } => {
                     break ready!(f.poll_ready(cx));
-                },
+                }
                 TryFlattenProj::Empty => panic!("poll_ready called after eof"),
             }
         })
@@ -155,10 +149,7 @@ where
         }
     }
 
-    fn poll_close(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let res = match self.as_mut().project() {
             TryFlattenProj::Second { f } => f.poll_close(cx),
             _ => Poll::Ready(Ok(())),

--- a/futures-util/src/future/try_future/try_flatten_err.rs
+++ b/futures-util/src/future/try_future/try_flatten_err.rs
@@ -21,8 +21,9 @@ impl<Fut1, Fut2> TryFlattenErr<Fut1, Fut2> {
 }
 
 impl<Fut> FusedFuture for TryFlattenErr<Fut, Fut::Error>
-    where Fut: TryFuture,
-          Fut::Error: TryFuture<Ok=Fut::Ok>,
+where
+    Fut: TryFuture,
+    Fut::Error: TryFuture<Ok = Fut::Ok>,
 {
     fn is_terminated(&self) -> bool {
         match self {
@@ -33,28 +34,27 @@ impl<Fut> FusedFuture for TryFlattenErr<Fut, Fut::Error>
 }
 
 impl<Fut> Future for TryFlattenErr<Fut, Fut::Error>
-    where Fut: TryFuture,
-          Fut::Error: TryFuture<Ok=Fut::Ok>,
+where
+    Fut: TryFuture,
+    Fut::Error: TryFuture<Ok = Fut::Ok>,
 {
     type Output = Result<Fut::Ok, <Fut::Error as TryFuture>::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Poll::Ready(loop {
             match self.as_mut().project() {
-                TryFlattenErrProj::First { f } => {
-                    match ready!(f.try_poll(cx)) {
-                        Err(f) => self.set(Self::Second { f }),
-                        Ok(e) => {
-                            self.set(Self::Empty);
-                            break Ok(e);
-                        }
+                TryFlattenErrProj::First { f } => match ready!(f.try_poll(cx)) {
+                    Err(f) => self.set(Self::Second { f }),
+                    Ok(e) => {
+                        self.set(Self::Empty);
+                        break Ok(e);
                     }
                 },
                 TryFlattenErrProj::Second { f } => {
                     let output = ready!(f.try_poll(cx));
                     self.set(Self::Empty);
                     break output;
-                },
+                }
                 TryFlattenErrProj::Empty => panic!("TryFlattenErr polled after completion"),
             }
         })

--- a/futures-util/src/future/try_join_all.rs
+++ b/futures-util/src/future/try_join_all.rs
@@ -1,14 +1,14 @@
 //! Definition of the `TryJoinAll` combinator, waiting for all of a list of
 //! futures to finish with either success or error.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::fmt;
 use core::future::Future;
 use core::iter::FromIterator;
 use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 
 use super::{assert_future, TryFuture, TryMaybeDone};
 
@@ -16,15 +16,13 @@ fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
     // invariants aren't required to transmit through slices. Otherwise this has
     // the same safety as a normal field pin projection.
-    unsafe { slice.get_unchecked_mut() }
-        .iter_mut()
-        .map(|t| unsafe { Pin::new_unchecked(t) })
+    unsafe { slice.get_unchecked_mut() }.iter_mut().map(|t| unsafe { Pin::new_unchecked(t) })
 }
 
 enum FinalState<E = ()> {
     Pending,
     AllDone,
-    Error(E)
+    Error(E),
 }
 
 /// Future for the [`try_join_all`] function.
@@ -43,9 +41,7 @@ where
     F::Error: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TryJoinAll")
-            .field("elems", &self.elems)
-            .finish()
+        f.debug_struct("TryJoinAll").field("elems", &self.elems).finish()
     }
 }
 
@@ -93,9 +89,9 @@ where
     I::Item: TryFuture,
 {
     let elems: Box<[_]> = i.into_iter().map(TryMaybeDone::Future).collect();
-    assert_future::<Result<Vec<<I::Item as TryFuture>::Ok>, <I::Item as TryFuture>::Error>, _>(TryJoinAll {
-        elems: elems.into(),
-    })
+    assert_future::<Result<Vec<<I::Item as TryFuture>::Ok>, <I::Item as TryFuture>::Error>, _>(
+        TryJoinAll { elems: elems.into() },
+    )
 }
 
 impl<F> Future for TryJoinAll<F>
@@ -110,7 +106,7 @@ where
         for elem in iter_pin_mut(self.elems.as_mut()) {
             match elem.try_poll(cx) {
                 Poll::Pending => state = FinalState::Pending,
-                Poll::Ready(Ok(())) => {},
+                Poll::Ready(Ok(())) => {}
                 Poll::Ready(Err(e)) => {
                     state = FinalState::Error(e);
                     break;
@@ -122,15 +118,14 @@ where
             FinalState::Pending => Poll::Pending,
             FinalState::AllDone => {
                 let mut elems = mem::replace(&mut self.elems, Box::pin([]));
-                let results = iter_pin_mut(elems.as_mut())
-                    .map(|e| e.take_output().unwrap())
-                    .collect();
+                let results =
+                    iter_pin_mut(elems.as_mut()).map(|e| e.take_output().unwrap()).collect();
                 Poll::Ready(Ok(results))
-            },
+            }
             FinalState::Error(e) => {
                 let _ = mem::replace(&mut self.elems, Box::pin([]));
                 Poll::Ready(Err(e))
-            },
+            }
         }
     }
 }

--- a/futures-util/src/future/try_maybe_done.rs
+++ b/futures-util/src/future/try_maybe_done.rs
@@ -49,13 +49,13 @@ impl<Fut: TryFuture> TryMaybeDone<Fut> {
     #[inline]
     pub fn take_output(self: Pin<&mut Self>) -> Option<Fut::Ok> {
         match &*self {
-            Self::Done(_) => {},
+            Self::Done(_) => {}
             Self::Future(_) | Self::Gone => return None,
         }
         unsafe {
             match mem::replace(self.get_unchecked_mut(), Self::Gone) {
                 TryMaybeDone::Done(output) => Some(output),
-                _ => unreachable!()
+                _ => unreachable!(),
             }
         }
     }
@@ -76,16 +76,14 @@ impl<Fut: TryFuture> Future for TryMaybeDone<Fut> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         unsafe {
             match self.as_mut().get_unchecked_mut() {
-                TryMaybeDone::Future(f) => {
-                    match ready!(Pin::new_unchecked(f).try_poll(cx)) {
-                        Ok(res) => self.set(Self::Done(res)),
-                        Err(e) => {
-                            self.set(Self::Gone);
-                            return Poll::Ready(Err(e));
-                        }
+                TryMaybeDone::Future(f) => match ready!(Pin::new_unchecked(f).try_poll(cx)) {
+                    Ok(res) => self.set(Self::Done(res)),
+                    Err(e) => {
+                        self.set(Self::Gone);
+                        return Poll::Ready(Err(e));
                     }
                 },
-                TryMaybeDone::Done(_) => {},
+                TryMaybeDone::Done(_) => {}
                 TryMaybeDone::Gone => panic!("TryMaybeDone polled after value taken"),
             }
         }

--- a/futures-util/src/future/try_select.rs
+++ b/futures-util/src/future/try_select.rs
@@ -1,7 +1,7 @@
+use crate::future::{Either, TryFutureExt};
 use core::pin::Pin;
 use futures_core::future::{Future, TryFuture};
 use futures_core::task::{Context, Poll};
-use crate::future::{Either, TryFutureExt};
 
 /// Future for the [`try_select()`] function.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -48,22 +48,23 @@ impl<A: Unpin, B: Unpin> Unpin for TrySelect<A, B> {}
 /// }
 /// ```
 pub fn try_select<A, B>(future1: A, future2: B) -> TrySelect<A, B>
-    where A: TryFuture + Unpin, B: TryFuture + Unpin
+where
+    A: TryFuture + Unpin,
+    B: TryFuture + Unpin,
 {
-    super::assert_future::<Result<
-        Either<(A::Ok, B), (B::Ok, A)>,
-        Either<(A::Error, B), (B::Error, A)>,
-    >, _>(TrySelect { inner: Some((future1, future2)) })
+    super::assert_future::<
+        Result<Either<(A::Ok, B), (B::Ok, A)>, Either<(A::Error, B), (B::Error, A)>>,
+        _,
+    >(TrySelect { inner: Some((future1, future2)) })
 }
 
 impl<A: Unpin, B: Unpin> Future for TrySelect<A, B>
-    where A: TryFuture, B: TryFuture
+where
+    A: TryFuture,
+    B: TryFuture,
 {
     #[allow(clippy::type_complexity)]
-    type Output = Result<
-        Either<(A::Ok, B), (B::Ok, A)>,
-        Either<(A::Error, B), (B::Error, A)>,
-    >;
+    type Output = Result<Either<(A::Ok, B), (B::Ok, A)>, Either<(A::Error, B), (B::Error, A)>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let (mut a, mut b) = self.inner.take().expect("cannot poll Select twice");
@@ -77,7 +78,7 @@ impl<A: Unpin, B: Unpin> Future for TrySelect<A, B>
                     self.inner = Some((a, b));
                     Poll::Pending
                 }
-            }
+            },
         }
     }
 }

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -1,3 +1,4 @@
+use super::DEFAULT_BUF_SIZE;
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "read-initializer")]
@@ -7,7 +8,6 @@ use pin_project_lite::pin_project;
 use std::io::{self, Read};
 use std::pin::Pin;
 use std::{cmp, fmt};
-use super::DEFAULT_BUF_SIZE;
 
 pin_project! {
     /// The `BufReader` struct adds buffering to any reader.
@@ -51,12 +51,7 @@ impl<R: AsyncRead> BufReader<R> {
             let mut buffer = Vec::with_capacity(capacity);
             buffer.set_len(capacity);
             super::initialize(&inner, &mut buffer);
-            Self {
-                inner,
-                buffer: buffer.into_boxed_slice(),
-                pos: 0,
-                cap: 0,
-            }
+            Self { inner, buffer: buffer.into_boxed_slice(), pos: 0, cap: 0 }
         }
     }
 
@@ -123,10 +118,7 @@ impl<R: AsyncRead> AsyncRead for BufReader<R> {
 }
 
 impl<R: AsyncRead> AsyncBufRead for BufReader<R> {
-    fn poll_fill_buf(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<io::Result<&[u8]>> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         let this = self.project();
 
         // If we've reached the end of our internal buffer then we need to fetch
@@ -192,7 +184,8 @@ impl<R: AsyncRead + AsyncSeek> AsyncSeek for BufReader<R> {
             // support seeking by i64::min_value() so we need to handle underflow when subtracting
             // remainder.
             if let Some(offset) = n.checked_sub(remainder) {
-                result = ready!(self.as_mut().project().inner.poll_seek(cx, SeekFrom::Current(offset)))?;
+                result =
+                    ready!(self.as_mut().project().inner.poll_seek(cx, SeekFrom::Current(offset)))?;
             } else {
                 // seek backwards by our remainder, and then by the offset
                 ready!(self.as_mut().project().inner.poll_seek(cx, SeekFrom::Current(-remainder)))?;

--- a/futures-util/src/io/buf_writer.rs
+++ b/futures-util/src/io/buf_writer.rs
@@ -1,3 +1,4 @@
+use super::DEFAULT_BUF_SIZE;
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, IoSlice, SeekFrom};
@@ -5,7 +6,6 @@ use pin_project_lite::pin_project;
 use std::fmt;
 use std::io::{self, Write};
 use std::pin::Pin;
-use super::DEFAULT_BUF_SIZE;
 
 pin_project! {
     /// Wraps a writer and buffers its output.
@@ -46,11 +46,7 @@ impl<W: AsyncWrite> BufWriter<W> {
 
     /// Creates a new `BufWriter` with the specified buffer capacity.
     pub fn with_capacity(cap: usize, inner: W) -> Self {
-        Self {
-            inner,
-            buf: Vec::with_capacity(cap),
-            written: 0,
-        }
+        Self { inner, buf: Vec::with_capacity(cap), written: 0 }
     }
 
     fn flush_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/futures-util/src/io/chain.rs
+++ b/futures-util/src/io/chain.rs
@@ -26,11 +26,7 @@ where
     U: AsyncRead,
 {
     pub(super) fn new(first: T, second: U) -> Self {
-        Self {
-            first,
-            second,
-            done_first: false,
-        }
+        Self { first, second, done_first: false }
     }
 
     /// Gets references to the underlying readers in this `Chain`.

--- a/futures-util/src/io/copy.rs
+++ b/futures-util/src/io/copy.rs
@@ -1,10 +1,10 @@
+use super::{copy_buf, BufReader, CopyBuf};
 use futures_core::future::Future;
 use futures_core::task::{Context, Poll};
 use futures_io::{AsyncRead, AsyncWrite};
+use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
-use super::{BufReader, copy_buf, CopyBuf};
-use pin_project_lite::pin_project;
 
 /// Creates a future which copies all the bytes from one object to another.
 ///
@@ -36,9 +36,7 @@ where
     R: AsyncRead,
     W: AsyncWrite + Unpin + ?Sized,
 {
-    Copy {
-        inner: copy_buf(BufReader::new(reader), writer),
-    }
+    Copy { inner: copy_buf(BufReader::new(reader), writer) }
 }
 
 pin_project! {

--- a/futures-util/src/io/copy_buf.rs
+++ b/futures-util/src/io/copy_buf.rs
@@ -2,9 +2,9 @@ use futures_core::future::Future;
 use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::{AsyncBufRead, AsyncWrite};
+use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
-use pin_project_lite::pin_project;
 
 /// Creates a future which copies all the bytes from one object to another.
 ///
@@ -36,11 +36,7 @@ where
     R: AsyncBufRead,
     W: AsyncWrite + Unpin + ?Sized,
 {
-    CopyBuf {
-        reader,
-        writer,
-        amt: 0,
-    }
+    CopyBuf { reader, writer, amt: 0 }
 }
 
 pin_project! {
@@ -56,8 +52,9 @@ pin_project! {
 }
 
 impl<R, W> Future for CopyBuf<'_, R, W>
-    where R: AsyncBufRead,
-          W: AsyncWrite + Unpin + ?Sized,
+where
+    R: AsyncBufRead,
+    W: AsyncWrite + Unpin + ?Sized,
 {
     type Output = io::Result<u64>;
 
@@ -72,7 +69,7 @@ impl<R, W> Future for CopyBuf<'_, R, W>
 
             let i = ready!(Pin::new(&mut this.writer).poll_write(cx, buffer))?;
             if i == 0 {
-                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
             }
             *this.amt += i as u64;
             this.reader.as_mut().consume(i);

--- a/futures-util/src/io/cursor.rs
+++ b/futures-util/src/io/cursor.rs
@@ -43,9 +43,7 @@ impl<T> Cursor<T> {
     /// # force_inference(&buff);
     /// ```
     pub fn new(inner: T) -> Self {
-        Self {
-            inner: io::Cursor::new(inner),
-        }
+        Self { inner: io::Cursor::new(inner) }
     }
 
     /// Consumes this cursor, returning the underlying value.
@@ -199,15 +197,19 @@ where
 
 macro_rules! delegate_async_write_to_stdio {
     () => {
-        fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
             Poll::Ready(io::Write::write(&mut self.inner, buf))
         }
 
-        fn poll_write_vectored(mut self: Pin<&mut Self>, _: &mut Context<'_>, bufs: &[IoSlice<'_>])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
             Poll::Ready(io::Write::write_vectored(&mut self.inner, bufs))
         }
 
@@ -218,7 +220,7 @@ macro_rules! delegate_async_write_to_stdio {
         fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             self.poll_flush(cx)
         }
-    }
+    };
 }
 
 impl AsyncWrite for Cursor<&mut [u8]> {

--- a/futures-util/src/io/fill_buf.rs
+++ b/futures-util/src/io/fill_buf.rs
@@ -20,7 +20,8 @@ impl<'a, R: AsyncBufRead + ?Sized + Unpin> FillBuf<'a, R> {
 }
 
 impl<'a, R> Future for FillBuf<'a, R>
-    where R: AsyncBufRead + ?Sized + Unpin,
+where
+    R: AsyncBufRead + ?Sized + Unpin,
 {
     type Output = io::Result<&'a [u8]>;
 

--- a/futures-util/src/io/flush.rs
+++ b/futures-util/src/io/flush.rs
@@ -20,7 +20,8 @@ impl<'a, W: AsyncWrite + ?Sized + Unpin> Flush<'a, W> {
 }
 
 impl<W> Future for Flush<'_, W>
-    where W: AsyncWrite + ?Sized + Unpin,
+where
+    W: AsyncWrite + ?Sized + Unpin,
 {
     type Output = io::Result<()>;
 

--- a/futures-util/src/io/lines.rs
+++ b/futures-util/src/io/lines.rs
@@ -1,12 +1,12 @@
+use super::read_line::read_line_internal;
 use futures_core::ready;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_io::AsyncBufRead;
+use pin_project_lite::pin_project;
 use std::io;
 use std::mem;
 use std::pin::Pin;
-use super::read_line::read_line_internal;
-use pin_project_lite::pin_project;
 
 pin_project! {
     /// Stream for the [`lines`](super::AsyncBufReadExt::lines) method.
@@ -23,12 +23,7 @@ pin_project! {
 
 impl<R: AsyncBufRead> Lines<R> {
     pub(super) fn new(reader: R) -> Self {
-        Self {
-            reader,
-            buf: String::new(),
-            bytes: Vec::new(),
-            read: 0,
-        }
+        Self { reader, buf: String::new(), bytes: Vec::new(), read: 0 }
     }
 }
 
@@ -39,7 +34,7 @@ impl<R: AsyncBufRead> Stream for Lines<R> {
         let this = self.project();
         let n = ready!(read_line_internal(this.reader, cx, this.buf, this.bytes, this.read))?;
         if n == 0 && this.buf.is_empty() {
-            return Poll::Ready(None)
+            return Poll::Ready(None);
         }
         if this.buf.ends_with('\n') {
             this.buf.pop();

--- a/futures-util/src/io/read_exact.rs
+++ b/futures-util/src/io/read_exact.rs
@@ -1,6 +1,6 @@
 use crate::io::AsyncRead;
-use futures_core::ready;
 use futures_core::future::Future;
+use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use std::io;
 use std::mem;
@@ -34,7 +34,7 @@ impl<R: AsyncRead + ?Sized + Unpin> Future for ReadExact<'_, R> {
                 this.buf = rest;
             }
             if n == 0 {
-                return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()))
+                return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()));
             }
         }
         Poll::Ready(Ok(()))

--- a/futures-util/src/io/read_line.rs
+++ b/futures-util/src/io/read_line.rs
@@ -1,12 +1,12 @@
-use futures_core::ready;
+use super::read_until::read_until_internal;
 use futures_core::future::Future;
+use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::AsyncBufRead;
 use std::io;
 use std::mem;
 use std::pin::Pin;
 use std::str;
-use super::read_until::read_until_internal;
 
 /// Future for the [`read_line`](super::AsyncBufReadExt::read_line) method.
 #[derive(Debug)]
@@ -22,12 +22,7 @@ impl<R: ?Sized + Unpin> Unpin for ReadLine<'_, R> {}
 
 impl<'a, R: AsyncBufRead + ?Sized + Unpin> ReadLine<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut String) -> Self {
-        Self {
-            reader,
-            bytes: mem::replace(buf, String::new()).into_bytes(),
-            buf,
-            read: 0,
-        }
+        Self { reader, bytes: mem::replace(buf, String::new()).into_bytes(), buf, read: 0 }
     }
 }
 

--- a/futures-util/src/io/read_to_end.rs
+++ b/futures-util/src/io/read_to_end.rs
@@ -20,11 +20,7 @@ impl<R: ?Sized + Unpin> Unpin for ReadToEnd<'_, R> {}
 impl<'a, R: AsyncRead + ?Sized + Unpin> ReadToEnd<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut Vec<u8>) -> Self {
         let start_len = buf.len();
-        Self {
-            reader,
-            buf,
-            start_len,
-        }
+        Self { reader, buf, start_len }
     }
 }
 
@@ -56,10 +52,7 @@ pub(super) fn read_to_end_internal<R: AsyncRead + ?Sized>(
     buf: &mut Vec<u8>,
     start_len: usize,
 ) -> Poll<io::Result<usize>> {
-    let mut g = Guard {
-        len: buf.len(),
-        buf,
-    };
+    let mut g = Guard { len: buf.len(), buf };
     loop {
         if g.len == g.buf.len() {
             unsafe {

--- a/futures-util/src/io/read_to_string.rs
+++ b/futures-util/src/io/read_to_string.rs
@@ -1,6 +1,6 @@
 use super::read_to_end::read_to_end_internal;
-use futures_core::ready;
 use futures_core::future::Future;
+use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::AsyncRead;
 use std::pin::Pin;
@@ -22,12 +22,7 @@ impl<R: ?Sized + Unpin> Unpin for ReadToString<'_, R> {}
 impl<'a, R: AsyncRead + ?Sized + Unpin> ReadToString<'a, R> {
     pub(super) fn new(reader: &'a mut R, buf: &'a mut String) -> Self {
         let start_len = buf.len();
-        Self {
-            reader,
-            bytes: mem::replace(buf, String::new()).into_bytes(),
-            buf,
-            start_len,
-        }
+        Self { reader, bytes: mem::replace(buf, String::new()).into_bytes(), buf, start_len }
     }
 }
 
@@ -41,10 +36,7 @@ fn read_to_string_internal<R: AsyncRead + ?Sized>(
     let ret = ready!(read_to_end_internal(reader, cx, bytes, start_len));
     if str::from_utf8(bytes).is_err() {
         Poll::Ready(ret.and_then(|_| {
-            Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "stream did not contain valid UTF-8",
-            ))
+            Err(io::Error::new(io::ErrorKind::InvalidData, "stream did not contain valid UTF-8"))
         }))
     } else {
         debug_assert!(buf.is_empty());

--- a/futures-util/src/io/take.rs
+++ b/futures-util/src/io/take.rs
@@ -2,10 +2,10 @@ use futures_core::ready;
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "read-initializer")]
 use futures_io::Initializer;
-use futures_io::{AsyncRead, AsyncBufRead};
+use futures_io::{AsyncBufRead, AsyncRead};
 use pin_project_lite::pin_project;
-use std::{cmp, io};
 use std::pin::Pin;
+use std::{cmp, io};
 
 pin_project! {
     /// Reader for the [`take`](super::AsyncReadExt::take) method.

--- a/futures-util/src/io/window.rs
+++ b/futures-util/src/io/window.rs
@@ -30,10 +30,7 @@ impl<T: AsRef<[u8]>> Window<T> {
     /// Further methods can be called on the returned `Window<T>` to alter the
     /// window into the data provided.
     pub fn new(t: T) -> Self {
-        Self {
-            range: 0..t.as_ref().len(),
-            inner: t,
-        }
+        Self { range: 0..t.as_ref().len(), inner: t }
     }
 
     /// Gets a shared reference to the underlying buffer inside of this

--- a/futures-util/src/io/write_all_vectored.rs
+++ b/futures-util/src/io/write_all_vectored.rs
@@ -1,5 +1,5 @@
-use futures_core::ready;
 use futures_core::future::Future;
+use futures_core::ready;
 use futures_core::task::{Context, Poll};
 use futures_io::AsyncWrite;
 use futures_io::IoSlice;
@@ -56,11 +56,7 @@ mod tests {
     /// Create a new writer that reads from at most `n_bufs` and reads
     /// `per_call` bytes (in total) per call to write.
     fn test_writer(n_bufs: usize, per_call: usize) -> TestWriter {
-        TestWriter {
-            n_bufs,
-            per_call,
-            written: Vec::new(),
-        }
+        TestWriter { n_bufs, per_call, written: Vec::new() }
     }
 
     // TODO: maybe move this the future-test crate?
@@ -110,10 +106,9 @@ mod tests {
             let expected = $expected;
             match $e {
                 Poll::Ready(Ok(ok)) if ok == expected => {}
-                got => panic!(
-                    "unexpected result, got: {:?}, wanted: Ready(Ok({:?}))",
-                    got, expected
-                ),
+                got => {
+                    panic!("unexpected result, got: {:?}, wanted: Ready(Ok({:?}))", got, expected)
+                }
             }
         };
     }
@@ -154,11 +149,7 @@ mod tests {
         assert_poll_ok!(dst.as_mut().poll_write_vectored(&mut cx, bufs), 3);
 
         // Read at most 3 bytes from three buffers.
-        let bufs = &[
-            IoSlice::new(&[3]),
-            IoSlice::new(&[4]),
-            IoSlice::new(&[5, 5]),
-        ];
+        let bufs = &[IoSlice::new(&[3]), IoSlice::new(&[4]), IoSlice::new(&[5, 5])];
         assert_poll_ok!(dst.as_mut().poll_write_vectored(&mut cx, bufs), 3);
 
         assert_eq!(dst.written, &[1, 2, 2, 3, 4, 5]);

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -5,12 +5,7 @@
 #![cfg_attr(feature = "read-initializer", feature(read_initializer))]
 #![cfg_attr(feature = "write-all-vectored", feature(io_slice_advance))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]

--- a/futures-util/src/sink/buffer.rs
+++ b/futures-util/src/sink/buffer.rs
@@ -1,10 +1,10 @@
+use alloc::collections::VecDeque;
+use core::pin::Pin;
 use futures_core::ready;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
-use core::pin::Pin;
-use alloc::collections::VecDeque;
 
 pin_project! {
     /// Sink for the [`buffer`](super::SinkExt::buffer) method.
@@ -22,19 +22,12 @@ pin_project! {
 
 impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
     pub(super) fn new(sink: Si, capacity: usize) -> Self {
-        Self {
-            sink,
-            buf: VecDeque::with_capacity(capacity),
-            capacity,
-        }
+        Self { sink, buf: VecDeque::with_capacity(capacity), capacity }
     }
 
     delegate_access_inner!(sink, Si, ());
 
-    fn try_empty_buffer(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Si::Error>> {
+    fn try_empty_buffer(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Si::Error>> {
         let mut this = self.project();
         ready!(this.sink.as_mut().poll_ready(cx))?;
         while let Some(item) = this.buf.pop_front() {
@@ -48,7 +41,10 @@ impl<Si: Sink<Item>, Item> Buffer<Si, Item> {
 }
 
 // Forwarding impl of Stream from the underlying sink
-impl<S, Item> Stream for Buffer<S, Item> where S: Sink<Item> + Stream {
+impl<S, Item> Stream for Buffer<S, Item>
+where
+    S: Sink<Item> + Stream,
+{
     type Item = S::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {
@@ -60,7 +56,10 @@ impl<S, Item> Stream for Buffer<S, Item> where S: Sink<Item> + Stream {
     }
 }
 
-impl<S, Item> FusedStream for Buffer<S, Item> where S: Sink<Item> + FusedStream {
+impl<S, Item> FusedStream for Buffer<S, Item>
+where
+    S: Sink<Item> + FusedStream,
+{
     fn is_terminated(&self) -> bool {
         self.sink.is_terminated()
     }
@@ -69,10 +68,7 @@ impl<S, Item> FusedStream for Buffer<S, Item> where S: Sink<Item> + FusedStream 
 impl<Si: Sink<Item>, Item> Sink<Item> for Buffer<Si, Item> {
     type Error = Si::Error;
 
-    fn poll_ready(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         if self.capacity == 0 {
             return self.project().sink.poll_ready(cx);
         }
@@ -86,10 +82,7 @@ impl<Si: Sink<Item>, Item> Sink<Item> for Buffer<Si, Item> {
         }
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        item: Item,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
         if self.capacity == 0 {
             self.project().sink.start_send(item)
         } else {
@@ -99,20 +92,14 @@ impl<Si: Sink<Item>, Item> Sink<Item> for Buffer<Si, Item> {
     }
 
     #[allow(clippy::debug_assert_with_mut_call)]
-    fn poll_flush(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         ready!(self.as_mut().try_empty_buffer(cx))?;
         debug_assert!(self.buf.is_empty());
         self.project().sink.poll_flush(cx)
     }
 
     #[allow(clippy::debug_assert_with_mut_call)]
-    fn poll_close(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         ready!(self.as_mut().try_empty_buffer(cx))?;
         debug_assert!(self.buf.is_empty());
         self.project().sink.poll_close(cx)

--- a/futures-util/src/sink/close.rs
+++ b/futures-util/src/sink/close.rs
@@ -19,20 +19,14 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Close<'_, Si, Item> {}
 /// The sink itself is returned after closing is complete.
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Close<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si) -> Self {
-        Self {
-            sink,
-            _phantom: PhantomData,
-        }
+        Self { sink, _phantom: PhantomData }
     }
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Close<'_, Si, Item> {
     type Output = Result<(), Si::Error>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.sink).poll_close(cx)
     }
 }

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -35,31 +35,19 @@ impl<T> Unpin for Drain<T> {}
 impl<T> Sink<T> for Drain<T> {
     type Error = Infallible;
 
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        _item: T,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, _item: T) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
-    fn poll_close(
-        self: Pin<&mut Self>,
-        _cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 }

--- a/futures-util/src/sink/err_into.rs
+++ b/futures-util/src/sink/err_into.rs
@@ -1,6 +1,6 @@
 use crate::sink::{SinkExt, SinkMapErr};
-use futures_core::stream::{Stream, FusedStream};
-use futures_sink::{Sink};
+use futures_core::stream::{FusedStream, Stream};
+use futures_sink::Sink;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -14,21 +14,21 @@ pin_project! {
 }
 
 impl<Si, E, Item> SinkErrInto<Si, Item, E>
-    where Si: Sink<Item>,
-          Si::Error: Into<E>,
+where
+    Si: Sink<Item>,
+    Si::Error: Into<E>,
 {
     pub(super) fn new(sink: Si) -> Self {
-        Self {
-            sink: SinkExt::sink_map_err(sink, Into::into),
-        }
+        Self { sink: SinkExt::sink_map_err(sink, Into::into) }
     }
 
     delegate_access_inner!(sink, Si, (.));
 }
 
 impl<Si, Item, E> Sink<Item> for SinkErrInto<Si, Item, E>
-    where Si: Sink<Item>,
-          Si::Error: Into<E>,
+where
+    Si: Sink<Item>,
+    Si::Error: Into<E>,
 {
     type Error = E;
 
@@ -37,8 +37,9 @@ impl<Si, Item, E> Sink<Item> for SinkErrInto<Si, Item, E>
 
 // Forwarding impl of Stream from the underlying sink
 impl<S, Item, E> Stream for SinkErrInto<S, Item, E>
-    where S: Sink<Item> + Stream,
-          S::Error: Into<E>
+where
+    S: Sink<Item> + Stream,
+    S::Error: Into<E>,
 {
     type Item = S::Item;
 
@@ -46,8 +47,9 @@ impl<S, Item, E> Stream for SinkErrInto<S, Item, E>
 }
 
 impl<S, Item, E> FusedStream for SinkErrInto<S, Item, E>
-    where S: Sink<Item> + FusedStream,
-          S::Error: Into<E>
+where
+    S: Sink<Item> + FusedStream,
+    S::Error: Into<E>,
 {
     fn is_terminated(&self) -> bool {
         self.sink.is_terminated()

--- a/futures-util/src/sink/fanout.rs
+++ b/futures-util/src/sink/fanout.rs
@@ -50,36 +50,32 @@ impl<Si1, Si2> Fanout<Si1, Si2> {
 
 impl<Si1: Debug, Si2: Debug> Debug for Fanout<Si1, Si2> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        f.debug_struct("Fanout")
-            .field("sink1", &self.sink1)
-            .field("sink2", &self.sink2)
-            .finish()
+        f.debug_struct("Fanout").field("sink1", &self.sink1).field("sink2", &self.sink2).finish()
     }
 }
 
 impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
-    where Si1: Sink<Item>,
-          Item: Clone,
-          Si2: Sink<Item, Error=Si1::Error>
+where
+    Si1: Sink<Item>,
+    Item: Clone,
+    Si2: Sink<Item, Error = Si1::Error>,
 {
     type Error = Si1::Error;
 
-    fn poll_ready(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
 
         let sink1_ready = this.sink1.poll_ready(cx)?.is_ready();
         let sink2_ready = this.sink2.poll_ready(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;
-        if ready { Poll::Ready(Ok(())) } else { Poll::Pending }
+        if ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 
-    fn start_send(
-        self: Pin<&mut Self>,
-        item: Item,
-    ) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: Item) -> Result<(), Self::Error> {
         let this = self.project();
 
         this.sink1.start_send(item.clone())?;
@@ -87,27 +83,29 @@ impl<Si1, Si2, Item> Sink<Item> for Fanout<Si1, Si2>
         Ok(())
     }
 
-    fn poll_flush(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
 
         let sink1_ready = this.sink1.poll_flush(cx)?.is_ready();
         let sink2_ready = this.sink2.poll_flush(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;
-        if ready { Poll::Ready(Ok(())) } else { Poll::Pending }
+        if ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 
-    fn poll_close(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), Self::Error>> {
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let this = self.project();
 
         let sink1_ready = this.sink1.poll_close(cx)?.is_ready();
         let sink2_ready = this.sink2.poll_close(cx)?.is_ready();
         let ready = sink1_ready && sink2_ready;
-        if ready { Poll::Ready(Ok(())) } else { Poll::Pending }
+        if ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
     }
 }

--- a/futures-util/src/sink/feed.rs
+++ b/futures-util/src/sink/feed.rs
@@ -17,10 +17,7 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Feed<'_, Si, Item> {}
 
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Feed<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si, item: Item) -> Self {
-        Feed {
-            sink,
-            item: Some(item),
-        }
+        Feed { sink, item: Some(item) }
     }
 
     pub(super) fn sink_pin_mut(&mut self) -> Pin<&mut Si> {
@@ -35,10 +32,7 @@ impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Feed<'a, Si, Item> {
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Feed<'_, Si, Item> {
     type Output = Result<(), Si::Error>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         let mut sink = Pin::new(&mut this.sink);
         ready!(sink.as_mut().poll_ready(cx))?;

--- a/futures-util/src/sink/flush.rs
+++ b/futures-util/src/sink/flush.rs
@@ -23,20 +23,14 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Flush<'_, Si, Item> {}
 /// all current requests are processed.
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Flush<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si) -> Self {
-        Self {
-            sink,
-            _phantom: PhantomData,
-        }
+        Self { sink, _phantom: PhantomData }
     }
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Flush<'_, Si, Item> {
     type Output = Result<(), Si::Error>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.sink).poll_flush(cx)
     }
 }

--- a/futures-util/src/sink/send.rs
+++ b/futures-util/src/sink/send.rs
@@ -17,19 +17,14 @@ impl<Si: Unpin + ?Sized, Item> Unpin for Send<'_, Si, Item> {}
 
 impl<'a, Si: Sink<Item> + Unpin + ?Sized, Item> Send<'a, Si, Item> {
     pub(super) fn new(sink: &'a mut Si, item: Item) -> Self {
-        Self {
-            feed: Feed::new(sink, item),
-        }
+        Self { feed: Feed::new(sink, item) }
     }
 }
 
 impl<Si: Sink<Item> + Unpin + ?Sized, Item> Future for Send<'_, Si, Item> {
     type Output = Result<(), Si::Error>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
 
         if this.feed.is_item_pending() {

--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -41,10 +41,7 @@ where
     F: FnMut(T, Item) -> R,
     R: Future<Output = Result<T, E>>,
 {
-    assert_sink::<Item, E, _>(Unfold {
-        function,
-        state: UnfoldState::Value { value: init },
-    })
+    assert_sink::<Item, E, _>(Unfold { function, state: UnfoldState::Value { value: init } })
 }
 
 impl<T, F, R, Item, E> Sink<Item> for Unfold<T, F, R>

--- a/futures-util/src/stream/empty.rs
+++ b/futures-util/src/stream/empty.rs
@@ -8,16 +8,14 @@ use futures_core::task::{Context, Poll};
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Empty<T> {
-    _phantom: PhantomData<T>
+    _phantom: PhantomData<T>,
 }
 
 /// Creates a stream which contains no elements.
 ///
 /// The returned stream will always return `Ready(None)` when polled.
 pub fn empty<T>() -> Empty<T> {
-    assert_stream::<T, _>(Empty {
-        _phantom: PhantomData
-    })
+    assert_stream::<T, _>(Empty { _phantom: PhantomData })
 }
 
 impl<T> Unpin for Empty<T> {}

--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -27,15 +27,15 @@ impl<I> Unpin for Iter<I> {}
 /// # });
 /// ```
 pub fn iter<I>(i: I) -> Iter<I::IntoIter>
-    where I: IntoIterator,
+where
+    I: IntoIterator,
 {
-    assert_stream::<I::Item, _>(Iter {
-        iter: i.into_iter(),
-    })
+    assert_stream::<I::Item, _>(Iter { iter: i.into_iter() })
 }
 
 impl<I> Stream for Iter<I>
-    where I: Iterator,
+where
+    I: Iterator,
 {
     type Item = I::Item;
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -19,8 +19,9 @@ pub use futures_core::stream::{FusedStream, Stream, TryStream};
 mod stream;
 pub use self::stream::{
     Chain, Collect, Concat, Cycle, Enumerate, Filter, FilterMap, FlatMap, Flatten, Fold, ForEach,
-    Fuse, Inspect, Map, Next, NextIf, NextIfEq, Peek, Peekable, Scan, SelectNextSome, Skip, SkipWhile, StreamExt,
-    StreamFuture, Take, TakeUntil, TakeWhile, Then, TryFold, TryForEach, Unzip, Zip,
+    Fuse, Inspect, Map, Next, NextIf, NextIfEq, Peek, Peekable, Scan, SelectNextSome, Skip,
+    SkipWhile, StreamExt, StreamFuture, Take, TakeUntil, TakeWhile, Then, TryFold, TryForEach,
+    Unzip, Zip,
 };
 
 #[cfg(feature = "std")]
@@ -49,8 +50,8 @@ pub use self::stream::{ReuniteError, SplitSink, SplitStream};
 mod try_stream;
 pub use self::try_stream::{
     try_unfold, AndThen, ErrInto, InspectErr, InspectOk, IntoStream, MapErr, MapOk, OrElse,
-    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext,
-    TrySkipWhile, TryStreamExt, TryTakeWhile, TryUnfold,
+    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext, TrySkipWhile,
+    TryStreamExt, TryTakeWhile, TryUnfold,
 };
 
 #[cfg(feature = "io")]

--- a/futures-util/src/stream/once.rs
+++ b/futures-util/src/stream/once.rs
@@ -2,7 +2,7 @@ use super::assert_stream;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 

--- a/futures-util/src/stream/repeat.rs
+++ b/futures-util/src/stream/repeat.rs
@@ -1,6 +1,6 @@
 use super::assert_stream;
 use core::pin::Pin;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 
 /// Stream for the [`repeat`] function.
@@ -25,7 +25,8 @@ pub struct Repeat<T> {
 /// # });
 /// ```
 pub fn repeat<T>(item: T) -> Repeat<T>
-    where T: Clone
+where
+    T: Clone,
 {
     assert_stream::<T, _>(Repeat { item })
 }
@@ -33,7 +34,8 @@ pub fn repeat<T>(item: T) -> Repeat<T>
 impl<T> Unpin for Repeat<T> {}
 
 impl<T> Stream for Repeat<T>
-    where T: Clone
+where
+    T: Clone,
 {
     type Item = T;
 
@@ -47,7 +49,8 @@ impl<T> Stream for Repeat<T>
 }
 
 impl<T> FusedStream for Repeat<T>
-    where T: Clone,
+where
+    T: Clone,
 {
     fn is_terminated(&self) -> bool {
         false

--- a/futures-util/src/stream/repeat_with.rs
+++ b/futures-util/src/stream/repeat_with.rs
@@ -1,6 +1,6 @@
 use super::assert_stream;
 use core::pin::Pin;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 
 /// An stream that repeats elements of type `A` endlessly by
@@ -28,8 +28,7 @@ impl<A, F: FnMut() -> A> Stream for RepeatWith<F> {
     }
 }
 
-impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F>
-{
+impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F> {
     fn is_terminated(&self) -> bool {
         false
     }

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,5 +1,5 @@
 use super::assert_stream;
-use crate::stream::{StreamExt, Fuse};
+use crate::stream::{Fuse, StreamExt};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -29,8 +29,9 @@ pin_project! {
 /// Note that this function consumes both streams and returns a wrapped
 /// version of them.
 pub fn select<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2>
-    where St1: Stream,
-          St2: Stream<Item = St1::Item>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     assert_stream::<St1::Item, _>(Select {
         stream1: stream1.fuse(),
@@ -75,8 +76,9 @@ impl<St1, St2> Select<St1, St2> {
 }
 
 impl<St1, St2> FusedStream for Select<St1, St2>
-    where St1: Stream,
-          St2: Stream<Item = St1::Item>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     fn is_terminated(&self) -> bool {
         self.stream1.is_terminated() && self.stream2.is_terminated()
@@ -84,15 +86,13 @@ impl<St1, St2> FusedStream for Select<St1, St2>
 }
 
 impl<St1, St2> Stream for Select<St1, St2>
-    where St1: Stream,
-          St2: Stream<Item = St1::Item>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     type Item = St1::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<St1::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St1::Item>> {
         let this = self.project();
         if !*this.flag {
             poll_inner(this.flag, this.stream1, this.stream2, cx)
@@ -106,24 +106,24 @@ fn poll_inner<St1, St2>(
     flag: &mut bool,
     a: Pin<&mut St1>,
     b: Pin<&mut St2>,
-    cx: &mut Context<'_>
+    cx: &mut Context<'_>,
 ) -> Poll<Option<St1::Item>>
-    where St1: Stream, St2: Stream<Item = St1::Item>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     let a_done = match a.poll_next(cx) {
         Poll::Ready(Some(item)) => {
             // give the other stream a chance to go first next time
             *flag = !*flag;
-            return Poll::Ready(Some(item))
-        },
+            return Poll::Ready(Some(item));
+        }
         Poll::Ready(None) => true,
         Poll::Pending => false,
     };
 
     match b.poll_next(cx) {
-        Poll::Ready(Some(item)) => {
-            Poll::Ready(Some(item))
-        }
+        Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
         Poll::Ready(None) if a_done => Poll::Ready(None),
         Poll::Ready(None) | Poll::Pending => Poll::Pending,
     }

--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -18,20 +18,19 @@ pin_project! {
 
 // All interactions with `Pin<&mut Chain<..>>` happen through these methods
 impl<St1, St2> Chain<St1, St2>
-where St1: Stream,
-      St2: Stream<Item = St1::Item>,
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     pub(super) fn new(stream1: St1, stream2: St2) -> Self {
-        Self {
-            first: Some(stream1),
-            second: stream2,
-        }
+        Self { first: Some(stream1), second: stream2 }
     }
 }
 
 impl<St1, St2> FusedStream for Chain<St1, St2>
-where St1: Stream,
-      St2: FusedStream<Item=St1::Item>,
+where
+    St1: Stream,
+    St2: FusedStream<Item = St1::Item>,
 {
     fn is_terminated(&self) -> bool {
         self.first.is_none() && self.second.is_terminated()
@@ -39,19 +38,17 @@ where St1: Stream,
 }
 
 impl<St1, St2> Stream for Chain<St1, St2>
-where St1: Stream,
-      St2: Stream<Item=St1::Item>,
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
 {
     type Item = St1::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         if let Some(first) = this.first.as_mut().as_pin_mut() {
             if let Some(item) = ready!(first.poll_next(cx)) {
-                return Poll::Ready(Some(item))
+                return Poll::Ready(Some(item));
             }
         }
         this.first.set(None);
@@ -67,7 +64,7 @@ where St1: Stream,
 
             let upper = match (first_upper, second_upper) {
                 (Some(x), Some(y)) => x.checked_add(y),
-                _ => None
+                _ => None,
             };
 
             (lower, upper)

--- a/futures-util/src/stream/stream/collect.rs
+++ b/futures-util/src/stream/stream/collect.rs
@@ -23,16 +23,14 @@ impl<St: Stream, C: Default> Collect<St, C> {
     }
 
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            collection: Default::default(),
-        }
+        Self { stream, collection: Default::default() }
     }
 }
 
 impl<St, C> FusedFuture for Collect<St, C>
-where St: FusedStream,
-      C: Default + Extend<St:: Item>
+where
+    St: FusedStream,
+    C: Default + Extend<St::Item>,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
@@ -40,8 +38,9 @@ where St: FusedStream,
 }
 
 impl<St, C> Future for Collect<St, C>
-where St: Stream,
-      C: Default + Extend<St:: Item>
+where
+    St: Stream,
+    C: Default + Extend<St::Item>,
 {
     type Output = C;
 

--- a/futures-util/src/stream/stream/concat.rs
+++ b/futures-util/src/stream/stream/concat.rs
@@ -1,7 +1,7 @@
 use core::pin::Pin;
-use futures_core::future::{Future, FusedFuture};
+use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
@@ -17,35 +17,28 @@ pin_project! {
 }
 
 impl<St> Concat<St>
-where St: Stream,
-      St::Item: Extend<<St::Item as IntoIterator>::Item> +
-                IntoIterator + Default,
+where
+    St: Stream,
+    St::Item: Extend<<St::Item as IntoIterator>::Item> + IntoIterator + Default,
 {
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            accum: None,
-        }
+        Self { stream, accum: None }
     }
 }
 
 impl<St> Future for Concat<St>
-where St: Stream,
-      St::Item: Extend<<St::Item as IntoIterator>::Item> +
-                IntoIterator + Default,
+where
+    St: Stream,
+    St::Item: Extend<<St::Item as IntoIterator>::Item> + IntoIterator + Default,
 {
     type Output = St::Item;
 
-    fn poll(
-        self: Pin<&mut Self>, cx: &mut Context<'_>
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
 
         loop {
             match ready!(this.stream.as_mut().poll_next(cx)) {
-                None => {
-                    return Poll::Ready(this.accum.take().unwrap_or_default())
-                }
+                None => return Poll::Ready(this.accum.take().unwrap_or_default()),
                 Some(e) => {
                     if let Some(a) = this.accum {
                         a.extend(e)
@@ -59,9 +52,9 @@ where St: Stream,
 }
 
 impl<St> FusedFuture for Concat<St>
-where St: FusedStream,
-      St::Item: Extend<<St::Item as IntoIterator>::Item> +
-                IntoIterator + Default,
+where
+    St: FusedStream,
+    St::Item: Extend<<St::Item as IntoIterator>::Item> + IntoIterator + Default,
 {
     fn is_terminated(&self) -> bool {
         self.accum.is_none() && self.stream.is_terminated()

--- a/futures-util/src/stream/stream/cycle.rs
+++ b/futures-util/src/stream/stream/cycle.rs
@@ -21,10 +21,7 @@ where
     St: Clone + Stream,
 {
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            orig: stream.clone(),
-            stream,
-        }
+        Self { orig: stream.clone(), stream }
     }
 }
 

--- a/futures-util/src/stream/stream/enumerate.rs
+++ b/futures-util/src/stream/stream/enumerate.rs
@@ -19,10 +19,7 @@ pin_project! {
 
 impl<St: Stream> Enumerate<St> {
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            count: 0,
-        }
+        Self { stream, count: 0 }
     }
 
     delegate_access_inner!(stream, St, ());
@@ -37,10 +34,7 @@ impl<St: Stream + FusedStream> FusedStream for Enumerate<St> {
 impl<St: Stream> Stream for Enumerate<St> {
     type Item = (usize, St::Item);
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
 
         match ready!(this.stream.poll_next(cx)) {

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -1,3 +1,4 @@
+use crate::fns::FnMut1;
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
@@ -7,7 +8,6 @@ use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
-use crate::fns::FnMut1;
 
 pin_project! {
     /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
@@ -35,9 +35,10 @@ where
 }
 
 impl<St, Fut, F> FilterMap<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, f, pending: None }
@@ -47,9 +48,10 @@ impl<St, Fut, F> FilterMap<St, Fut, F>
 }
 
 impl<St, Fut, F, T> FusedStream for FilterMap<St, Fut, F>
-    where St: Stream + FusedStream,
-          F: FnMut1<St::Item, Output=Fut>,
-          Fut: Future<Output = Option<T>>,
+where
+    St: Stream + FusedStream,
+    F: FnMut1<St::Item, Output = Fut>,
+    Fut: Future<Output = Option<T>>,
 {
     fn is_terminated(&self) -> bool {
         self.pending.is_none() && self.stream.is_terminated()
@@ -57,16 +59,14 @@ impl<St, Fut, F, T> FusedStream for FilterMap<St, Fut, F>
 }
 
 impl<St, Fut, F, T> Stream for FilterMap<St, Fut, F>
-    where St: Stream,
-          F: FnMut1<St::Item, Output=Fut>,
-          Fut: Future<Output = Option<T>>,
+where
+    St: Stream,
+    F: FnMut1<St::Item, Output = Fut>,
+    Fut: Future<Output = Option<T>>,
 {
     type Item = T;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<T>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
         let mut this = self.project();
         Poll::Ready(loop {
             if let Some(p) = this.pending.as_mut().as_pin_mut() {
@@ -100,9 +100,10 @@ impl<St, Fut, F, T> Stream for FilterMap<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for FilterMap<S, Fut, F>
-    where S: Stream + Sink<Item>,
-          F: FnMut1<S::Item, Output=Fut>,
-          Fut: Future,
+where
+    S: Stream + Sink<Item>,
+    F: FnMut1<S::Item, Output = Fut>,
+    Fut: Future,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/stream/fold.rs
+++ b/futures-util/src/stream/stream/fold.rs
@@ -35,24 +35,21 @@ where
 }
 
 impl<St, Fut, T, F> Fold<St, Fut, T, F>
-where St: Stream,
-      F: FnMut(T, St::Item) -> Fut,
-      Fut: Future<Output = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: Future<Output = T>,
 {
     pub(super) fn new(stream: St, f: F, t: T) -> Self {
-        Self {
-            stream,
-            f,
-            accum: Some(t),
-            future: None,
-        }
+        Self { stream, f, accum: Some(t), future: None }
     }
 }
 
 impl<St, Fut, T, F> FusedFuture for Fold<St, Fut, T, F>
-    where St: Stream,
-          F: FnMut(T, St::Item) -> Fut,
-          Fut: Future<Output = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: Future<Output = T>,
 {
     fn is_terminated(&self) -> bool {
         self.accum.is_none() && self.future.is_none()
@@ -60,9 +57,10 @@ impl<St, Fut, T, F> FusedFuture for Fold<St, Fut, T, F>
 }
 
 impl<St, Fut, T, F> Future for Fold<St, Fut, T, F>
-    where St: Stream,
-          F: FnMut(T, St::Item) -> Fut,
-          Fut: Future<Output = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: Future<Output = T>,
 {
     type Output = T;
 

--- a/futures-util/src/stream/stream/for_each.rs
+++ b/futures-util/src/stream/stream/for_each.rs
@@ -32,23 +32,21 @@ where
 }
 
 impl<St, Fut, F> ForEach<St, Fut, F>
-where St: Stream,
-      F: FnMut(St::Item) -> Fut,
-      Fut: Future<Output = ()>,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = ()>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            future: None,
-        }
+        Self { stream, f, future: None }
     }
 }
 
 impl<St, Fut, F> FusedFuture for ForEach<St, Fut, F>
-    where St: FusedStream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future<Output = ()>,
+where
+    St: FusedStream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = ()>,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
@@ -56,9 +54,10 @@ impl<St, Fut, F> FusedFuture for ForEach<St, Fut, F>
 }
 
 impl<St, Fut, F> Future for ForEach<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future<Output = ()>,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = ()>,
 {
     type Output = ();
 

--- a/futures-util/src/stream/stream/forward.rs
+++ b/futures-util/src/stream/stream/forward.rs
@@ -23,11 +23,7 @@ pin_project! {
 
 impl<St, Si, Item> Forward<St, Si, Item> {
     pub(crate) fn new(stream: St, sink: Si) -> Self {
-        Self {
-            sink: Some(sink),
-            stream: Fuse::new(stream),
-            buffered_item: None,
-        }
+        Self { sink: Some(sink), stream: Fuse::new(stream), buffered_item: None }
     }
 }
 
@@ -48,10 +44,7 @@ where
 {
     type Output = Result<(), E>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let ForwardProj { mut sink, mut stream, buffered_item } = self.project();
         let mut si = sink.as_mut().as_pin_mut().expect("polled `Forward` after completion");
 
@@ -70,11 +63,11 @@ where
                 Poll::Ready(None) => {
                     ready!(si.poll_close(cx))?;
                     sink.set(None);
-                    return Poll::Ready(Ok(()))
+                    return Poll::Ready(Ok(()));
                 }
                 Poll::Pending => {
                     ready!(si.poll_flush(cx))?;
-                    return Poll::Pending
+                    return Poll::Pending;
                 }
             }
         }

--- a/futures-util/src/stream/stream/fuse.rs
+++ b/futures-util/src/stream/stream/fuse.rs
@@ -43,10 +43,7 @@ impl<S: Stream> FusedStream for Fuse<S> {
 impl<S: Stream> Stream for Fuse<S> {
     type Item = S::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<S::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {
         let this = self.project();
 
         if *this.done {

--- a/futures-util/src/stream/stream/into_future.rs
+++ b/futures-util/src/stream/stream/into_future.rs
@@ -79,10 +79,7 @@ impl<St: Stream + Unpin> FusedFuture for StreamFuture<St> {
 impl<St: Stream + Unpin> Future for StreamFuture<St> {
     type Output = (Option<St::Item>, St);
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let item = {
             let s = self.stream.as_mut().expect("polling StreamFuture twice");
             ready!(s.poll_next_unpin(cx))

--- a/futures-util/src/stream/stream/map.rs
+++ b/futures-util/src/stream/stream/map.rs
@@ -24,9 +24,7 @@ where
     St: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Map")
-            .field("stream", &self.stream)
-            .finish()
+        f.debug_struct("Map").field("stream", &self.stream).finish()
     }
 }
 
@@ -39,8 +37,9 @@ impl<St, F> Map<St, F> {
 }
 
 impl<St, F> FusedStream for Map<St, F>
-    where St: FusedStream,
-          F: FnMut1<St::Item>,
+where
+    St: FusedStream,
+    F: FnMut1<St::Item>,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
@@ -48,15 +47,13 @@ impl<St, F> FusedStream for Map<St, F>
 }
 
 impl<St, F> Stream for Map<St, F>
-    where St: Stream,
-          F: FnMut1<St::Item>,
+where
+    St: Stream,
+    F: FnMut1<St::Item>,
 {
     type Item = F::Output;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         let res = ready!(this.stream.as_mut().poll_next(cx));
         Poll::Ready(res.map(|x| this.f.call_mut(x)))
@@ -70,8 +67,9 @@ impl<St, F> Stream for Map<St, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<St, F, Item> Sink<Item> for Map<St, F>
-    where St: Stream + Sink<Item>,
-          F: FnMut1<St::Item>,
+where
+    St: Stream + Sink<Item>,
+    F: FnMut1<St::Item>,
 {
     type Error = St::Error;
 

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -123,7 +123,7 @@ pub use self::select_next_some::SelectNextSome;
 
 mod peek;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::peek::{Peek, Peekable, NextIf, NextIfEq};
+pub use self::peek::{NextIf, NextIfEq, Peek, Peekable};
 
 mod skip;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
@@ -1078,11 +1078,7 @@ pub trait StreamExt: Stream {
         Fut: Future<Output = Result<(), E>>,
         Self: Sized,
     {
-        assert_future::<Result<(), E>, _>(TryForEachConcurrent::new(
-            self,
-            limit.into(),
-            f,
-        ))
+        assert_future::<Result<(), E>, _>(TryForEachConcurrent::new(self, limit.into(), f))
     }
 
     /// Creates a new stream of at most `n` items of the underlying stream.

--- a/futures-util/src/stream/stream/next.rs
+++ b/futures-util/src/stream/stream/next.rs
@@ -28,10 +28,7 @@ impl<St: ?Sized + FusedStream + Unpin> FusedFuture for Next<'_, St> {
 impl<St: ?Sized + Stream + Unpin> Future for Next<'_, St> {
     type Output = Option<St::Item>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.stream.poll_next_unpin(cx)
     }
 }

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -28,10 +28,7 @@ pin_project! {
 
 impl<St: Stream> Peekable<St> {
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream: stream.fuse(),
-            peeked: None,
-        }
+        Self { stream: stream.fuse(), peeked: None }
     }
 
     delegate_access_inner!(stream, St, (.));
@@ -105,9 +102,7 @@ impl<St: Stream> Peekable<St> {
     where
         F: FnOnce(&St::Item) -> bool,
     {
-        NextIf {
-            inner: Some((self, func)),
-        }
+        NextIf { inner: Some((self, func)) }
     }
 
     /// Creates a future which will consume and return the next item if it is
@@ -138,15 +133,7 @@ impl<St: Stream> Peekable<St> {
         St::Item: PartialEq<T>,
     {
         NextIfEq {
-            inner: NextIf {
-                inner: Some((
-                    self,
-                    NextIfEqFn {
-                        expected,
-                        _next: PhantomData,
-                    },
-                )),
-            },
+            inner: NextIf { inner: Some((self, NextIfEqFn { expected, _next: PhantomData })) },
         }
     }
 }
@@ -247,9 +234,7 @@ where
     St::Item: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("NextIf")
-            .field("inner", &self.inner.as_ref().map(|(s, _f)| s))
-            .finish()
+        f.debug_struct("NextIf").field("inner", &self.inner.as_ref().map(|(s, _f)| s)).finish()
     }
 }
 

--- a/futures-util/src/stream/stream/scan.rs
+++ b/futures-util/src/stream/stream/scan.rs
@@ -56,14 +56,7 @@ where
     Fut: Future<Output = Option<B>>,
 {
     pub(super) fn new(stream: St, initial_state: S, f: F) -> Self {
-        Self {
-            stream,
-            state_f: Some(StateFn {
-                state: initial_state,
-                f,
-            }),
-            future: None,
-        }
+        Self { stream, state_f: Some(StateFn { state: initial_state, f }), future: None }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/stream/select_next_some.rs
+++ b/futures-util/src/stream/stream/select_next_some.rs
@@ -1,9 +1,9 @@
+use crate::stream::StreamExt;
 use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
 use futures_core::ready;
 use futures_core::stream::FusedStream;
-use futures_core::future::{Future, FusedFuture};
 use futures_core::task::{Context, Poll};
-use crate::stream::StreamExt;
 
 /// Future for the [`select_next_some`](super::StreamExt::select_next_some)
 /// method.

--- a/futures-util/src/stream/stream/skip.rs
+++ b/futures-util/src/stream/stream/skip.rs
@@ -19,10 +19,7 @@ pin_project! {
 
 impl<St: Stream> Skip<St> {
     pub(super) fn new(stream: St, n: usize) -> Self {
-        Self {
-            stream,
-            remaining: n,
-        }
+        Self { stream, remaining: n }
     }
 
     delegate_access_inner!(stream, St, ());
@@ -37,10 +34,7 @@ impl<St: FusedStream> FusedStream for Skip<St> {
 impl<St: Stream> Stream for Skip<St> {
     type Item = St::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<St::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
         let mut this = self.project();
 
         while *this.remaining > 0 {

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -39,27 +39,23 @@ where
 }
 
 impl<St, Fut, F> SkipWhile<St, Fut, F>
-    where St: Stream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            pending_fut: None,
-            pending_item: None,
-            done_skipping: false,
-        }
+        Self { stream, f, pending_fut: None, pending_item: None, done_skipping: false }
     }
 
     delegate_access_inner!(stream, St, ());
 }
 
 impl<St, Fut, F> FusedStream for SkipWhile<St, Fut, F>
-    where St: FusedStream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: FusedStream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     fn is_terminated(&self) -> bool {
         self.pending_item.is_none() && self.stream.is_terminated()
@@ -67,16 +63,14 @@ impl<St, Fut, F> FusedStream for SkipWhile<St, Fut, F>
 }
 
 impl<St, Fut, F> Stream for SkipWhile<St, Fut, F>
-    where St: Stream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     type Item = St::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<St::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
         let mut this = self.project();
 
         if *this.done_skipping {
@@ -119,9 +113,10 @@ impl<St, Fut, F> Stream for SkipWhile<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for SkipWhile<S, Fut, F>
-    where S: Stream + Sink<Item>,
-          F: FnMut(&S::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    S: Stream + Sink<Item>,
+    F: FnMut(&S::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/stream/take_until.rs
+++ b/futures-util/src/stream/stream/take_until.rs
@@ -34,10 +34,7 @@ where
     Fut: Future + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TakeUntil")
-            .field("stream", &self.stream)
-            .field("fut", &self.fut)
-            .finish()
+        f.debug_struct("TakeUntil").field("stream", &self.stream).field("fut", &self.fut).finish()
     }
 }
 
@@ -47,12 +44,7 @@ where
     Fut: Future,
 {
     pub(super) fn new(stream: St, fut: Fut) -> Self {
-        Self {
-            stream,
-            fut: Some(fut),
-            fut_result: None,
-            free: false,
-        }
+        Self { stream, fut: Some(fut), fut_result: None, free: false }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/stream/take_while.rs
+++ b/futures-util/src/stream/stream/take_while.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::{Stream, FusedStream};
+use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -39,34 +39,27 @@ where
 }
 
 impl<St, Fut, F> TakeWhile<St, Fut, F>
-    where St: Stream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            pending_fut: None,
-            pending_item: None,
-            done_taking: false,
-        }
+        Self { stream, f, pending_fut: None, pending_item: None, done_taking: false }
     }
 
     delegate_access_inner!(stream, St, ());
 }
 
 impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
-    where St: Stream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     type Item = St::Item;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<St::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
         if self.done_taking {
             return Poll::Ready(None);
         }
@@ -109,9 +102,10 @@ impl<St, Fut, F> Stream for TakeWhile<St, Fut, F>
 }
 
 impl<St, Fut, F> FusedStream for TakeWhile<St, Fut, F>
-    where St: FusedStream,
-          F: FnMut(&St::Item) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: FusedStream,
+    F: FnMut(&St::Item) -> Fut,
+    Fut: Future<Output = bool>,
 {
     fn is_terminated(&self) -> bool {
         self.done_taking || self.pending_item.is_none() && self.stream.is_terminated()
@@ -121,7 +115,8 @@ impl<St, Fut, F> FusedStream for TakeWhile<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for TakeWhile<S, Fut, F>
-    where S: Stream + Sink<Item>,
+where
+    S: Stream + Sink<Item>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/stream/then.rs
+++ b/futures-util/src/stream/stream/then.rs
@@ -26,32 +26,27 @@ where
     Fut: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Then")
-            .field("stream", &self.stream)
-            .field("future", &self.future)
-            .finish()
+        f.debug_struct("Then").field("stream", &self.stream).field("future", &self.future).finish()
     }
 }
 
 impl<St, Fut, F> Then<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            future: None,
-            f,
-        }
+        Self { stream, future: None, f }
     }
 
     delegate_access_inner!(stream, St, ());
 }
 
 impl<St, Fut, F> FusedStream for Then<St, Fut, F>
-    where St: FusedStream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future,
+where
+    St: FusedStream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
@@ -59,16 +54,14 @@ impl<St, Fut, F> FusedStream for Then<St, Fut, F>
 }
 
 impl<St, Fut, F> Stream for Then<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: Future,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future,
 {
     type Item = Fut::Output;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         Poll::Ready(loop {
@@ -99,7 +92,8 @@ impl<St, Fut, F> Stream for Then<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for Then<S, Fut, F>
-    where S: Sink<Item>,
+where
+    S: Sink<Item>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/stream/try_fold.rs
+++ b/futures-util/src/stream/stream/try_fold.rs
@@ -35,24 +35,21 @@ where
 }
 
 impl<St, Fut, T, F> TryFold<St, Fut, T, F>
-where St: Stream,
-      F: FnMut(T, St::Item) -> Fut,
-      Fut: TryFuture<Ok = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: TryFuture<Ok = T>,
 {
     pub(super) fn new(stream: St, f: F, t: T) -> Self {
-        Self {
-            stream,
-            f,
-            accum: Some(t),
-            future: None,
-        }
+        Self { stream, f, accum: Some(t), future: None }
     }
 }
 
 impl<St, Fut, T, F> FusedFuture for TryFold<St, Fut, T, F>
-    where St: Stream,
-          F: FnMut(T, St::Item) -> Fut,
-          Fut: TryFuture<Ok = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: TryFuture<Ok = T>,
 {
     fn is_terminated(&self) -> bool {
         self.accum.is_none() && self.future.is_none()
@@ -60,9 +57,10 @@ impl<St, Fut, T, F> FusedFuture for TryFold<St, Fut, T, F>
 }
 
 impl<St, Fut, T, F> Future for TryFold<St, Fut, T, F>
-    where St: Stream,
-          F: FnMut(T, St::Item) -> Fut,
-          Fut: TryFuture<Ok = T>,
+where
+    St: Stream,
+    F: FnMut(T, St::Item) -> Fut,
+    Fut: TryFuture<Ok = T>,
 {
     type Output = Result<T, Fut::Error>;
 

--- a/futures-util/src/stream/stream/try_for_each.rs
+++ b/futures-util/src/stream/stream/try_for_each.rs
@@ -32,23 +32,21 @@ where
 }
 
 impl<St, Fut, F> TryForEach<St, Fut, F>
-where St: Stream,
-      F: FnMut(St::Item) -> Fut,
-      Fut: TryFuture<Ok = ()>,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = ()>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            future: None,
-        }
+        Self { stream, f, future: None }
     }
 }
 
 impl<St, Fut, F> Future for TryForEach<St, Fut, F>
-    where St: Stream,
-          F: FnMut(St::Item) -> Fut,
-          Fut: TryFuture<Ok = ()>,
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = ()>,
 {
     type Output = Result<(), Fut::Error>;
 

--- a/futures-util/src/stream/stream/unzip.rs
+++ b/futures-util/src/stream/stream/unzip.rs
@@ -21,25 +21,19 @@ pin_project! {
 impl<St: Stream, FromA: Default, FromB: Default> Unzip<St, FromA, FromB> {
     fn finish(self: Pin<&mut Self>) -> (FromA, FromB) {
         let this = self.project();
-        (
-            mem::replace(this.left, Default::default()),
-            mem::replace(this.right, Default::default()),
-        )
+        (mem::replace(this.left, Default::default()), mem::replace(this.right, Default::default()))
     }
 
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            left: Default::default(),
-            right: Default::default(),
-        }
+        Self { stream, left: Default::default(), right: Default::default() }
     }
 }
 
 impl<St, A, B, FromA, FromB> FusedFuture for Unzip<St, FromA, FromB>
-where St: FusedStream<Item = (A, B)>,
-      FromA: Default + Extend<A>,
-      FromB: Default + Extend<B>,
+where
+    St: FusedStream<Item = (A, B)>,
+    FromA: Default + Extend<A>,
+    FromB: Default + Extend<B>,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
@@ -47,9 +41,10 @@ where St: FusedStream<Item = (A, B)>,
 }
 
 impl<St, A, B, FromA, FromB> Future for Unzip<St, FromA, FromB>
-where St: Stream<Item = (A, B)>,
-      FromA: Default + Extend<A>,
-      FromB: Default + Extend<B>,
+where
+    St: Stream<Item = (A, B)>,
+    FromA: Default + Extend<A>,
+    FromB: Default + Extend<B>,
 {
     type Output = (FromA, FromB);
 
@@ -60,7 +55,7 @@ where St: Stream<Item = (A, B)>,
                 Some(e) => {
                     this.left.extend(Some(e.0));
                     this.right.extend(Some(e.1));
-                },
+                }
                 None => return Poll::Ready(self.finish()),
             }
         }

--- a/futures-util/src/stream/try_stream/and_then.rs
+++ b/futures-util/src/stream/try_stream/and_then.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
+use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -34,9 +34,10 @@ where
 }
 
 impl<St, Fut, F> AndThen<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(St::Ok) -> Fut,
-          Fut: TryFuture<Error = St::Error>,
+where
+    St: TryStream,
+    F: FnMut(St::Ok) -> Fut,
+    Fut: TryFuture<Error = St::Error>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, future: None, f }
@@ -46,16 +47,14 @@ impl<St, Fut, F> AndThen<St, Fut, F>
 }
 
 impl<St, Fut, F> Stream for AndThen<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(St::Ok) -> Fut,
-          Fut: TryFuture<Error = St::Error>,
+where
+    St: TryStream,
+    F: FnMut(St::Ok) -> Fut,
+    Fut: TryFuture<Error = St::Error>,
 {
     type Item = Result<Fut::Ok, St::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         Poll::Ready(loop {
@@ -84,9 +83,10 @@ impl<St, Fut, F> Stream for AndThen<St, Fut, F>
 }
 
 impl<St, Fut, F> FusedStream for AndThen<St, Fut, F>
-    where St: TryStream + FusedStream,
-          F: FnMut(St::Ok) -> Fut,
-          Fut: TryFuture<Error = St::Error>,
+where
+    St: TryStream + FusedStream,
+    F: FnMut(St::Ok) -> Fut,
+    Fut: TryFuture<Error = St::Error>,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
@@ -96,7 +96,8 @@ impl<St, Fut, F> FusedStream for AndThen<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for AndThen<S, Fut, F>
-    where S: Sink<Item>,
+where
+    S: Sink<Item>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/try_stream/into_stream.rs
+++ b/futures-util/src/stream/try_stream/into_stream.rs
@@ -34,10 +34,7 @@ impl<St: TryStream> Stream for IntoStream<St> {
     type Item = Result<St::Ok, St::Error>;
 
     #[inline]
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().stream.try_poll_next(cx)
     }
 

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -5,18 +5,19 @@
 
 #[cfg(feature = "compat")]
 use crate::compat::Compat;
+use crate::fns::{
+    inspect_err_fn, inspect_ok_fn, into_fn, map_err_fn, map_ok_fn, InspectErrFn, InspectOkFn,
+    IntoFn, MapErrFn, MapOkFn,
+};
+use crate::future::assert_future;
+use crate::stream::assert_stream;
+use crate::stream::{Inspect, Map};
 use core::pin::Pin;
 use futures_core::{
     future::{Future, TryFuture},
     stream::TryStream,
     task::{Context, Poll},
 };
-use crate::fns::{
-    InspectOkFn, inspect_ok_fn, InspectErrFn, inspect_err_fn, MapErrFn, map_err_fn, IntoFn, into_fn, MapOkFn, map_ok_fn,
-};
-use crate::future::assert_future;
-use crate::stream::{Map, Inspect};
-use crate::stream::assert_stream;
 
 mod and_then;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
@@ -766,7 +767,9 @@ pub trait TryStreamExt: TryStream {
         Self::Ok: TryFuture<Error = Self::Error>,
         Self: Sized,
     {
-        assert_stream::<Result<<Self::Ok as TryFuture>::Ok, Self::Error>, _>(TryBuffered::new(self, n))
+        assert_stream::<Result<<Self::Ok as TryFuture>::Ok, Self::Error>, _>(TryBuffered::new(
+            self, n,
+        ))
     }
 
     // TODO: false positive warning from rustdoc. Verify once #43466 settles

--- a/futures-util/src/stream/try_stream/or_else.rs
+++ b/futures-util/src/stream/try_stream/or_else.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
+use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -34,9 +34,10 @@ where
 }
 
 impl<St, Fut, F> OrElse<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(St::Error) -> Fut,
-          Fut: TryFuture<Ok = St::Ok>,
+where
+    St: TryStream,
+    F: FnMut(St::Error) -> Fut,
+    Fut: TryFuture<Ok = St::Ok>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
         Self { stream, future: None, f }
@@ -46,16 +47,14 @@ impl<St, Fut, F> OrElse<St, Fut, F>
 }
 
 impl<St, Fut, F> Stream for OrElse<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(St::Error) -> Fut,
-          Fut: TryFuture<Ok = St::Ok>,
+where
+    St: TryStream,
+    F: FnMut(St::Error) -> Fut,
+    Fut: TryFuture<Ok = St::Ok>,
 {
     type Item = Result<St::Ok, Fut::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         Poll::Ready(loop {
@@ -68,7 +67,7 @@ impl<St, Fut, F> Stream for OrElse<St, Fut, F>
                     Some(Ok(item)) => break Some(Ok(item)),
                     Some(Err(e)) => {
                         this.future.set(Some((this.f)(e)));
-                    },
+                    }
                     None => break None,
                 }
             }
@@ -88,9 +87,10 @@ impl<St, Fut, F> Stream for OrElse<St, Fut, F>
 }
 
 impl<St, Fut, F> FusedStream for OrElse<St, Fut, F>
-    where St: TryStream + FusedStream,
-          F: FnMut(St::Error) -> Fut,
-          Fut: TryFuture<Ok = St::Ok>,
+where
+    St: TryStream + FusedStream,
+    F: FnMut(St::Error) -> Fut,
+    Fut: TryFuture<Ok = St::Ok>,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()
@@ -100,7 +100,8 @@ impl<St, Fut, F> FusedStream for OrElse<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for OrElse<S, Fut, F>
-    where S: Sink<Item>,
+where
+    S: Sink<Item>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/try_stream/try_collect.rs
+++ b/futures-util/src/stream/try_stream/try_collect.rs
@@ -19,10 +19,7 @@ pin_project! {
 
 impl<St: TryStream, C: Default> TryCollect<St, C> {
     pub(super) fn new(s: St) -> Self {
-        Self {
-            stream: s,
-            items: Default::default(),
-        }
+        Self { stream: s, items: Default::default() }
     }
 }
 
@@ -43,10 +40,7 @@ where
 {
     type Output = Result<C, St::Error>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
         Poll::Ready(Ok(loop {
             match ready!(this.stream.as_mut().try_poll_next(cx)?) {

--- a/futures-util/src/stream/try_stream/try_concat.rs
+++ b/futures-util/src/stream/try_stream/try_concat.rs
@@ -22,10 +22,7 @@ where
     St::Ok: Extend<<St::Ok as IntoIterator>::Item> + IntoIterator + Default,
 {
     pub(super) fn new(stream: St) -> Self {
-        Self {
-            stream,
-            accum: None,
-        }
+        Self { stream, accum: None }
     }
 }
 

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
+use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -40,24 +40,21 @@ where
 }
 
 impl<St, Fut, F> TryFilter<St, Fut, F>
-    where St: TryStream
+where
+    St: TryStream,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            pending_fut: None,
-            pending_item: None,
-        }
+        Self { stream, f, pending_fut: None, pending_item: None }
     }
 
     delegate_access_inner!(stream, St, ());
 }
 
 impl<St, Fut, F> FusedStream for TryFilter<St, Fut, F>
-    where St: TryStream + FusedStream,
-          F: FnMut(&St::Ok) -> Fut,
-          Fut: Future<Output = bool>,
+where
+    St: TryStream + FusedStream,
+    F: FnMut(&St::Ok) -> Fut,
+    Fut: Future<Output = bool>,
 {
     fn is_terminated(&self) -> bool {
         self.pending_fut.is_none() && self.stream.is_terminated()
@@ -65,16 +62,14 @@ impl<St, Fut, F> FusedStream for TryFilter<St, Fut, F>
 }
 
 impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
-    where St: TryStream,
-          Fut: Future<Output = bool>,
-          F: FnMut(&St::Ok) -> Fut,
+where
+    St: TryStream,
+    Fut: Future<Output = bool>,
+    F: FnMut(&St::Ok) -> Fut,
 {
     type Item = Result<St::Ok, St::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         Poll::Ready(loop {
@@ -108,7 +103,8 @@ impl<St, Fut, F> Stream for TryFilter<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item, E> Sink<Item> for TryFilter<S, Fut, F>
-    where S: TryStream + Sink<Item, Error = E>,
+where
+    S: TryStream + Sink<Item, Error = E>,
 {
     type Error = E;
 

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 use core::pin::Pin;
-use futures_core::future::{TryFuture};
+use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
+use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -43,9 +43,10 @@ impl<St, Fut, F> TryFilterMap<St, Fut, F> {
 }
 
 impl<St, Fut, F, T> FusedStream for TryFilterMap<St, Fut, F>
-    where St: TryStream + FusedStream,
-          Fut: TryFuture<Ok = Option<T>, Error = St::Error>,
-          F: FnMut(St::Ok) -> Fut,
+where
+    St: TryStream + FusedStream,
+    Fut: TryFuture<Ok = Option<T>, Error = St::Error>,
+    F: FnMut(St::Ok) -> Fut,
 {
     fn is_terminated(&self) -> bool {
         self.pending.is_none() && self.stream.is_terminated()
@@ -53,16 +54,14 @@ impl<St, Fut, F, T> FusedStream for TryFilterMap<St, Fut, F>
 }
 
 impl<St, Fut, F, T> Stream for TryFilterMap<St, Fut, F>
-    where St: TryStream,
-          Fut: TryFuture<Ok = Option<T>, Error = St::Error>,
-          F: FnMut(St::Ok) -> Fut,
+where
+    St: TryStream,
+    Fut: TryFuture<Ok = Option<T>, Error = St::Error>,
+    F: FnMut(St::Ok) -> Fut,
 {
     type Item = Result<T, St::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         Poll::Ready(loop {
@@ -98,7 +97,8 @@ impl<St, Fut, F, T> Stream for TryFilterMap<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item> Sink<Item> for TryFilterMap<S, Fut, F>
-    where S: Sink<Item>,
+where
+    S: Sink<Item>,
 {
     type Error = S::Error;
 

--- a/futures-util/src/stream/try_stream/try_next.rs
+++ b/futures-util/src/stream/try_stream/try_next.rs
@@ -28,10 +28,7 @@ impl<St: ?Sized + TryStream + Unpin + FusedStream> FusedFuture for TryNext<'_, S
 impl<St: ?Sized + TryStream + Unpin> Future for TryNext<'_, St> {
     type Output = Result<Option<St::Ok>, St::Error>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.stream.try_poll_next_unpin(cx)?.map(Ok)
     }
 }

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use core::pin::Pin;
 use futures_core::future::TryFuture;
 use futures_core::ready;
-use futures_core::stream::{Stream, TryStream, FusedStream};
+use futures_core::stream::{FusedStream, Stream, TryStream};
 use futures_core::task::{Context, Poll};
 #[cfg(feature = "sink")]
 use futures_sink::Sink;
@@ -40,34 +40,27 @@ where
 }
 
 impl<St, Fut, F> TrySkipWhile<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(&St::Ok) -> Fut,
-          Fut: TryFuture<Ok = bool, Error = St::Error>,
+where
+    St: TryStream,
+    F: FnMut(&St::Ok) -> Fut,
+    Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            pending_fut: None,
-            pending_item: None,
-            done_skipping: false,
-        }
+        Self { stream, f, pending_fut: None, pending_item: None, done_skipping: false }
     }
 
     delegate_access_inner!(stream, St, ());
 }
 
 impl<St, Fut, F> Stream for TrySkipWhile<St, Fut, F>
-    where St: TryStream,
-          F: FnMut(&St::Ok) -> Fut,
-          Fut: TryFuture<Ok = bool, Error = St::Error>,
+where
+    St: TryStream,
+    F: FnMut(&St::Ok) -> Fut,
+    Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     type Item = Result<St::Ok, St::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         if *this.done_skipping {
@@ -105,9 +98,10 @@ impl<St, Fut, F> Stream for TrySkipWhile<St, Fut, F>
 }
 
 impl<St, Fut, F> FusedStream for TrySkipWhile<St, Fut, F>
-    where St: TryStream + FusedStream,
-          F: FnMut(&St::Ok) -> Fut,
-          Fut: TryFuture<Ok = bool, Error = St::Error>,
+where
+    St: TryStream + FusedStream,
+    F: FnMut(&St::Ok) -> Fut,
+    Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     fn is_terminated(&self) -> bool {
         self.pending_item.is_none() && self.stream.is_terminated()
@@ -117,7 +111,8 @@ impl<St, Fut, F> FusedStream for TrySkipWhile<St, Fut, F>
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
 impl<S, Fut, F, Item, E> Sink<Item> for TrySkipWhile<S, Fut, F>
-    where S: TryStream + Sink<Item, Error = E>,
+where
+    S: TryStream + Sink<Item, Error = E>,
 {
     type Error = E;
 

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -49,13 +49,7 @@ where
     Fut: TryFuture<Ok = bool, Error = St::Error>,
 {
     pub(super) fn new(stream: St, f: F) -> Self {
-        Self {
-            stream,
-            f,
-            pending_fut: None,
-            pending_item: None,
-            done_taking: false,
-        }
+        Self { stream, f, pending_fut: None, pending_item: None, done_taking: false }
     }
 
     delegate_access_inner!(stream, St, ());

--- a/futures-util/src/stream/try_stream/try_unfold.rs
+++ b/futures-util/src/stream/try_stream/try_unfold.rs
@@ -61,11 +61,7 @@ where
     F: FnMut(T) -> Fut,
     Fut: TryFuture<Ok = Option<(Item, T)>>,
 {
-    assert_stream::<Result<Item, Fut::Error>, _>(TryUnfold {
-        f,
-        state: Some(init),
-        fut: None,
-    })
+    assert_stream::<Result<Item, Fut::Error>, _>(TryUnfold { f, state: Some(init), fut: None })
 }
 
 pin_project! {
@@ -85,10 +81,7 @@ where
     Fut: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TryUnfold")
-            .field("state", &self.state)
-            .field("fut", &self.fut)
-            .finish()
+        f.debug_struct("TryUnfold").field("state", &self.state).field("fut", &self.fut).finish()
     }
 }
 
@@ -99,10 +92,7 @@ where
 {
     type Item = Result<Item, Fut::Error>;
 
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
         if let Some(state) = this.state.take() {

--- a/futures-util/src/stream/unfold.rs
+++ b/futures-util/src/stream/unfold.rs
@@ -52,10 +52,7 @@ where
     F: FnMut(T) -> Fut,
     Fut: Future<Output = Option<(Item, T)>>,
 {
-    assert_stream::<Item, _>(Unfold {
-        f,
-        state: UnfoldState::Value { value: init },
-    })
+    assert_stream::<Item, _>(Unfold { f, state: UnfoldState::Value { value: init } })
 }
 
 pin_project! {
@@ -74,9 +71,7 @@ where
     Fut: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Unfold")
-            .field("state", &self.state)
-            .finish()
+        f.debug_struct("Unfold").field("state", &self.state).finish()
     }
 }
 
@@ -105,9 +100,7 @@ where
         let mut this = self.project();
 
         if let Some(state) = this.state.as_mut().take_value() {
-            this.state.set(UnfoldState::Future {
-                future: (this.f)(state),
-            });
+            this.state.set(UnfoldState::Future { future: (this.f)(state) });
         }
 
         let step = match this.state.as_mut().project_future() {

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -11,12 +11,9 @@
 //! executors or dealing with synchronization issues around task wakeup.
 
 #[doc(no_inline)]
-pub use core::task::{Context, Poll, Waker, RawWaker, RawWakerVTable};
+pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-pub use futures_task::{
-    Spawn, LocalSpawn, SpawnError,
-    FutureObj, LocalFutureObj, UnsafeFutureObj,
-};
+pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj};
 
 pub use futures_task::noop_waker;
 #[cfg(feature = "std")]
@@ -36,4 +33,4 @@ cfg_target_has_atomic! {
 }
 
 mod spawn;
-pub use self::spawn::{SpawnExt, LocalSpawnExt};
+pub use self::spawn::{LocalSpawnExt, SpawnExt};

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -80,15 +80,12 @@
 
 #![cfg_attr(feature = "cfg-target-has-atomic", feature(cfg_target_has_atomic))]
 #![cfg_attr(feature = "read-initializer", feature(read_initializer))]
-
 #![cfg_attr(not(feature = "std"), no_std)]
-
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms, unreachable_pub)]
 // It cannot be included in the published code because this lints have false positives in the minimum required version.
 #![cfg_attr(test, warn(single_use_lifetimes))]
 #![warn(clippy::all)]
 #![doc(test(attr(deny(warnings), allow(dead_code, unused_assignments, unused_variables))))]
-
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(all(feature = "cfg-target-has-atomic", not(feature = "unstable")))]

--- a/futures/tests/_require_features.rs
+++ b/futures/tests/_require_features.rs
@@ -1,8 +1,13 @@
 #[cfg(not(all(
-    feature = "std", feature = "alloc", feature = "async-await",
-    feature = "compat", feature = "io-compat",
-    feature = "executor", feature = "thread-pool",
+    feature = "std",
+    feature = "alloc",
+    feature = "async-await",
+    feature = "compat",
+    feature = "io-compat",
+    feature = "executor",
+    feature = "thread-pool",
 )))]
-compile_error!("`futures` tests must have all stable features activated: \
+compile_error!(
+    "`futures` tests must have all stable features activated: \
     use `--all-features` or `--features default,thread-pool,io-compat`"
 );

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,16 +1,14 @@
 #![cfg(feature = "compat")]
 
-use tokio::timer::Delay;
-use tokio::runtime::Runtime;
-use std::time::Instant;
-use futures::prelude::*;
 use futures::compat::Future01CompatExt;
+use futures::prelude::*;
+use std::time::Instant;
+use tokio::runtime::Runtime;
+use tokio::timer::Delay;
 
 #[test]
 fn can_use_01_futures_in_a_03_future_running_on_a_01_executor() {
-    let f = async {
-        Delay::new(Instant::now()).compat().await
-    };
+    let f = async { Delay::new(Instant::now()).compat().await };
 
     let mut runtime = Runtime::new().unwrap();
     runtime.block_on(f.boxed().compat()).unwrap();

--- a/futures/tests/eager_drop.rs
+++ b/futures/tests/eager_drop.rs
@@ -69,16 +69,13 @@ fn then_drops_eagerly() {
     let (tx1, rx1) = mpsc::channel::<()>();
     let (tx2, rx2) = mpsc::channel::<()>();
 
-    FutureData {
-        _data: tx1,
-        future: rx0.unwrap_or_else(|_| panic!()),
-    }
-    .then(move |_| {
-        assert!(rx1.recv().is_err()); // tx1 should have been dropped
-        tx2.send(()).unwrap();
-        future::ready(())
-    })
-    .run_in_background();
+    FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+        .then(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready(())
+        })
+        .run_in_background();
 
     assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
     tx0.send(()).unwrap();
@@ -91,16 +88,13 @@ fn and_then_drops_eagerly() {
     let (tx1, rx1) = mpsc::channel::<()>();
     let (tx2, rx2) = mpsc::channel::<()>();
 
-    FutureData {
-        _data: tx1,
-        future: rx0.unwrap_or_else(|_| panic!()),
-    }
-    .and_then(move |_| {
-        assert!(rx1.recv().is_err()); // tx1 should have been dropped
-        tx2.send(()).unwrap();
-        future::ready(Ok(()))
-    })
-    .run_in_background();
+    FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+        .and_then(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready(Ok(()))
+        })
+        .run_in_background();
 
     assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
     tx0.send(Ok(())).unwrap();
@@ -113,16 +107,13 @@ fn or_else_drops_eagerly() {
     let (tx1, rx1) = mpsc::channel::<()>();
     let (tx2, rx2) = mpsc::channel::<()>();
 
-    FutureData {
-        _data: tx1,
-        future: rx0.unwrap_or_else(|_| panic!()),
-    }
-    .or_else(move |_| {
-        assert!(rx1.recv().is_err()); // tx1 should have been dropped
-        tx2.send(()).unwrap();
-        future::ready::<Result<(), ()>>(Ok(()))
-    })
-    .run_in_background();
+    FutureData { _data: tx1, future: rx0.unwrap_or_else(|_| panic!()) }
+        .or_else(move |_| {
+            assert!(rx1.recv().is_err()); // tx1 should have been dropped
+            tx2.send(()).unwrap();
+            future::ready::<Result<(), ()>>(Ok(()))
+        })
+        .run_in_background();
 
     assert_eq!(Err(mpsc::TryRecvError::Empty), rx2.try_recv());
     tx0.send(Err(())).unwrap();

--- a/futures/tests/future_basic_combinators.rs
+++ b/futures/tests/future_basic_combinators.rs
@@ -13,17 +13,21 @@ fn basic_future_combinators() {
             tx1.send(x).unwrap(); // Send 1
             tx1.send(2).unwrap(); // Send 2
             future::ready(3)
-        }).map(move |x| {
+        })
+        .map(move |x| {
             tx2.send(x).unwrap(); // Send 3
             tx2.send(4).unwrap(); // Send 4
             5
-        }).map(move |x| {
+        })
+        .map(move |x| {
             tx3.send(x).unwrap(); // Send 5
         });
 
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
-    for i in 1..=5 { assert_eq!(rx.recv(), Ok(i)); } // Check it
+    for i in 1..=5 {
+        assert_eq!(rx.recv(), Ok(i));
+    } // Check it
     assert!(rx.recv().is_err()); // Should be done
 }
 
@@ -93,6 +97,8 @@ fn basic_try_future_combinators() {
 
     assert!(rx.try_recv().is_err()); // Not started yet
     fut.run_in_background(); // Start it
-    for i in 1..=12 { assert_eq!(rx.recv(), Ok(i)); } // Check it
+    for i in 1..=12 {
+        assert_eq!(rx.recv(), Ok(i));
+    } // Check it
     assert!(rx.recv().is_err()); // Should be done
 }

--- a/futures/tests/future_shared.rs
+++ b/futures/tests/future_shared.rs
@@ -119,9 +119,7 @@ fn peek() {
     }
 
     // Once the Shared has been polled, the value is peekable on the clone.
-    spawn
-        .spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ()))))
-        .unwrap();
+    spawn.spawn_local_obj(LocalFutureObj::new(Box::new(f1.map(|_| ())))).unwrap();
     local_pool.run();
     for _ in 0..2 {
         assert_eq!(*f2.peek().unwrap(), Ok(42));
@@ -193,8 +191,5 @@ fn shared_future_that_wakes_itself_until_pending_is_returned() {
 
     // The join future can only complete if the second future gets a chance to run after the first
     // has returned pending
-    assert_eq!(
-        block_on(futures::future::join(fut, async { proceed.set(true) })),
-        ((), ())
-    );
+    assert_eq!(block_on(futures::future::join(fut, async { proceed.set(true) })), ((), ()));
 }

--- a/futures/tests/future_try_join_all.rs
+++ b/futures/tests/future_try_join_all.rs
@@ -14,15 +14,9 @@ where
 
 #[test]
 fn collect_collects() {
-    assert_done(
-        || Box::new(try_join_all(vec![ok(1), ok(2)])),
-        Ok::<_, usize>(vec![1, 2]),
-    );
+    assert_done(|| Box::new(try_join_all(vec![ok(1), ok(2)])), Ok::<_, usize>(vec![1, 2]));
     assert_done(|| Box::new(try_join_all(vec![ok(1), err(2)])), Err(2));
-    assert_done(
-        || Box::new(try_join_all(vec![ok(1)])),
-        Ok::<_, usize>(vec![1]),
-    );
+    assert_done(|| Box::new(try_join_all(vec![ok(1)])), Ok::<_, usize>(vec![1]));
     // REVIEW: should this be implemented?
     // assert_done(|| Box::new(try_join_all(Vec::<i32>::new())), Ok(vec![]));
 
@@ -38,10 +32,7 @@ fn try_join_all_iter_lifetime() {
         Box::new(try_join_all(iter))
     }
 
-    assert_done(
-        || sizes(vec![&[1, 2, 3], &[], &[0]]),
-        Ok(vec![3_usize, 0, 1]),
-    );
+    assert_done(|| sizes(vec![&[1, 2, 3], &[], &[0]]), Ok(vec![3_usize, 0, 1]));
 }
 
 #[test]

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -38,11 +38,7 @@ struct MaybePending<'a> {
 
 impl<'a> MaybePending<'a> {
     fn new(inner: &'a [u8]) -> Self {
-        Self {
-            inner,
-            ready_read: false,
-            ready_fill_buf: false,
-        }
+        Self { inner, ready_read: false, ready_fill_buf: false }
     }
 }
 
@@ -126,10 +122,7 @@ fn test_buffered_reader_seek() {
 
     assert_eq!(block_on(reader.seek(SeekFrom::Start(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(
-        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        None
-    );
+    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(block_on(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));
@@ -172,23 +165,14 @@ fn test_buffered_reader_seek_underflow() {
 
     let mut reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1, 2, 3, 4][..]));
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::End(-5))).ok(),
-        Some(u64::max_value() - 5)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::End(-5))).ok(), Some(u64::max_value() - 5));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // the following seek will require two underlying seeks
     let expected = 9_223_372_036_854_775_802;
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        Some(expected)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), Some(expected));
     assert_eq!(run_fill_buf!(reader).ok().map(|s| s.len()), Some(5));
     // seeking to 0 should empty the buffer.
-    assert_eq!(
-        block_on(reader.seek(SeekFrom::Current(0))).ok(),
-        Some(expected)
-    );
+    assert_eq!(block_on(reader.seek(SeekFrom::Current(0))).ok(), Some(expected));
     assert_eq!(reader.get_ref().get_ref().pos, expected);
 }
 
@@ -209,9 +193,7 @@ fn test_short_reads() {
         }
     }
 
-    let inner = ShortReader {
-        lengths: vec![0, 1, 2, 0, 1, 0],
-    };
+    let inner = ShortReader { lengths: vec![0, 1, 2, 0, 1, 0] };
     let mut reader = BufReader::new(AllowStdIo::new(inner));
     let mut buf = [0, 0];
     assert_eq!(block_on(reader.read(&mut buf)).unwrap(), 0);
@@ -288,10 +270,7 @@ fn maybe_pending_seek() {
 
     impl<'a> MaybePendingSeek<'a> {
         fn new(inner: &'a [u8]) -> Self {
-            Self {
-                inner: Cursor::new(inner),
-                ready: true,
-            }
+            Self { inner: Cursor::new(inner), ready: true }
         }
     }
 
@@ -340,10 +319,7 @@ fn maybe_pending_seek() {
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
-    assert_eq!(
-        run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(),
-        None
-    );
+    assert_eq!(run(reader.seek(SeekFrom::Current(i64::min_value()))).ok(), None);
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[0, 1][..]));
     assert_eq!(run(reader.seek(SeekFrom::Current(1))).ok(), Some(4));
     assert_eq!(run_fill_buf!(reader).ok(), Some(&[1, 2][..]));

--- a/futures/tests/io_buf_writer.rs
+++ b/futures/tests/io_buf_writer.rs
@@ -15,10 +15,7 @@ struct MaybePending {
 
 impl MaybePending {
     fn new(inner: Vec<u8>) -> Self {
-        Self {
-            inner,
-            ready: false,
-        }
+        Self { inner, ready: false }
     }
 }
 
@@ -157,17 +154,11 @@ fn maybe_pending_buf_writer() {
 
     run(writer.write(&[9, 10, 11])).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(
-        writer.get_ref().inner,
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    );
+    assert_eq!(writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     run(writer.flush()).unwrap();
     assert_eq!(writer.buffer(), []);
-    assert_eq!(
-        &writer.get_ref().inner,
-        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    );
+    assert_eq!(&writer.get_ref().inner, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 }
 
 #[test]
@@ -190,11 +181,7 @@ fn maybe_pending_buf_writer_seek() {
 
     impl MaybePendingSeek {
         fn new(inner: Vec<u8>) -> Self {
-            Self {
-                inner: Cursor::new(inner),
-                ready_write: false,
-                ready_seek: false,
-            }
+            Self { inner: Cursor::new(inner), ready_write: false, ready_seek: false }
         }
     }
 
@@ -244,15 +231,9 @@ fn maybe_pending_buf_writer_seek() {
     run(w.write_all(&[0, 1, 2, 3, 4, 5])).unwrap();
     run(w.write_all(&[6, 7])).unwrap();
     assert_eq!(run(w.seek(SeekFrom::Current(0))).ok(), Some(8));
-    assert_eq!(
-        &w.get_ref().inner.get_ref()[..],
-        &[0, 1, 2, 3, 4, 5, 6, 7][..]
-    );
+    assert_eq!(&w.get_ref().inner.get_ref()[..], &[0, 1, 2, 3, 4, 5, 6, 7][..]);
     assert_eq!(run(w.seek(SeekFrom::Start(2))).ok(), Some(2));
     run(w.write_all(&[8, 9])).unwrap();
     run(w.flush()).unwrap();
-    assert_eq!(
-        &w.into_inner().inner.into_inner()[..],
-        &[0, 1, 8, 9, 4, 5, 6, 7]
-    );
+    assert_eq!(&w.into_inner().inner.into_inner()[..], &[0, 1, 8, 9, 4, 5, 6, 7]);
 }

--- a/futures/tests/io_cursor.rs
+++ b/futures/tests/io_cursor.rs
@@ -9,22 +9,10 @@ use std::pin::Pin;
 fn cursor_asyncwrite_vec() {
     let mut cursor = Cursor::new(vec![0; 5]);
     block_on(lazy(|cx| {
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
-            Poll::Ready(Ok(2))
-        );
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(2)));
     }));
     assert_eq!(cursor.into_inner(), [1, 2, 3, 4, 5, 6, 6, 7]);
 }
@@ -33,22 +21,10 @@ fn cursor_asyncwrite_vec() {
 fn cursor_asyncwrite_box() {
     let mut cursor = Cursor::new(vec![0; 5].into_boxed_slice());
     block_on(lazy(|cx| {
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[1, 2]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[3, 4]),
-            Poll::Ready(Ok(2))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[5, 6]),
-            Poll::Ready(Ok(1))
-        );
-        assert_matches!(
-            Pin::new(&mut cursor).poll_write(cx, &[6, 7]),
-            Poll::Ready(Ok(0))
-        );
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[1, 2]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[3, 4]), Poll::Ready(Ok(2)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[5, 6]), Poll::Ready(Ok(1)));
+        assert_matches!(Pin::new(&mut cursor).poll_write(cx, &[6, 7]), Poll::Ready(Ok(0)));
     }));
     assert_eq!(&*cursor.into_inner(), [1, 2, 3, 4, 5]);
 }

--- a/futures/tests/io_lines.rs
+++ b/futures/tests/io_lines.rs
@@ -43,10 +43,8 @@ fn lines() {
 
 #[test]
 fn maybe_pending() {
-    let buf = stream::iter(vec![&b"12"[..], &b"\r"[..]])
-        .map(Ok)
-        .into_async_read()
-        .interleave_pending();
+    let buf =
+        stream::iter(vec![&b"12"[..], &b"\r"[..]]).map(Ok).into_async_read().interleave_pending();
     let mut s = buf.lines();
     assert_eq!(run_next!(s), "12\r".to_string());
     assert!(run(s.next()).is_none());

--- a/futures/tests/io_read_line.rs
+++ b/futures/tests/io_read_line.rs
@@ -41,10 +41,8 @@ fn maybe_pending() {
     assert_eq!(run(buf.read_line(&mut v)).unwrap(), 2);
     assert_eq!(v, "12");
 
-    let mut buf = stream::iter(vec![&b"12"[..], &b"\n\n"[..]])
-        .map(Ok)
-        .into_async_read()
-        .interleave_pending();
+    let mut buf =
+        stream::iter(vec![&b"12"[..], &b"\n\n"[..]]).map(Ok).into_async_read().interleave_pending();
     let mut v = String::new();
     assert_eq!(run(buf.read_line(&mut v)).unwrap(), 3);
     assert_eq!(v, "12\n");

--- a/futures/tests/io_write.rs
+++ b/futures/tests/io_write.rs
@@ -57,11 +57,7 @@ fn write_vectored_first_non_empty() {
         Poll::Ready(Ok(4))
     });
     let cx = &mut panic_context();
-    let bufs = &mut [
-        io::IoSlice::new(&[]),
-        io::IoSlice::new(&[]),
-        io::IoSlice::new(b"four"),
-    ];
+    let bufs = &mut [io::IoSlice::new(&[]), io::IoSlice::new(&[]), io::IoSlice::new(b"four")];
 
     let res = Pin::new(&mut writer).poll_write_vectored(cx, bufs);
     let res = res.map_err(|e| e.kind());

--- a/futures/tests/macro-reexport/src/lib.rs
+++ b/futures/tests/macro-reexport/src/lib.rs
@@ -1,8 +1,7 @@
 // normal reexport
-pub use futures04::{join, try_join, select, select_biased};
+pub use futures04::{join, select, select_biased, try_join};
 
 // reexport + rename
 pub use futures04::{
-    join as join2, try_join as try_join2,
-    select as select2, select_biased as select_biased2,
+    join as join2, select as select2, select_biased as select_biased2, try_join as try_join2,
 };

--- a/futures/tests/macro-tests/src/main.rs
+++ b/futures/tests/macro-tests/src/main.rs
@@ -65,5 +65,4 @@ fn main() {
             _ = b => unreachable!(),
         };
     });
-
 }

--- a/futures/tests/oneshot.rs
+++ b/futures/tests/oneshot.rs
@@ -21,8 +21,7 @@ fn oneshot_send2() {
     let (tx2, rx2) = mpsc::channel();
 
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
-    rx1.map_ok(move |x| tx2.send(x).unwrap())
-        .run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
     assert_eq!(1, rx2.recv().unwrap());
 }
 
@@ -31,8 +30,7 @@ fn oneshot_send3() {
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (tx2, rx2) = mpsc::channel();
 
-    rx1.map_ok(move |x| tx2.send(x).unwrap())
-        .run_in_background();
+    rx1.map_ok(move |x| tx2.send(x).unwrap()).run_in_background();
     thread::spawn(|| tx1.send(1).unwrap()).join().unwrap();
     assert_eq!(1, rx2.recv().unwrap());
 }
@@ -43,8 +41,7 @@ fn oneshot_drop_tx1() {
     let (tx2, rx2) = mpsc::channel();
 
     drop(tx1);
-    rx1.map(move |result| tx2.send(result).unwrap())
-        .run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());
 }
@@ -55,8 +52,7 @@ fn oneshot_drop_tx2() {
     let (tx2, rx2) = mpsc::channel();
 
     let t = thread::spawn(|| drop(tx1));
-    rx1.map(move |result| tx2.send(result).unwrap())
-        .run_in_background();
+    rx1.map(move |result| tx2.send(result).unwrap()).run_in_background();
     t.join().unwrap();
 
     assert_eq!(Err(oneshot::Canceled), rx2.recv().unwrap());

--- a/futures/tests/ready_queue.rs
+++ b/futures/tests/ready_queue.rs
@@ -52,19 +52,13 @@ fn resolving_errors() {
 
         drop(tx2);
 
-        assert_eq!(
-            Poll::Ready(Some(Err(oneshot::Canceled))),
-            queue.poll_next_unpin(cx)
-        );
+        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
         assert!(!queue.poll_next_unpin(cx).is_ready());
 
         drop(tx1);
         tx3.send("world2").unwrap();
 
-        assert_eq!(
-            Poll::Ready(Some(Err(oneshot::Canceled))),
-            queue.poll_next_unpin(cx)
-        );
+        assert_eq!(Poll::Ready(Some(Err(oneshot::Canceled))), queue.poll_next_unpin(cx));
         assert_eq!(Poll::Ready(Some(Ok("world2"))), queue.poll_next_unpin(cx));
         assert_eq!(Poll::Ready(None), queue.poll_next_unpin(cx));
     }));

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -131,10 +131,7 @@ impl<T: Unpin> Sink<Option<T>> for ManualFlush<T> {
 
 impl<T: Unpin> ManualFlush<T> {
     fn new() -> Self {
-        Self {
-            data: Vec::new(),
-            waiting_tasks: Vec::new(),
-        }
+        Self { data: Vec::new(), waiting_tasks: Vec::new() }
     }
 
     fn force_flush(&mut self) -> Vec<T> {
@@ -157,10 +154,7 @@ struct Allow {
 
 impl Allow {
     fn new() -> Self {
-        Self {
-            flag: Cell::new(false),
-            tasks: RefCell::new(Vec::new()),
-        }
+        Self { flag: Cell::new(false), tasks: RefCell::new(Vec::new()) }
     }
 
     fn check(&self, cx: &mut Context<'_>) -> bool {
@@ -208,20 +202,14 @@ impl<T: Unpin> Sink<T> for ManualAllow<T> {
 
 fn manual_allow<T: Unpin>() -> (ManualAllow<T>, Rc<Allow>) {
     let allow = Rc::new(Allow::new());
-    let manual_allow = ManualAllow {
-        data: Vec::new(),
-        allow: allow.clone(),
-    };
+    let manual_allow = ManualAllow { data: Vec::new(), allow: allow.clone() };
     (manual_allow, allow)
 }
 
 #[test]
 fn either_sink() {
-    let mut s = if true {
-        Vec::<i32>::new().left_sink()
-    } else {
-        VecDeque::<i32>::new().right_sink()
-    };
+    let mut s =
+        if true { Vec::<i32>::new().left_sink() } else { VecDeque::<i32>::new().right_sink() };
 
     Pin::new(&mut s).start_send(0).unwrap();
 }
@@ -400,13 +388,10 @@ fn with_implements_clone() {
     let (mut tx, rx) = mpsc::channel(5);
 
     {
-        let mut is_positive = tx
-            .clone()
-            .with(|item| future::ok::<bool, mpsc::SendError>(item > 0));
+        let mut is_positive = tx.clone().with(|item| future::ok::<bool, mpsc::SendError>(item > 0));
 
-        let mut is_long = tx
-            .clone()
-            .with(|item: &str| future::ok::<bool, mpsc::SendError>(item.len() > 5));
+        let mut is_long =
+            tx.clone().with(|item: &str| future::ok::<bool, mpsc::SendError>(item.len() > 5));
 
         block_on(is_positive.clone().send(-1)).unwrap();
         block_on(is_long.clone().send("123456")).unwrap();
@@ -418,10 +403,7 @@ fn with_implements_clone() {
 
     block_on(tx.close()).unwrap();
 
-    assert_eq!(
-        block_on(rx.collect::<Vec<_>>()),
-        vec![false, true, false, true, false]
-    );
+    assert_eq!(block_on(rx.collect::<Vec<_>>()), vec![false, true, false, true, false]);
 }
 
 // test that a buffer is a no-nop around a sink that always accepts sends
@@ -513,10 +495,7 @@ fn sink_map_err() {
     }
 
     let tx = mpsc::channel(0).0;
-    assert_eq!(
-        Pin::new(&mut tx.sink_map_err(|_| ())).start_send(()),
-        Err(())
-    );
+    assert_eq!(Pin::new(&mut tx.sink_map_err(|_| ())).start_send(()), Err(()));
 }
 
 #[test]
@@ -571,8 +550,5 @@ fn err_into() {
     }
 
     let tx = mpsc::channel(0).0;
-    assert_eq!(
-        Pin::new(&mut tx.sink_err_into()).start_send(()),
-        Err(ErrIntoTest)
-    );
+    assert_eq!(Pin::new(&mut tx.sink_err_into()).start_send(()), Err(ErrIntoTest));
 }

--- a/futures/tests/sink_fanout.rs
+++ b/futures/tests/sink_fanout.rs
@@ -15,7 +15,7 @@ fn it_works() {
 
     let collect_fut1 = rx1.collect::<Vec<_>>();
     let collect_fut2 = rx2.collect::<Vec<_>>();
-    let (_, vec1, vec2) = block_on(async move { join!(fwd, collect_fut1, collect_fut2)});
+    let (_, vec1, vec2) = block_on(async move { join!(fwd, collect_fut1, collect_fut2) });
 
     let expected = (0..10).collect::<Vec<_>>();
 

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -1,10 +1,10 @@
-use futures::{channel::mpsc, future::BoxFuture};
 use futures::executor::block_on;
 use futures::future::{self, Future};
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt};
 use futures::task::Poll;
 use futures::FutureExt;
+use futures::{channel::mpsc, future::BoxFuture};
 use futures_test::task::noop_context;
 
 #[test]
@@ -24,16 +24,11 @@ fn select() {
 #[test]
 fn flat_map() {
     block_on(async {
-        let st = stream::iter(vec![
-            stream::iter(0..=4u8),
-            stream::iter(6..=10),
-            stream::iter(0..=2),
-        ]);
+        let st =
+            stream::iter(vec![stream::iter(0..=4u8), stream::iter(6..=10), stream::iter(0..=2)]);
 
-        let values: Vec<_> = st
-            .flat_map(|s| s.filter(|v| futures::future::ready(v % 2 == 0)))
-            .collect()
-            .await;
+        let values: Vec<_> =
+            st.flat_map(|s| s.filter(|v| futures::future::ready(v % 2 == 0))).collect().await;
 
         assert_eq!(values, vec![0, 2, 4, 6, 8, 10, 0, 2]);
     });

--- a/futures/tests/stream_futures_ordered.rs
+++ b/futures/tests/stream_futures_ordered.rs
@@ -11,9 +11,7 @@ fn works_1() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![a_rx, b_rx, c_rx]
-        .into_iter()
-        .collect::<FuturesOrdered<_>>();
+    let mut stream = vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesOrdered<_>>();
 
     b_tx.send(99).unwrap();
     assert!(stream.poll_next_unpin(&mut noop_context()).is_pending());
@@ -34,12 +32,9 @@ fn works_2() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![
-        a_rx.boxed(),
-        join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed(),
-    ]
-    .into_iter()
-    .collect::<FuturesOrdered<_>>();
+    let mut stream = vec![a_rx.boxed(), join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed()]
+        .into_iter()
+        .collect::<FuturesOrdered<_>>();
 
     let mut cx = noop_context();
     a_tx.send(33).unwrap();
@@ -52,13 +47,9 @@ fn works_2() {
 
 #[test]
 fn from_iterator() {
-    let stream = vec![
-        future::ready::<i32>(1),
-        future::ready::<i32>(2),
-        future::ready::<i32>(3),
-    ]
-    .into_iter()
-    .collect::<FuturesOrdered<_>>();
+    let stream = vec![future::ready::<i32>(1), future::ready::<i32>(2), future::ready::<i32>(3)]
+        .into_iter()
+        .collect::<FuturesOrdered<_>>();
     assert_eq!(stream.len(), 3);
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -43,11 +43,8 @@ fn works_1() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut iter = block_on_stream(
-        vec![a_rx, b_rx, c_rx]
-            .into_iter()
-            .collect::<FuturesUnordered<_>>(),
-    );
+    let mut iter =
+        block_on_stream(vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesUnordered<_>>());
 
     b_tx.send(99).unwrap();
     assert_eq!(Some(Ok(99)), iter.next());
@@ -65,12 +62,9 @@ fn works_2() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![
-        a_rx.boxed(),
-        join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let mut stream = vec![a_rx.boxed(), join(b_rx, c_rx).map(|(a, b)| Ok(a? + b?)).boxed()]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
 
     a_tx.send(9).unwrap();
     b_tx.send(10).unwrap();
@@ -84,13 +78,9 @@ fn works_2() {
 
 #[test]
 fn from_iterator() {
-    let stream = vec![
-        future::ready::<i32>(1),
-        future::ready::<i32>(2),
-        future::ready::<i32>(3),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let stream = vec![future::ready::<i32>(1), future::ready::<i32>(2), future::ready::<i32>(3)]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
     assert_eq!(stream.len(), 3);
     assert_eq!(block_on(stream.collect::<Vec<_>>()), vec![1, 2, 3]);
 }
@@ -126,9 +116,7 @@ fn iter_mut_cancel() {
     let (b_tx, b_rx) = oneshot::channel::<i32>();
     let (c_tx, c_rx) = oneshot::channel::<i32>();
 
-    let mut stream = vec![a_rx, b_rx, c_rx]
-        .into_iter()
-        .collect::<FuturesUnordered<_>>();
+    let mut stream = vec![a_rx, b_rx, c_rx].into_iter().collect::<FuturesUnordered<_>>();
 
     for rx in stream.iter_mut() {
         rx.close();
@@ -148,13 +136,10 @@ fn iter_mut_cancel() {
 
 #[test]
 fn iter_mut_len() {
-    let mut stream = vec![
-        future::pending::<()>(),
-        future::pending::<()>(),
-        future::pending::<()>(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let mut stream =
+        vec![future::pending::<()>(), future::pending::<()>(), future::pending::<()>()]
+            .into_iter()
+            .collect::<FuturesUnordered<_>>();
 
     let mut iter_mut = stream.iter_mut();
     assert_eq!(iter_mut.len(), 3);
@@ -188,10 +173,7 @@ fn iter_cancel() {
 
     impl<F: Future + Unpin> AtomicCancel<F> {
         fn new(future: F) -> Self {
-            Self {
-                future,
-                cancel: AtomicBool::new(false),
-            }
+            Self { future, cancel: AtomicBool::new(false) }
         }
     }
 
@@ -217,13 +199,9 @@ fn iter_cancel() {
 
 #[test]
 fn iter_len() {
-    let stream = vec![
-        future::pending::<()>(),
-        future::pending::<()>(),
-        future::pending::<()>(),
-    ]
-    .into_iter()
-    .collect::<FuturesUnordered<_>>();
+    let stream = vec![future::pending::<()>(), future::pending::<()>(), future::pending::<()>()]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
 
     let mut iter = stream.iter();
     assert_eq!(iter.len(), 3);

--- a/futures/tests/stream_split.rs
+++ b/futures/tests/stream_split.rs
@@ -45,10 +45,7 @@ fn test_split() {
 
     let mut dest: Vec<i32> = Vec::new();
     {
-        let join = Join {
-            stream: stream::iter(vec![10, 20, 30]),
-            sink: &mut dest,
-        };
+        let join = Join { stream: stream::iter(vec![10, 20, 30]), sink: &mut dest };
 
         let (sink, stream) = join.split();
         let join = sink.reunite(stream).expect("test_split: reunite error");

--- a/futures/tests/task_arc_wake.rs
+++ b/futures/tests/task_arc_wake.rs
@@ -8,9 +8,7 @@ struct CountingWaker {
 
 impl CountingWaker {
     fn new() -> Self {
-        Self {
-            nr_wake: Mutex::new(0),
-        }
+        Self { nr_wake: Mutex::new(0) }
     }
 
     fn wakes(&self) -> i32 {
@@ -73,10 +71,7 @@ fn proper_refcount_on_wake_panic() {
     let w1: Waker = task::waker(some_w.clone());
     assert_eq!(
         "WAKE UP",
-        *panic::catch_unwind(|| w1.wake_by_ref())
-            .unwrap_err()
-            .downcast::<&str>()
-            .unwrap()
+        *panic::catch_unwind(|| w1.wake_by_ref()).unwrap_err().downcast::<&str>().unwrap()
     );
     assert_eq!(2, Arc::strong_count(&some_w)); // some_w + w1
     drop(w1);

--- a/futures/tests/task_atomic_waker.rs
+++ b/futures/tests/task_atomic_waker.rs
@@ -1,4 +1,3 @@
-
 use futures::executor::block_on;
 use futures::future::poll_fn;
 use futures::task::{AtomicWaker, Poll};


### PR DESCRIPTION
To assuage the concerns noted in #2338 regarding blocking other in progress PRs I have developed a process to rebase branches on top of this branch by formatting each commit. I have already rebased the following PRs which have no merge conflicts with `master`.

https://github.com/exrook/futures-rs/compare/format...exrook:pr2384 2384
https://github.com/exrook/futures-rs/compare/format...exrook:pr2379 2379
https://github.com/exrook/futures-rs/compare/format...exrook:pr2374 2374
https://github.com/exrook/futures-rs/compare/format...exrook:pr2355 2355
https://github.com/exrook/futures-rs/compare/format...exrook:pr2352 2352
https://github.com/exrook/futures-rs/compare/format...exrook:pr2343 2343
https://github.com/exrook/futures-rs/compare/format...exrook:pr2342 2342
https://github.com/exrook/futures-rs/compare/format...exrook:pr2328 2328
https://github.com/exrook/futures-rs/compare/format...exrook:pr2244 2244
https://github.com/exrook/futures-rs/compare/format...exrook:pr1956 1956

Additionally I have created `.git-blame-ignore-revs` and added the format commit to it to improve `git-blame` output, see:
https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

<details><summary>Instructions/script for updating a branch</summary>
<p>

## Convert current branch (manual, for branches with conflicts)

Do as `rebase` instructs to resolve any conflicts here!
```sh
git rebase master
```
Format all commits, should not require intervention
```sh
REV_SPEC=$(git rev-list master..HEAD | tail -n1)~~..HEAD
git filter-branch -f --tree-filter 'cargo fmt -- --config disable_all_formatting=false --config use_small_heuristics="Max"' $REV_SPEC
```
Rebase onto the formatted branch, should not require intervention
```sh
git fetch upstream pull/2385/head:format # grab the branch from this PR
git rebase format
```
Push rewritten commits
```sh
git push -f
```

## Batch convert PRs: usage `./script.sh <pr numbers>`
Will have problems with prs with merge conflicts. You probably want to do this on a fresh clone. Replace `upstream` with the name of your `rust-lang/futures-rs` remote
```bash
#!/bin/bash

export FILTER_BRANCH_SQUELCH_WARNING=1
PRS=$@
cd futures-rs
git checkout master
git fetch -f upstream pull/2385/head:format
for pull in $PRS; do
    echo PR $pull
    git fetch -f upstream pull/$pull/head:pr$pull
    echo FETCH DONE
    git checkout pr$pull
    echo CHECKOUT DONE
    git rebase master || git rebase --abort
    echo REBASE 1 DONE
    REV_SPEC=$(git rev-list origin/master..HEAD | tail -n1)~~..HEAD
    git filter-branch -f --tree-filter 'cargo fmt -- --config disable_all_formatting=false --config use_small_heuristics="Max"' $REV_SPEC && \
        echo FILTER BRANCH DONE && \
        git rebase format || git rebase --abort
        echo REBASE 2 DONE && \
        git push -fu origin pr$pull && \
        echo PUSH DONE
    echo PR $pull DONE
done
cd ..
```
</p>
</details>