### PR TITLE
Remove extra text from test attribute docs

### DIFF
--- a/futures-macro/src/lib.rs
+++ b/futures-macro/src/lib.rs
@@ -46,7 +46,8 @@ pub fn select_biased_internal(input: TokenStream) -> TokenStream {
     crate::select::select_biased(input)
 }
 
-/// The `test` attribute.
+// TODO: Change this to doc comment once rustdoc bug fixed.
+// The `test` attribute.
 #[proc_macro_attribute]
 pub fn test_internal(input: TokenStream, item: TokenStream) -> TokenStream {
     crate::executor::test(input, item)


### PR DESCRIPTION
Seems there is a rustdoc bug regarding docs on use items.

<img width="556" alt="doc" src="https://user-images.githubusercontent.com/43724913/117696894-caf71f00-b1fc-11eb-9bf9-2a12668bfa34.png">

The main docs for test attribute is in [the code that reexports it](https://github.com/rust-lang/futures-rs/blob/961af12aa5d8e9984bbb0154d1e6f7e23f817257/futures-test/src/lib.rs#L54-L77).
"The `test` attribute." is not what we are expecting to see.
