### PR TITLE
Introduce stream::select_with_strategy

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -92,8 +92,8 @@ pub use self::poll_fn::{poll_fn, PollFn};
 mod select;
 pub use self::select::{select, Select};
 
-mod select_bias;
-pub use self::select_bias::{select_bias, PollNext, SelectBias};
+mod select_with_strategy;
+pub use self::select_with_strategy::{select_with_strategy, PollNext, SelectWithStrategy};
 
 mod unfold;
 pub use self::unfold::{unfold, Unfold};

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -92,6 +92,9 @@ pub use self::poll_fn::{poll_fn, PollFn};
 mod select;
 pub use self::select::{select, Select};
 
+mod select_bias;
+pub use self::select_bias::{select_bias, PollNext, SelectBias};
+
 mod unfold;
 pub use self::unfold::{unfold, Unfold};
 

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -29,7 +29,7 @@ pin_project! {
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
-/// use futures_util::stream::{ repeat, select, StreamExt };
+/// use futures::stream::{ repeat, select, StreamExt };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,5 +1,5 @@
 use super::assert_stream;
-use crate::stream::{Fuse, StreamExt};
+use crate::stream::{select_with_strategy, SelectWithStrategy, PollNext};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -7,14 +7,10 @@ use pin_project_lite::pin_project;
 
 pin_project! {
     /// Stream for the [`select()`] function.
-    #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
     pub struct Select<St1, St2> {
         #[pin]
-        stream1: Fuse<St1>,
-        #[pin]
-        stream2: Fuse<St2>,
-        flag: bool,
+        inner: SelectWithStrategy<St1, St2, fn(&mut PollNext)-> PollNext, PollNext>,
     }
 }
 
@@ -28,15 +24,34 @@ pin_project! {
 ///
 /// Note that this function consumes both streams and returns a wrapped
 /// version of them.
+///
+/// ## Examples
+///
+/// ```rust
+/// # futures::executor::block_on(async {
+/// use futures_util::stream::{ repeat, select, StreamExt };
+///
+/// let left = repeat(1);
+/// let right = repeat(2);
+///
+/// let mut out = select(left, right);
+///
+/// for _ in 0..100 {
+///     // We should be alternating.
+///     assert_eq!(1, out.select_next_some().await);
+///     assert_eq!(2, out.select_next_some().await);
+/// }
+/// # });
+/// ```
 pub fn select<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
 {
-    assert_stream::<St1::Item, _>(Select {
-        stream1: stream1.fuse(),
-        stream2: stream2.fuse(),
-        flag: false,
+    fn round_robin(last: &mut PollNext) -> PollNext { last.toggle() }
+
+    assert_stream::<St1::Item, _>( Select {
+        inner: select_with_strategy(stream1, stream2, round_robin)
     })
 }
 
@@ -44,7 +59,7 @@ impl<St1, St2> Select<St1, St2> {
     /// Acquires a reference to the underlying streams that this combinator is
     /// pulling from.
     pub fn get_ref(&self) -> (&St1, &St2) {
-        (self.stream1.get_ref(), self.stream2.get_ref())
+        self.inner.get_ref()
     }
 
     /// Acquires a mutable reference to the underlying streams that this
@@ -53,7 +68,7 @@ impl<St1, St2> Select<St1, St2> {
     /// Note that care must be taken to avoid tampering with the state of the
     /// stream which may otherwise confuse this combinator.
     pub fn get_mut(&mut self) -> (&mut St1, &mut St2) {
-        (self.stream1.get_mut(), self.stream2.get_mut())
+        self.inner.get_mut()
     }
 
     /// Acquires a pinned mutable reference to the underlying streams that this
@@ -63,7 +78,7 @@ impl<St1, St2> Select<St1, St2> {
     /// stream which may otherwise confuse this combinator.
     pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>) {
         let this = self.project();
-        (this.stream1.get_pin_mut(), this.stream2.get_pin_mut())
+        this.inner.get_pin_mut()
     }
 
     /// Consumes this combinator, returning the underlying streams.
@@ -71,7 +86,7 @@ impl<St1, St2> Select<St1, St2> {
     /// Note that this may discard intermediate state of this combinator, so
     /// care should be taken to avoid losing resources when this is called.
     pub fn into_inner(self) -> (St1, St2) {
-        (self.stream1.into_inner(), self.stream2.into_inner())
+        self.inner.into_inner()
     }
 }
 
@@ -81,7 +96,7 @@ where
     St2: Stream<Item = St1::Item>,
 {
     fn is_terminated(&self) -> bool {
-        self.stream1.is_terminated() && self.stream2.is_terminated()
+        self.inner.is_terminated()
     }
 }
 
@@ -94,37 +109,6 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St1::Item>> {
         let this = self.project();
-        if !*this.flag {
-            poll_inner(this.flag, this.stream1, this.stream2, cx)
-        } else {
-            poll_inner(this.flag, this.stream2, this.stream1, cx)
-        }
-    }
-}
-
-fn poll_inner<St1, St2>(
-    flag: &mut bool,
-    a: Pin<&mut St1>,
-    b: Pin<&mut St2>,
-    cx: &mut Context<'_>,
-) -> Poll<Option<St1::Item>>
-where
-    St1: Stream,
-    St2: Stream<Item = St1::Item>,
-{
-    let a_done = match a.poll_next(cx) {
-        Poll::Ready(Some(item)) => {
-            // give the other stream a chance to go first next time
-            *flag = !*flag;
-            return Poll::Ready(Some(item));
-        }
-        Poll::Ready(None) => true,
-        Poll::Pending => false,
-    };
-
-    match b.poll_next(cx) {
-        Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
-        Poll::Ready(None) if a_done => Poll::Ready(None),
-        Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        this.inner.poll_next(cx)
     }
 }

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,5 +1,5 @@
 use super::assert_stream;
-use crate::stream::{select_with_strategy, SelectWithStrategy, PollNext};
+use crate::stream::{select_with_strategy, PollNext, SelectWithStrategy};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -48,10 +48,12 @@ where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
 {
-    fn round_robin(last: &mut PollNext) -> PollNext { last.toggle() }
+    fn round_robin(last: &mut PollNext) -> PollNext {
+        last.toggle()
+    }
 
-    assert_stream::<St1::Item, _>( Select {
-        inner: select_with_strategy(stream1, stream2, round_robin)
+    assert_stream::<St1::Item, _>(Select {
+        inner: select_with_strategy(stream1, stream2, round_robin),
     })
 }
 

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -22,7 +22,7 @@ pin_project! {
 /// stream will be polled in a round-robin fashion, and whenever a stream is
 /// ready to yield an item that item is yielded.
 ///
-/// After one of the two input stream completes, the remaining one will be
+/// After one of the two input streams completes, the remaining one will be
 /// polled exclusively. The returned stream completes when both input
 /// streams have completed.
 ///

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -7,6 +7,7 @@ use pin_project_lite::pin_project;
 
 pin_project! {
     /// Stream for the [`select()`] function.
+    #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
     pub struct Select<St1, St2> {
         #[pin]

--- a/futures-util/src/stream/select_bias.rs
+++ b/futures-util/src/stream/select_bias.rs
@@ -53,7 +53,7 @@ pin_project! {
 /// store state on `SelectBias` to which it will receive a `&mut` on every
 /// invocation. This allows basing the strategy on prior choices.
 ///
-/// After one of the two input stream completes, the remaining one will be
+/// After one of the two input streams completes, the remaining one will be
 /// polled exclusively. The returned stream completes when both input
 /// streams have completed.
 ///
@@ -66,15 +66,13 @@ pin_project! {
 /// This example shows how to always prioritize the left stream.
 ///
 /// ```rust
-///
 /// # futures::executor::block_on(async {
-/// use futures_util::stream::{ select_bias, PollNext, StreamExt };
-/// use futures::stream::repeat;
+/// use futures_util::stream::{ repeat, select_bias, PollNext, StreamExt };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);
 ///
-/// // We don't need any state, so lets make it an empty tuple.
+/// // We don't need any state, so let's make it an empty tuple.
 /// // We must provide some type here, as there is no way for the compiler
 /// // to infer it.
 /// let prio_left = |_: &mut ()| PollNext::Left;
@@ -82,26 +80,23 @@ pin_project! {
 /// let mut out = select_bias(left, right, prio_left);
 ///
 /// for _ in 0..100 {
-///     // Whenever we poll out, we will alwasy get `1`.
+///     // Whenever we poll out, we will alwas get `1`.
 ///     assert_eq!(1, out.select_next_some().await);
 /// }
-///
-/// });
+/// # });
 /// ```
 ///
 /// ### Round Robin
 /// This example shows how to select from both streams round robin.
 ///
 /// ```rust
-///
 /// # futures::executor::block_on(async {
-/// use futures_util::stream::{ select_bias, PollNext, StreamExt };
-/// use futures::stream::repeat;
+/// use futures_util::stream::{ repeat, select_bias, PollNext, StreamExt };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);
 ///
-/// // We don't need any state, so lets make it an empty tuple.
+/// // We don't need any state, so let's make it an empty tuple.
 /// let rrobin = |last: &mut PollNext| last.toggle();
 ///
 /// let mut out = select_bias(left, right, rrobin);
@@ -111,8 +106,7 @@ pin_project! {
 ///     assert_eq!(1, out.select_next_some().await);
 ///     assert_eq!(2, out.select_next_some().await);
 /// }
-///
-/// });
+/// # });
 /// ```
 pub fn select_bias<St1, St2, Clos, State>(
     stream1: St1,

--- a/futures-util/src/stream/select_bias.rs
+++ b/futures-util/src/stream/select_bias.rs
@@ -1,0 +1,220 @@
+use super::assert_stream;
+use crate::stream::{Fuse, StreamExt};
+use core::pin::Pin;
+use futures_core::stream::{FusedStream, Stream};
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+/// Type to tell [`SelectBias`] which stream to poll next.
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+pub enum PollNext {
+    /// Poll the first stream.
+    Left,
+    /// Poll the second stream.
+    Right,
+}
+
+impl PollNext {
+    /// Toggle the value and return the old one.
+    pub fn toggle(&mut self) -> Self {
+        let old = *self;
+
+        match self {
+            PollNext::Left => *self = PollNext::Right,
+            PollNext::Right => *self = PollNext::Left,
+        }
+
+        old
+    }
+}
+
+impl Default for PollNext {
+    fn default() -> Self {
+        PollNext::Left
+    }
+}
+
+pin_project! {
+    /// Stream for the [`select_bias()`] function. See function docs for details.
+    #[derive(Debug)]
+    #[must_use = "streams do nothing unless polled"]
+    pub struct SelectBias<St1, St2, Clos, State> {
+        #[pin]
+        stream1: Fuse<St1>,
+        #[pin]
+        stream2: Fuse<St2>,
+        state: State,
+        clos: Clos,
+    }
+}
+
+/// This function will attempt to pull items from both streams. You provide a
+/// closure to tell the [`SelectBias`] which stream to poll. The closure can
+/// store state on `SelectBias` to which it will receive a `&mut` on every
+/// invocation. This allows basing the strategy on prior choices.
+///
+/// After one of the two input stream completes, the remaining one will be
+/// polled exclusively. The returned stream completes when both input
+/// streams have completed.
+///
+/// Note that this function consumes both streams and returns a wrapped
+/// version of them.
+///
+/// ## Examples
+///
+/// ### Priority
+/// This example shows how to always prioritize the left stream.
+///
+/// ```rust
+///
+/// # futures::executor::block_on(async {
+/// use futures_util::stream::{ select_bias, PollNext, StreamExt };
+/// use futures::stream::repeat;
+///
+/// let left = repeat(1);
+/// let right = repeat(2);
+///
+/// // We don't need any state, so lets make it an empty tuple.
+/// // We must provide some type here, as there is no way for the compiler
+/// // to infer it.
+/// let prio_left = |_: &mut ()| PollNext::Left;
+///
+/// let mut out = select_bias(left, right, prio_left);
+///
+/// for _ in 0..100 {
+///     // Whenever we poll out, we will alwasy get `1`.
+///     assert_eq!(1, out.select_next_some().await);
+/// }
+///
+/// });
+/// ```
+///
+/// ### Round Robin
+/// This example shows how to select from both streams round robin.
+///
+/// ```rust
+///
+/// # futures::executor::block_on(async {
+/// use futures_util::stream::{ select_bias, PollNext, StreamExt };
+/// use futures::stream::repeat;
+///
+/// let left = repeat(1);
+/// let right = repeat(2);
+///
+/// // We don't need any state, so lets make it an empty tuple.
+/// let rrobin = |last: &mut PollNext| last.toggle();
+///
+/// let mut out = select_bias(left, right, rrobin);
+///
+/// for _ in 0..100 {
+///     // We should be alternating now.
+///     assert_eq!(1, out.select_next_some().await);
+///     assert_eq!(2, out.select_next_some().await);
+/// }
+///
+/// });
+/// ```
+pub fn select_bias<St1, St2, Clos, State>(
+    stream1: St1,
+    stream2: St2,
+    which: Clos,
+) -> SelectBias<St1, St2, Clos, State>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
+    Clos: FnMut(&mut State) -> PollNext,
+    State: Default,
+{
+    assert_stream::<St1::Item, _>(SelectBias {
+        stream1: stream1.fuse(),
+        stream2: stream2.fuse(),
+        state: Default::default(),
+        clos: which,
+    })
+}
+
+impl<St1, St2, Clos, State> SelectBias<St1, St2, Clos, State> {
+    /// Acquires a reference to the underlying streams that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> (&St1, &St2) {
+        (self.stream1.get_ref(), self.stream2.get_ref())
+    }
+
+    /// Acquires a mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> (&mut St1, &mut St2) {
+        (self.stream1.get_mut(), self.stream2.get_mut())
+    }
+
+    /// Acquires a pinned mutable reference to the underlying streams that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> (Pin<&mut St1>, Pin<&mut St2>) {
+        let this = self.project();
+        (this.stream1.get_pin_mut(), this.stream2.get_pin_mut())
+    }
+
+    /// Consumes this combinator, returning the underlying streams.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> (St1, St2) {
+        (self.stream1.into_inner(), self.stream2.into_inner())
+    }
+}
+
+impl<St1, St2, Clos, State> FusedStream for SelectBias<St1, St2, Clos, State>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
+    Clos: FnMut(&mut State) -> PollNext,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream1.is_terminated() && self.stream2.is_terminated()
+    }
+}
+
+impl<St1, St2, Clos, State> Stream for SelectBias<St1, St2, Clos, State>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
+    Clos: FnMut(&mut State) -> PollNext,
+{
+    type Item = St1::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St1::Item>> {
+        let this = self.project();
+
+        match (this.clos)(this.state) {
+            PollNext::Left => poll_inner(this.stream1, this.stream2, cx),
+            PollNext::Right => poll_inner(this.stream2, this.stream1, cx),
+        }
+    }
+}
+
+fn poll_inner<St1, St2>(
+    a: Pin<&mut St1>,
+    b: Pin<&mut St2>,
+    cx: &mut Context<'_>,
+) -> Poll<Option<St1::Item>>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
+{
+    let a_done = match a.poll_next(cx) {
+        Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
+        Poll::Ready(None) => true,
+        Poll::Pending => false,
+    };
+
+    match b.poll_next(cx) {
+        Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
+        Poll::Ready(None) if a_done => Poll::Ready(None),
+        Poll::Ready(None) | Poll::Pending => Poll::Pending,
+    }
+}

--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -74,8 +74,9 @@ pin_project! {
 ///
 /// // We don't need any state, so let's make it an empty tuple.
 /// // We must provide some type here, as there is no way for the compiler
-/// // to infer it.
-/// let prio_left = |_: &mut ()| PollNext::Left;
+/// // to infer it. As we don't need to capture variables, we can just
+/// // use a function pointer instead of a closure.
+/// fn prio_left(_: &mut ()) -> PollNext { PollNext::Left }
 ///
 /// let mut out = select_with_strategy(left, right, prio_left);
 ///
@@ -88,6 +89,7 @@ pin_project! {
 ///
 /// ### Round Robin
 /// This example shows how to select from both streams round robin.
+/// Note: this special case is provided by [`futures-util::stream::select`].
 ///
 /// ```rust
 /// # futures::executor::block_on(async {

--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -1,6 +1,6 @@
 use super::assert_stream;
 use crate::stream::{Fuse, StreamExt};
-use core::pin::Pin;
+use core::{fmt, pin::Pin};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
@@ -36,7 +36,6 @@ impl Default for PollNext {
 
 pin_project! {
     /// Stream for the [`select_with_strategy()`] function. See function docs for details.
-    #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
     pub struct SelectWithStrategy<St1, St2, Clos, State> {
         #[pin]
@@ -212,5 +211,20 @@ where
         Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
         Poll::Ready(None) if a_done => Poll::Ready(None),
         Poll::Ready(None) | Poll::Pending => Poll::Pending,
+    }
+}
+
+impl<St1, St2, Clos, State> fmt::Debug for SelectWithStrategy<St1, St2, Clos, State>
+where
+    St1: fmt::Debug,
+    St2: fmt::Debug,
+    State: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SelectWithStrategy")
+            .field("stream1", &self.stream1)
+            .field("stream2", &self.stream2)
+            .field("state", &self.state)
+            .finish()
     }
 }

--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -67,7 +67,7 @@ pin_project! {
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
-/// use futures_util::stream::{ repeat, select_with_strategy, PollNext, StreamExt };
+/// use futures::stream::{ repeat, select_with_strategy, PollNext, StreamExt };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);
@@ -93,7 +93,7 @@ pin_project! {
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
-/// use futures_util::stream::{ repeat, select_with_strategy, PollNext, StreamExt };
+/// use futures::stream::{ repeat, select_with_strategy, PollNext, StreamExt };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);


### PR DESCRIPTION
The current stream::select function only supports round robin. To change that
would be a breaking change, so for now I propose a `select_bias` which
takes a closure that defines the selection strategy.

- When a breaking change is planned, we could re-consider this, but it
  does have 4 generic parameters of which one is a closure, compared to
  the 2 streams in `select`. We could also reimplement `select` on top of this,
  we just need to deal with hiding the generics of the closure, but I reckon a 
  function pointer can be named and we don't need to capture anything....
- note the name select_bias. It's not consistent with `select_biased` used
  elsewhere in the lib. This can obviously be changed, but I feel the "ed"
  at the end does not add any semantic value but makes function names
  longer.
- There isn't really integration tests included right now, but the examples
  in the docs get tested by doc test.