### PR TITLE
Release 0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.3.15 - 2021-05-10
+# 0.3.15 - 2021-05-11
 * Use `#[proc_macro]` at Rust 1.45+ to fix an issue where proc macros don't work with rust-analyzer (#2407)
 * Support targets that do not have atomic CAS on stable Rust (#2400)
 * futures-test: Add async `#[test]` function attribute (#2409)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,30 @@
+# 0.3.15 - 2021-05-10
+* Use `#[proc_macro]` at Rust 1.45+ to fix an issue where proc macros don't work with rust-analyzer (#2407)
+* Support targets that do not have atomic CAS on stable Rust (#2400)
+* futures-test: Add async `#[test]` function attribute (#2409)
+* Add `stream::abortable` (#2410)
+* Add `FuturesUnordered::clear` (#2415)
+* Implement `IntoIterator` for `FuturesUnordered` (#2423)
+* Implement `Send` and `Sync` for `FuturesUnordered` iterators (#2416)
+* Make `FuturesUnordered::iter_pin_ref` public (#2423)
+* Add `SelectAll::clear` (#2430)
+* Add `SelectAll::{iter, iter_mut}` (#2428)
+* Implement `IntoIterator` for `SelectAll` (#2428)
+* Implement `Clone` for `WeakShared` (#2396)
+
 # 0.3.14 - 2021-04-10
-- Add `future::SelectAll::into_inner` (#2363)
-- Allow calling `UnboundedReceiver::try_next` after `None` (#2369)
-- Reexport non-Ext traits from the root of `futures_util` (#2377)
-- Add `AsyncSeekExt::stream_position` (#2380)
-- Add `stream::Peekable::{next_if, next_if_eq}` (#2379)
+* Add `future::SelectAll::into_inner` (#2363)
+* Allow calling `UnboundedReceiver::try_next` after `None` (#2369)
+* Reexport non-Ext traits from the root of `futures_util` (#2377)
+* Add `AsyncSeekExt::stream_position` (#2380)
+* Add `stream::Peekable::{next_if, next_if_eq}` (#2379)
 
 # 0.3.13 - 2021-02-23
-- Mitigated starvation issues in `FuturesUnordered` (#2333)
-- Fixed race with dropping `mpsc::Receiver` (#2304)
-- Added `Shared::{strong_count, weak_count}` (#2346)
-- Added `no_std` support for `task::noop_waker_ref` (#2332)
-- Implemented `Stream::size_hint` for `Either` (#2325)
+* Mitigated starvation issues in `FuturesUnordered` (#2333)
+* Fixed race with dropping `mpsc::Receiver` (#2304)
+* Added `Shared::{strong_count, weak_count}` (#2346)
+* Added `no_std` support for `task::noop_waker_ref` (#2332)
+* Implemented `Stream::size_hint` for `Either` (#2325)
 
 # 0.3.12 - 2021-01-15
 * Fixed `Unpin` impl of `future::{MaybeDone, TryMaybeDone}` where trait bounds were accidentally added in 0.3.9. (#2317)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-channel"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -23,8 +23,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.14", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.14", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.15", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.15", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-core"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-executor"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.14", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.14", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.14", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.15", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.15", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.15", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-io"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-macro"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-sink"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-task"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-test"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -12,13 +12,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.14", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.14", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.14", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.14", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.14", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.14", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.14", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.15", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.15", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.15", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.15", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.15", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.15", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.15", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.1"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-util"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
@@ -39,12 +39,12 @@ cfg-target-has-atomic = []
 autocfg = "1"
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.14", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.14", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.14", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.14", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.14", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.14", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.15", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.15", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.15", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.15", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.15", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.15", default-features = false, optional = true }
 proc-macro-hack = { version = "0.5.19", optional = true }
 proc-macro-nested = { version = "0.1.2", optional = true }
 slab = { version = "0.4.2", optional = true }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures"
 edition = "2018"
-version = "0.3.14"
+version = "0.3.15"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.14", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.14", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.14", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.14", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.14", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.14", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.14", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.15", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.15", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.15", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.15", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.15", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.15", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.15", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }


### PR DESCRIPTION
Changes:

* Use `#[proc_macro]` at Rust 1.45+ to fix an issue where proc macros don't work with rust-analyzer (#2407)
* Support targets that do not have atomic CAS on stable Rust (#2400)
* futures-test: Add async `#[test]` function attribute (#2409)
* Add `stream::abortable` (#2410)
* Add `FuturesUnordered::clear` (#2415)
* Implement `IntoIterator` for `FuturesUnordered` (#2423)
* Implement `Send` and `Sync` for `FuturesUnordered` iterators (#2416)
* Make `FuturesUnordered::iter_pin_ref` public (#2423)
* Add `SelectAll::clear` (#2430)
* Add `SelectAll::{iter, iter_mut}` (#2428)
* Implement `IntoIterator` for `SelectAll` (#2428)
* Implement `Clone` for `WeakShared` (#2396)
