### PR TITLE
Bump MSRV of futures-util to 1.41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         rust:
           # This is the minimum Rust version supported by futures-core, futures-io, futures-sink, futures-task, futures-channel.
-          # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
+          # When updating this, the reminder to update the minimum required version in .clippy.toml.
           - 1.36.0
     runs-on: ubuntu-latest
     steps:
@@ -74,8 +74,8 @@ jobs:
       matrix:
         rust:
           # This is the minimum Rust version supported by futures, futures-util, futures-macro, futures-executor, futures-test.
-          # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
-          - 1.37.0
+          # When updating this, the reminder to update the minimum required version in README.md.
+          - 1.41.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -84,6 +84,8 @@ jobs:
       - run: cargo +stable install cargo-hack
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
+      # Check default features
+      - run: cargo hack build --workspace --ignore-private
       # Check no-default-features
       - run: cargo hack build --workspace --exclude futures-test --ignore-private --no-default-features
       # Check alloc feature
@@ -94,22 +96,6 @@ jobs:
       - run: cargo hack build -p futures -p futures-util --no-default-features --features std,io-compat
       # Check thread-pool feature (futures, futures-executor)
       - run: cargo hack build -p futures -p futures-executor --no-default-features --features std,thread-pool
-
-  async-await-msrv:
-    name: cargo +${{ matrix.rust }} build
-    strategy:
-      matrix:
-        rust:
-          # This is the minimum Rust version supported by `async-await` feature.
-          # When updating this, the reminder to update the minimum required version of `async-await` feature in README.md.
-          - 1.39.0
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo +stable install cargo-hack
-      - run: cargo hack build --workspace --no-dev-deps
 
   build:
     name: cargo +${{ matrix.rust }} build

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
     <img alt="Crates.io" src="https://img.shields.io/crates/v/futures.svg">
   </a>
 
-  <a href="https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html">
-    <img alt="Rustc Version" src="https://img.shields.io/badge/rustc-1.39+-lightgray.svg">
+  <a href="https://www.rust-lang.org">
+    <img alt="Rustc Version" src="https://img.shields.io/badge/rustc-1.41+-lightgray.svg">
   </a>
 </p>
 
@@ -48,7 +48,7 @@ Now, you can use futures-rs:
 use futures::future::Future;
 ```
 
-The current futures-rs requires Rust 1.39 or later.
+The current futures-rs requires Rust 1.41 or later.
 
 ### Feature `std`
 


### PR DESCRIPTION
This bumps MSRV of futures-util and its dependents (futures, futures-executor, futures-test).

This is because the latest memchr (dependency of futures-util) requires Rust 1.41.

https://github.com/rust-lang/futures-rs/runs/2480445418?check_suite_focus=true

```
error[E0658]: non exhaustive is an experimental feature
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/memchr-2.4.0/src/memmem/prefilter/mod.rs:152:1
    |
152 | #[non_exhaustive]
    | ^^^^^^^^^^^^^^^^^
    |
```

Also, the motivation behind Rust 1.41 being set as memchr's new MSRV seems reasonable to me:

https://github.com/BurntSushi/memchr/commit/952717e1c370693ae68777b0c9367bd31bd8fb03

> This also bumps the MSRV to Rust 1.41, which is what is currently in
> Debian stable.

Users can continue to use the old compiler by downgrading memchr. However, I don't think futures-util itself needs to do that as I think 1.41 is a reasonable MSRV (it was released [over a year ago](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html)).