### PR TITLE
clean up try(join) combinator

### DIFF
--- a/futures-util/src/future/join.rs
+++ b/futures-util/src/future/join.rs
@@ -1,81 +1,59 @@
-#![allow(non_snake_case)]
-
-use super::assert_future;
-use crate::future::{maybe_done, MaybeDone};
+use crate::future::{assert_future, maybe_done, MaybeDone};
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
-macro_rules! generate {
-    ($(
-        $(#[$doc:meta])*
-        ($Join:ident, <$($Fut:ident),*>),
-    )*) => ($(
-        pin_project! {
-            $(#[$doc])*
-            #[must_use = "futures do nothing unless you `.await` or poll them"]
-            pub struct $Join<$($Fut: Future),*> {
-                $(#[pin] $Fut: MaybeDone<$Fut>,)*
-            }
-        }
-
-        impl<$($Fut),*> fmt::Debug for $Join<$($Fut),*>
-        where
-            $(
-                $Fut: Future + fmt::Debug,
-                $Fut::Output: fmt::Debug,
-            )*
-        {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_struct(stringify!($Join))
-                    $(.field(stringify!($Fut), &self.$Fut))*
-                    .finish()
-            }
-        }
-
-        impl<$($Fut: Future),*> $Join<$($Fut),*> {
-            fn new($($Fut: $Fut),*) -> Self {
-                Self {
-                    $($Fut: maybe_done($Fut)),*
-                }
-            }
-        }
-
-        impl<$($Fut: Future),*> Future for $Join<$($Fut),*> {
-            type Output = ($($Fut::Output),*);
-
-            fn poll(
-                self: Pin<&mut Self>, cx: &mut Context<'_>
-            ) -> Poll<Self::Output> {
-                let mut all_done = true;
-                let mut futures = self.project();
-                $(
-                    all_done &= futures.$Fut.as_mut().poll(cx).is_ready();
-                )*
-
-                if all_done {
-                    Poll::Ready(($(futures.$Fut.take_output().unwrap()), *))
-                } else {
-                    Poll::Pending
-                }
-            }
-        }
-
-        impl<$($Fut: FusedFuture),*> FusedFuture for $Join<$($Fut),*> {
-            fn is_terminated(&self) -> bool {
-                $(
-                    self.$Fut.is_terminated()
-                ) && *
-            }
-        }
-    )*)
+pin_project! {
+    /// Future for the [`join`](super::FutureExt::join) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Join<Fut1, Fut2> where Fut1: Future, Fut2: Future {
+        #[pin] fut1: MaybeDone<Fut1>,
+        #[pin] fut2: MaybeDone<Fut2>,
+    }
 }
 
-generate! {
-    /// Future for the [`join`](join()) function.
-    (Join, <Fut1, Fut2>),
+impl<Fut1: Future, Fut2: Future> Join<Fut1, Fut2> {
+    pub(crate) fn new(fut1: Fut1, fut2: Fut2) -> Self {
+        Self { fut1: maybe_done(fut1), fut2: maybe_done(fut2) }
+    }
+}
+
+impl<Fut1, Fut2> fmt::Debug for Join<Fut1, Fut2>
+where
+    Fut1: Future + fmt::Debug,
+    Fut1::Output: fmt::Debug,
+    Fut2: Future + fmt::Debug,
+    Fut2::Output: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Join").field("fut1", &self.fut1).field("fut2", &self.fut2).finish()
+    }
+}
+
+impl<Fut1: Future, Fut2: Future> Future for Join<Fut1, Fut2> {
+    type Output = (Fut1::Output, Fut2::Output);
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut all_done = true;
+        let mut futures = self.project();
+
+        all_done &= futures.fut1.as_mut().poll(cx).is_ready();
+        all_done &= futures.fut2.as_mut().poll(cx).is_ready();
+
+        if all_done {
+            Poll::Ready((futures.fut1.take_output().unwrap(), futures.fut2.take_output().unwrap()))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl<Fut1: FusedFuture, Fut2: FusedFuture> FusedFuture for Join<Fut1, Fut2> {
+    fn is_terminated(&self) -> bool {
+        self.fut1.is_terminated() && self.fut2.is_terminated()
+    }
 }
 
 /// Joins the result of two futures, waiting for them both to complete.
@@ -104,6 +82,5 @@ where
     Fut1: Future,
     Fut2: Future,
 {
-    let f = Join::new(future1, future2);
-    assert_future::<(Fut1::Output, Fut2::Output), _>(f)
+    assert_future::<(Fut1::Output, Fut2::Output), _>(Join::new(future1, future2))
 }

--- a/futures-util/src/sink/mod.rs
+++ b/futures-util/src/sink/mod.rs
@@ -243,7 +243,7 @@ pub trait SinkExt<Item>: Sink<Item> {
     /// This future will drive the stream to keep producing items until it is
     /// exhausted, sending each item to the sink. It will complete once both the
     /// stream is exhausted, the sink has received all items, and the sink has
-    /// been flushed. Note that the sink is **not** closed. If the stream produces 
+    /// been flushed. Note that the sink is **not** closed. If the stream produces
     /// an error, that error will be returned by this future without flushing the sink.
     ///
     /// Doing `sink.send_all(stream)` is roughly equivalent to


### PR DESCRIPTION
Now that `Try/JoinX` was removed, the macros are just noise.