### PR TITLE
Use futuresordered in join_all

### DIFF
--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -11,10 +11,9 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use super::{assert_future, MaybeDone};
-use crate::stream::Collect;
 
 #[cfg(not(futures_no_atomic_cas))]
-use crate::stream::{FuturesOrdered, StreamExt};
+use crate::stream::{Collect, FuturesOrdered, StreamExt};
 
 fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
@@ -106,7 +105,7 @@ where
 {
     #[cfg(futures_no_atomic_cas)]
     {
-        let elems = iter.map(MaybeDone::Future).collect::<Box<[_]>>().into();
+        let elems = iter.into_iter().map(MaybeDone::Future).collect::<Box<[_]>>().into();
         let kind = JoinAllKind::Small { elems };
         assert_future::<Vec<<I::Item as Future>::Output>, _>(JoinAll { kind })
     }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -11,6 +11,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use super::{assert_future, MaybeDone};
+use crate::stream::{Collect, FuturesOrdered, StreamExt};
 
 fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     // Safety: `std` _could_ make this unsound if it were to decide Pin's
@@ -19,13 +20,29 @@ fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
     unsafe { slice.get_unchecked_mut() }.iter_mut().map(|t| unsafe { Pin::new_unchecked(t) })
 }
 
-/// Future for the [`join_all`] function.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct JoinAll<F>
-where
-    F: Future,
-{
-    elems: Pin<Box<[MaybeDone<F>]>>,
+pin_project_lite::pin_project! {
+    /// Future for the [`join_all`] function.
+    pub struct JoinAll<F>
+    where
+        F: Future,
+    {
+        #[pin]
+        kind: JoinAllKind<F>,
+    }
+}
+
+const SMALL: usize = 30;
+
+pin_project_lite::pin_project! {
+    #[project = JoinAllKindProj]
+    pub enum JoinAllKind<F>
+    where
+        F: Future,
+    {
+        Small { elems: Pin<Box<[MaybeDone<F>]>> },
+        Big  { #[pin] ordered: Collect<FuturesOrdered<F>, Vec<F::Output>> },
+    }
 }
 
 impl<F> fmt::Debug for JoinAll<F>
@@ -34,7 +51,12 @@ where
     F::Output: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("JoinAll").field("elems", &self.elems).finish()
+        match self.kind {
+            JoinAllKind::Small { ref elems } => {
+                f.debug_struct("JoinAll").field("elems", elems).finish()
+            }
+            JoinAllKind::Big { ref ordered, .. } => fmt::Debug::fmt(ordered, f),
+        }
     }
 }
 
@@ -50,10 +72,7 @@ where
 ///
 /// # See Also
 ///
-/// This is purposefully a very simple API for basic use-cases. In a lot of
-/// cases you will want to use the more powerful
-/// [`FuturesOrdered`][crate::stream::FuturesOrdered] APIs, or, if order does
-/// not matter, [`FuturesUnordered`][crate::stream::FuturesUnordered].
+/// `join_all` will switch to the more powerful [`FuturesOrdered`] if the number of futures is large for performance reasons. If the return order does not matter and you are polling many futures, you should look into [`FuturesUnordered`][crate::stream::FuturesUnordered].
 ///
 /// Some examples for additional functionality provided by these are:
 ///
@@ -80,8 +99,36 @@ where
     I: IntoIterator,
     I::Item: Future,
 {
-    let elems: Box<[_]> = i.into_iter().map(MaybeDone::Future).collect();
-    assert_future::<Vec<<I::Item as Future>::Output>, _>(JoinAll { elems: elems.into() })
+    let iter = i.into_iter();
+    let kind = match iter.size_hint().1 {
+        None => big(iter),
+        Some(max) => {
+            if max <= SMALL {
+                small(iter)
+            } else {
+                big(iter)
+            }
+        }
+    };
+    assert_future::<Vec<<I::Item as Future>::Output>, _>(JoinAll { kind })
+}
+
+fn small<I>(i: I) -> JoinAllKind<I::Item>
+where
+    I: Iterator,
+    I::Item: Future,
+{
+    let elems: Box<[_]> = i.map(MaybeDone::Future).collect();
+    JoinAllKind::Small { elems: elems.into() }
+}
+
+fn big<I>(i: I) -> JoinAllKind<I::Item>
+where
+    I: Iterator,
+    I::Item: Future,
+{
+    let ordered = FuturesOrdered::from_iter(i);
+    JoinAllKind::Big { ordered: StreamExt::collect(ordered) }
 }
 
 impl<F> Future for JoinAll<F>
@@ -90,21 +137,27 @@ where
 {
     type Output = Vec<F::Output>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut all_done = true;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().kind.project() {
+            JoinAllKindProj::Small { elems } => {
+                let mut all_done = true;
 
-        for elem in iter_pin_mut(self.elems.as_mut()) {
-            if elem.poll(cx).is_pending() {
-                all_done = false;
+                for elem in iter_pin_mut(elems.as_mut()) {
+                    if elem.poll(cx).is_pending() {
+                        all_done = false;
+                    }
+                }
+
+                if all_done {
+                    let mut elems = mem::replace(elems, Box::pin([]));
+                    let result =
+                        iter_pin_mut(elems.as_mut()).map(|e| e.take_output().unwrap()).collect();
+                    Poll::Ready(result)
+                } else {
+                    Poll::Pending
+                }
             }
-        }
-
-        if all_done {
-            let mut elems = mem::replace(&mut self.elems, Box::pin([]));
-            let result = iter_pin_mut(elems.as_mut()).map(|e| e.take_output().unwrap()).collect();
-            Poll::Ready(result)
-        } else {
-            Poll::Pending
+            JoinAllKindProj::Big { ordered } => ordered.poll(cx),
         }
     }
 }

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -75,7 +75,9 @@ where
 ///
 /// # See Also
 ///
-/// `join_all` will switch to the more powerful [`FuturesOrdered`] if the number of futures is large for performance reasons. If the return order does not matter and you are polling many futures, you should look into [`FuturesUnordered`][crate::stream::FuturesUnordered].
+/// `join_all` will switch to the more powerful [`FuturesOrdered`] for performance
+/// reasons if the number of futures is large. You may want to look into using it or
+/// it's counterpart [`FuturesUnordered`][crate::stream::FuturesUnordered] directly.
 ///
 /// Some examples for additional functionality provided by these are:
 ///

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -31,6 +31,7 @@ where
     kind: JoinAllKind<F>,
 }
 
+#[cfg(not(futures_no_atomic_cas))]
 const SMALL: usize = 30;
 
 pub(crate) enum JoinAllKind<F>

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -34,7 +34,7 @@ where
 
 const SMALL: usize = 30;
 
-pub enum JoinAllKind<F>
+pub(crate) enum JoinAllKind<F>
 where
     F: Future,
 {

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -243,7 +243,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// This future will drive the stream to keep producing items until it is
     /// exhausted, sending each item to the sink. It will complete once both the
     /// stream is exhausted, the sink has received all items, and the sink has
-    /// been flushed. Note that the sink is **not** closed. If the stream produces 
+    /// been flushed. Note that the sink is **not** closed. If the stream produces
     /// an error, that error will be returned by this future without flushing the sink.
     ///
     /// Doing `sink.send_all(stream)` is roughly equivalent to


### PR DESCRIPTION
Switch to `FuturesOrdered` in `join_all` when dealing with large amounts of futures. We will probably need benchmarks to determine what `SMALL` is.

Closes #2201