### PR TITLE
Use stable compiler to installing cargo-hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       # cargo does not support for --features/--no-default-features with workspace, so use cargo-hack instead.
       # Refs: cargo#3620, cargo#4106, cargo#4463, cargo#4753, cargo#5015, cargo#5364, cargo#6195
-      - run: cargo install cargo-hack
+      - run: cargo +stable install cargo-hack
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
       # Check no-default-features
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo install cargo-hack
+      - run: cargo +stable install cargo-hack
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
       # Check no-default-features
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo install cargo-hack
+      - run: cargo +stable install cargo-hack
       - run: cargo hack build --workspace --no-dev-deps
 
   build:


### PR DESCRIPTION
I'm planning to increase the Rust version required for the installation of cargo-hack from 1.36 to 1.40. (cargo-hack is usually runnable with Cargo versions older than the Rust version required for installation. Rust 1.36 will continue to be supported after the increase the Rust version required for the installation of cargo-hack has been increased.)