### PR TITLE
Fix clippy::bool_assert_comparison warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
       - '[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '40 1 * * *'
 
 env:
   RUSTFLAGS: -D warnings

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -15,26 +15,26 @@ fn is_terminated() {
     let mut cx = noop_context();
     let mut tasks = FuturesUnordered::new();
 
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(None));
-    assert_eq!(tasks.is_terminated(), true);
+    assert!(tasks.is_terminated());
 
     // Test that the sentinel value doesn't leak
-    assert_eq!(tasks.is_empty(), true);
+    assert!(tasks.is_empty());
     assert_eq!(tasks.len(), 0);
     assert_eq!(tasks.iter_mut().len(), 0);
 
     tasks.push(future::ready(1));
 
-    assert_eq!(tasks.is_empty(), false);
+    assert!(!tasks.is_empty());
     assert_eq!(tasks.len(), 1);
     assert_eq!(tasks.iter_mut().len(), 1);
 
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(Some(1)));
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(None));
-    assert_eq!(tasks.is_terminated(), true);
+    assert!(tasks.is_terminated());
 }
 
 #[test]

--- a/futures/tests/stream_select_all.rs
+++ b/futures/tests/stream_select_all.rs
@@ -10,24 +10,24 @@ fn is_terminated() {
     let mut cx = noop_context();
     let mut tasks = SelectAll::new();
 
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(None));
-    assert_eq!(tasks.is_terminated(), true);
+    assert!(tasks.is_terminated());
 
     // Test that the sentinel value doesn't leak
-    assert_eq!(tasks.is_empty(), true);
+    assert!(tasks.is_empty());
     assert_eq!(tasks.len(), 0);
 
     tasks.push(future::ready(1).into_stream());
 
-    assert_eq!(tasks.is_empty(), false);
+    assert!(!tasks.is_empty());
     assert_eq!(tasks.len(), 1);
 
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(Some(1)));
-    assert_eq!(tasks.is_terminated(), false);
+    assert!(!tasks.is_terminated());
     assert_eq!(tasks.poll_next_unpin(&mut cx), Poll::Ready(None));
-    assert_eq!(tasks.is_terminated(), true);
+    assert!(tasks.is_terminated());
 }
 
 #[test]

--- a/futures/tests/stream_select_next_some.rs
+++ b/futures/tests/stream_select_next_some.rs
@@ -14,20 +14,20 @@ fn is_terminated() {
     let mut tasks = FuturesUnordered::new();
 
     let mut select_next_some = tasks.select_next_some();
-    assert_eq!(select_next_some.is_terminated(), false);
+    assert!(!select_next_some.is_terminated());
     assert_eq!(select_next_some.poll_unpin(&mut cx), Poll::Pending);
     assert_eq!(counter, 1);
-    assert_eq!(select_next_some.is_terminated(), true);
+    assert!(select_next_some.is_terminated());
     drop(select_next_some);
 
     tasks.push(future::ready(1));
 
     let mut select_next_some = tasks.select_next_some();
-    assert_eq!(select_next_some.is_terminated(), false);
+    assert!(!select_next_some.is_terminated());
     assert_eq!(select_next_some.poll_unpin(&mut cx), Poll::Ready(1));
-    assert_eq!(select_next_some.is_terminated(), false);
+    assert!(!select_next_some.is_terminated());
     assert_eq!(select_next_some.poll_unpin(&mut cx), Poll::Pending);
-    assert_eq!(select_next_some.is_terminated(), true);
+    assert!(select_next_some.is_terminated());
 }
 
 #[test]


### PR DESCRIPTION
```
warning: used `assert_eq!` with a literal bool
  --> futures/tests/stream_select_next_some.rs:20:5
   |
20 |     assert_eq!(select_next_some.is_terminated(), true);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison
```