### PR TITLE
add size_hint to mpsc receiver

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -282,7 +282,7 @@ struct UnboundedInner<T> {
 
 #[derive(Debug)]
 struct BoundedInner<T> {
-    // Max buffer size of the channel. If `None` then the channel is unbounded.
+    // Max buffer size of the channel.
     buffer: usize,
 
     // Internal channel state. Consists of the number of messages stored in the
@@ -1124,6 +1124,10 @@ impl<T> Stream for Receiver<T> {
                 self.next_message()
             }
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.inner.as_ref().map(|i| i.buffer))
     }
 }
 


### PR DESCRIPTION
Return the max buffer size of `mpsc::Receiver` as the upper bound in `Stream::size_hint`.