### PR TITLE
Change StreamExt::scan to pass state to closure by value

### DIFF
--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -10,10 +10,10 @@ pin_project! {
     /// Sink for the [`unfold`] function.
     #[derive(Debug)]
     #[must_use = "sinks do nothing unless polled"]
-    pub struct Unfold<T, F, R> {
+    pub struct Unfold<T, F, Fut> {
         function: F,
         #[pin]
-        state: UnfoldState<T, R>,
+        state: UnfoldState<T, Fut>,
     }
 }
 
@@ -36,18 +36,18 @@ pin_project! {
 /// unfold.send(5).await?;
 /// # Ok::<(), std::convert::Infallible>(()) }).unwrap();
 /// ```
-pub fn unfold<T, F, R, Item, E>(init: T, function: F) -> Unfold<T, F, R>
+pub fn unfold<T, F, Fut, Item, E>(init: T, function: F) -> Unfold<T, F, Fut>
 where
-    F: FnMut(T, Item) -> R,
-    R: Future<Output = Result<T, E>>,
+    F: FnMut(T, Item) -> Fut,
+    Fut: Future<Output = Result<T, E>>,
 {
     assert_sink::<Item, E, _>(Unfold { function, state: UnfoldState::Value { value: init } })
 }
 
-impl<T, F, R, Item, E> Sink<Item> for Unfold<T, F, R>
+impl<T, F, Fut, Item, E> Sink<Item> for Unfold<T, F, Fut>
 where
-    F: FnMut(T, Item) -> R,
-    R: Future<Output = Result<T, E>>,
+    F: FnMut(T, Item) -> Fut,
+    Fut: Future<Output = Result<T, E>>,
 {
     type Error = E;
 

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -715,18 +715,25 @@ pub trait StreamExt: Stream {
     /// of the stream until provided closure returns `None`. Once `None` is
     /// returned, stream will be terminated.
     ///
+    /// Unlike [`Iterator::scan`], the closure takes the state by value instead of
+    /// mutable reference to avoid [the limitation of the async
+    /// block](https://github.com/rust-lang/futures-rs/issues/2171).
+    ///
     /// # Examples
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::future;
     /// use futures::stream::{self, StreamExt};
     ///
     /// let stream = stream::iter(1..=10);
     ///
-    /// let stream = stream.scan(0, |state, x| {
-    ///     *state += x;
-    ///     future::ready(if *state < 10 { Some(x) } else { None })
+    /// let stream = stream.scan(0, |mut state, x| async move {
+    ///     state += x;
+    ///     if state < 10 {
+    ///         Some((state, x))
+    ///     } else {
+    ///         None
+    ///     }
     /// });
     ///
     /// assert_eq!(vec![1, 2, 3], stream.collect::<Vec<_>>().await);
@@ -734,8 +741,8 @@ pub trait StreamExt: Stream {
     /// ```
     fn scan<S, B, Fut, F>(self, initial_state: S, f: F) -> Scan<Self, S, Fut, F>
     where
-        F: FnMut(&mut S, Self::Item) -> Fut,
-        Fut: Future<Output = Option<B>>,
+        F: FnMut(S, Self::Item) -> Fut,
+        Fut: Future<Output = Option<(S, B)>>,
         Self: Sized,
     {
         assert_stream::<B, _>(Scan::new(self, initial_state, f))

--- a/futures-util/src/unfold_state.rs
+++ b/futures-util/src/unfold_state.rs
@@ -7,20 +7,34 @@ pin_project! {
     #[project = UnfoldStateProj]
     #[project_replace = UnfoldStateProjReplace]
     #[derive(Debug)]
-    pub(crate) enum UnfoldState<T, R> {
+    pub(crate) enum UnfoldState<T, Fut> {
         Value {
             value: T,
         },
         Future {
             #[pin]
-            future: R,
+            future: Fut,
         },
         Empty,
     }
 }
 
-impl<T, R> UnfoldState<T, R> {
-    pub(crate) fn project_future(self: Pin<&mut Self>) -> Option<Pin<&mut R>> {
+impl<T, Fut> UnfoldState<T, Fut> {
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            Self::Empty => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn is_future(&self) -> bool {
+        match self {
+            Self::Future { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn project_future(self: Pin<&mut Self>) -> Option<Pin<&mut Fut>> {
         match self.project() {
             UnfoldStateProj::Future { future } => Some(future),
             _ => None,


### PR DESCRIPTION
Fixes #2171

```diff
      fn scan<S, B, Fut, F>(self, initial_state: S, f: F) -> Scan<Self, S, Fut, F>
      where
-         F: FnMut(&mut S, Self::Item) -> Fut,
-         Fut: Future<Output = Option<B>>,
+         F: FnMut(S, Self::Item) -> Fut,
+         Fut: Future<Output = Option<(S, B)>>,
          Self: Sized,
```

Related: https://github.com/rust-lang/futures-rs/issues/1609#issuecomment-493526043, https://github.com/rust-lang/futures-rs/pull/2254#issuecomment-731860678