### PR TITLE
Revert "add size_hint to mpsc receiver"

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -282,7 +282,7 @@ struct UnboundedInner<T> {
 
 #[derive(Debug)]
 struct BoundedInner<T> {
-    // Max buffer size of the channel. If `None` then the channel is unbounded.
+    // Max buffer size of the channel.
     buffer: usize,
 
     // Internal channel state. Consists of the number of messages stored in the

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -282,7 +282,7 @@ struct UnboundedInner<T> {
 
 #[derive(Debug)]
 struct BoundedInner<T> {
-    // Max buffer size of the channel.
+    // Max buffer size of the channel. If `None` then the channel is unbounded.
     buffer: usize,
 
     // Internal channel state. Consists of the number of messages stored in the
@@ -1124,10 +1124,6 @@ impl<T> Stream for Receiver<T> {
                 self.next_message()
             }
         }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, self.inner.as_ref().map(|i| i.buffer))
     }
 }
 


### PR DESCRIPTION
This reverts commit 0e4dc7da6046fcb2c8f869e9b65c9f0ff792a534. (#2417)

[The buffer size information is not sufficient to recognize the size of the entire stream.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=69198f485e2e5ff50d0b0d7679d6b7b2) Sorry I missed this in the review of #2417.

FYI @Nemo157 @ibraheemdev 


