### PR TITLE
futures-core: Remove __private module

### DIFF
--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -20,9 +20,3 @@ pub use self::stream::{FusedStream, Stream, TryStream};
 
 #[macro_use]
 pub mod task;
-
-// Not public API.
-#[doc(hidden)]
-pub mod __private {
-    pub use core::task::Poll;
-}

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -5,8 +5,8 @@
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {
-            $crate::__private::Poll::Ready(t) => t,
-            $crate::__private::Poll::Pending => return $crate::__private::Poll::Pending,
+            $crate::task::Poll::Ready(t) => t,
+            $crate::task::Poll::Pending => return $crate::task::Poll::Pending,
         }
     };
 }


### PR DESCRIPTION
`Poll` has already been re-exported in the public API, so this module is not needed.