### PR TITLE
New poll_immediate functions to immediately return from a poll

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -69,9 +69,7 @@ mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 
 mod poll_immediate;
-pub use self::poll_immediate::{
-    poll_immediate, poll_immediate_reuse, PollImmediate, PollImmediateReuse,
-};
+pub use self::poll_immediate::{poll_immediate, PollImmediate};
 
 mod ready;
 pub use self::ready::{err, ok, ready, Ready};

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -68,6 +68,11 @@ pub use self::option::OptionFuture;
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 
+mod poll_immediate;
+pub use self::poll_immediate::{
+    poll_immediate, poll_immediate_reuse, PollImmediate, PollImmediateReuse,
+};
+
 mod ready;
 pub use self::ready::{err, ok, ready, Ready};
 

--- a/futures-util/src/future/poll_immediate.rs
+++ b/futures-util/src/future/poll_immediate.rs
@@ -1,0 +1,201 @@
+use super::assert_future;
+use crate::FutureExt;
+use core::pin::Pin;
+use futures_core::task::{Context, Poll};
+use futures_core::{FusedFuture, Future, Stream};
+
+/// Future for the [`poll_immediate`](poll_immediate()) function.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct PollImmediate<T>(Option<T>);
+
+impl<T, F> Future for PollImmediate<F>
+where
+    F: Future<Output = T>,
+{
+    type Output = Option<T>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        // # Safety
+        // This is the only time that this future will ever be polled.
+        let inner =
+            unsafe { self.get_unchecked_mut().0.take().expect("PollOnce polled after completion") };
+        crate::pin_mut!(inner);
+        match inner.poll(cx) {
+            Poll::Ready(t) => Poll::Ready(Some(t)),
+            Poll::Pending => Poll::Ready(None),
+        }
+    }
+}
+
+impl<T: Future> FusedFuture for PollImmediate<T> {
+    fn is_terminated(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+/// Creates a stream that can be polled repeatedly until the future is done
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::task::Poll;
+/// use futures::{StreamExt, future, pin_mut};
+/// use future::FusedFuture;
+///
+/// let f = async { 1_u32 };
+/// pin_mut!(f);
+/// let mut r = future::poll_immediate(f);
+/// assert_eq!(r.next().await, Some(Poll::Ready(1)));
+///
+/// let f = async {futures::pending!(); 42_u8};
+/// pin_mut!(f);
+/// let mut p = future::poll_immediate(f);
+/// assert_eq!(p.next().await, Some(Poll::Pending));
+/// assert!(!p.is_terminated());
+/// assert_eq!(p.next().await, Some(Poll::Ready(42)));
+/// assert!(p.is_terminated());
+/// assert_eq!(p.next().await, None);
+/// # });
+/// ```
+impl<T, F> Stream for PollImmediate<F>
+where
+    F: Future<Output = T>,
+{
+    type Item = Poll<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        unsafe {
+            // # Safety
+            // We never move the inner value until it is done. We only get a reference to it.
+            let inner = &mut self.get_unchecked_mut().0;
+            let fut = match inner.as_mut() {
+                // inner is gone, so we can signal that the stream is closed.
+                None => return Poll::Ready(None),
+                Some(inner) => inner,
+            };
+            let fut = Pin::new_unchecked(fut);
+            Poll::Ready(Some(fut.poll(cx).map(|t| {
+                // # Safety
+                // The inner option value is done, so we need to drop it. We do it without moving it
+                // by using drop in place. We then write over the value without trying to drop it first
+                // This should uphold all the safety requirements of `Pin`
+                std::ptr::drop_in_place(inner);
+                std::ptr::write(inner, None);
+                t
+            })))
+        }
+    }
+}
+
+/// Creates a future that is immediately ready with an Option of a value.
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::future;
+///
+/// let r = future::poll_immediate(async { 1_u32 });
+/// assert_eq!(r.await, Some(1));
+///
+/// let p = future::poll_immediate(future::pending::<i32>());
+/// assert_eq!(p.await, None);
+/// # });
+/// ```
+pub fn poll_immediate<F: Future>(f: F) -> PollImmediate<F> {
+    assert_future::<Option<F::Output>, PollImmediate<F>>(PollImmediate(Some(f)))
+}
+
+/// Future for the [`poll_immediate_reuse`](poll_immediate_reuse()) function.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct PollImmediateReuse<T>(Option<T>);
+
+impl<T, F> Future for PollImmediateReuse<F>
+where
+    F: Future<Output = T> + Unpin,
+{
+    type Output = Result<T, F>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<T, F>> {
+        let mut inner = self.get_mut().0.take().expect("PollOnceReuse polled after completion");
+        match inner.poll_unpin(cx) {
+            Poll::Ready(t) => Poll::Ready(Ok(t)),
+            Poll::Pending => Poll::Ready(Err(inner)),
+        }
+    }
+}
+
+impl<T: Future + Unpin> FusedFuture for PollImmediateReuse<T> {
+    fn is_terminated(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+/// Creates a stream that can be polled repeatedly until the future is done
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::task::Poll;
+/// use futures::{StreamExt, future};
+/// use future::FusedFuture;
+///
+/// let mut r = future::poll_immediate_reuse(future::ready(1_u32));
+/// assert_eq!(r.next().await, Some(Poll::Ready(1)));
+///
+/// let mut p = future::poll_immediate_reuse(Box::pin(async {futures::pending!(); 42_u8}));
+/// assert_eq!(p.next().await, Some(Poll::Pending));
+/// assert!(!p.is_terminated());
+/// assert_eq!(p.next().await, Some(Poll::Ready(42)));
+/// assert!(p.is_terminated());
+/// assert_eq!(p.next().await, None);
+/// # });
+/// ```
+impl<T, F> Stream for PollImmediateReuse<F>
+where
+    F: Future<Output = T> + Unpin,
+{
+    type Item = Poll<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let inner = &mut self.get_mut().0;
+        let fut = match inner.as_mut() {
+            // inner is gone, so we can signal that the stream is closed.
+            None => return Poll::Ready(None),
+            Some(inner) => inner,
+        };
+        let fut = Pin::new(fut);
+        Poll::Ready(Some(fut.poll(cx).map(|t| {
+            *inner = None;
+            t
+        })))
+    }
+}
+
+/// Creates a future that is immediately ready with a Result of a value or the future.
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::future;
+///
+/// let r = future::poll_immediate_reuse(future::ready(1_i32));
+/// assert_eq!(r.await.unwrap(), 1);
+///
+/// // futures::pending!() returns pending once and then evaluates to `()`
+/// let p = future::poll_immediate_reuse(Box::pin(async {
+///     futures::pending!();
+///     42_u8
+/// }));
+/// match p.await {
+///     Ok(_) => unreachable!(),
+///     Err(e) => {
+///         assert_eq!(e.await, 42);
+///     }
+/// }
+/// # });
+/// ```
+pub fn poll_immediate_reuse<F: Future + Unpin>(f: F) -> PollImmediateReuse<F> {
+    assert_future::<Result<F::Output, _>, PollImmediateReuse<F>>(PollImmediateReuse(Some(f)))
+}

--- a/futures-util/src/future/poll_immediate.rs
+++ b/futures-util/src/future/poll_immediate.rs
@@ -91,10 +91,10 @@ where
 ///
 /// # Caution
 ///
-/// Some futures expect to run until completion. If the future passed to this function isn't some sort of `&mut Future` then it will
-/// be dropped and can cause performance problems when creating and dropping futures continuously. In some cases this is fine like
-/// when asking for the [next()](crate::stream::StreamExt::next()) value of a stream and dropping the [Next](crate::stream::Next) future
-/// doesn't change any state in the stream.
+/// When consuming the future by this function, note the following:
+///
+/// - This function does not guarantee that the future will run to completion, so it is generally incompatible with passing the non-cancellation-safe future by value.
+/// - Even if the future is cancellation-safe, creating and dropping new futures frequently may lead to performance problems.
 ///
 /// # Examples
 ///

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -89,6 +89,9 @@ pub use self::pending::{pending, Pending};
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 
+mod poll_immediate;
+pub use self::poll_immediate::{poll_immediate, PollImmediate};
+
 mod select;
 pub use self::select::{select, Select};
 

--- a/futures-util/src/stream/poll_immediate.rs
+++ b/futures-util/src/stream/poll_immediate.rs
@@ -1,0 +1,80 @@
+use futures_core::task::{Context, Poll};
+use futures_core::Stream;
+use std::pin::Pin;
+
+/// Stream for the [`poll_immediate`](poll_immediate()) function.
+#[derive(Debug, Clone)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct PollImmediate<S>(Option<S>);
+
+impl<T, S> Stream for PollImmediate<S>
+where
+  S: Stream<Item = T>,
+{
+    type Item = Poll<T>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        unsafe {
+            // # Safety
+            // We never move the inner value until it is done. We only get a reference to it.
+            let inner = &mut self.get_unchecked_mut().0;
+            let fut = match inner.as_mut() {
+                // inner is gone, so we can continue to signal that the stream is closed.
+                None => return Poll::Ready(None),
+                Some(inner) => inner,
+            };
+            let stream = Pin::new_unchecked(fut);
+            match stream.poll_next(cx) {
+                Poll::Ready(Some(t)) => Poll::Ready(Some(Poll::Ready(t))),
+                Poll::Ready(None) => {
+                    // # Safety
+                    // The inner stream is done, so we need to drop it. We do it without moving it
+                    // by using drop in place. We then write over the value without trying to drop it first
+                    // This should uphold all the safety requirements of `Pin`
+                    std::ptr::drop_in_place(inner);
+                    std::ptr::write(inner, None);
+                    Poll::Ready(None)
+                }
+                Poll::Pending => Poll::Ready(Some(Poll::Pending)),
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.as_ref().map_or((0, Some(0)), Stream::size_hint)
+    }
+}
+
+impl<S: Stream> super::FusedStream for PollImmediate<S> {
+    fn is_terminated(&self) -> bool {
+        self.0.is_none()
+    }
+}
+
+/// Creates a new stream that never blocks when awaiting it. This is useful
+/// when immediacy is more important than waiting for the next item to be ready
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::stream::{self, StreamExt};
+/// use futures::task::Poll;
+///
+/// let mut r = stream::poll_immediate(Box::pin(stream::iter(1_u32..3)));
+/// assert_eq!(r.next().await, Some(Poll::Ready(1)));
+/// assert_eq!(r.next().await, Some(Poll::Ready(2)));
+/// assert_eq!(r.next().await, None);
+///
+/// let mut p = stream::poll_immediate(Box::pin(stream::once(async {
+///     futures::pending!();
+///     42_u8
+/// })));
+/// assert_eq!(p.next().await, Some(Poll::Pending));
+/// assert_eq!(p.next().await, Some(Poll::Ready(42)));
+/// assert_eq!(p.next().await, None);
+/// # });
+/// ```
+pub fn poll_immediate<S: Stream>(s: S) -> PollImmediate<S> {
+    super::assert_stream::<Poll<S::Item>, PollImmediate<S>>(PollImmediate(Some(s)))
+}

--- a/futures-util/src/stream/poll_immediate.rs
+++ b/futures-util/src/stream/poll_immediate.rs
@@ -1,53 +1,50 @@
+use core::pin::Pin;
 use futures_core::task::{Context, Poll};
 use futures_core::Stream;
-use std::pin::Pin;
+use pin_project_lite::pin_project;
 
-/// Stream for the [`poll_immediate`](poll_immediate()) function.
-#[derive(Debug, Clone)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct PollImmediate<S>(Option<S>);
+pin_project! {
+    /// Stream for the [`poll_immediate`](poll_immediate()) function.
+    #[derive(Debug, Clone)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct PollImmediate<S> {
+        #[pin]
+        stream: Option<S>
+    }
+}
 
 impl<T, S> Stream for PollImmediate<S>
 where
-  S: Stream<Item = T>,
+    S: Stream<Item = T>,
 {
     type Item = Poll<T>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        unsafe {
-            // # Safety
-            // We never move the inner value until it is done. We only get a reference to it.
-            let inner = &mut self.get_unchecked_mut().0;
-            let fut = match inner.as_mut() {
-                // inner is gone, so we can continue to signal that the stream is closed.
-                None => return Poll::Ready(None),
-                Some(inner) => inner,
-            };
-            let stream = Pin::new_unchecked(fut);
-            match stream.poll_next(cx) {
-                Poll::Ready(Some(t)) => Poll::Ready(Some(Poll::Ready(t))),
-                Poll::Ready(None) => {
-                    // # Safety
-                    // The inner stream is done, so we need to drop it. We do it without moving it
-                    // by using drop in place. We then write over the value without trying to drop it first
-                    // This should uphold all the safety requirements of `Pin`
-                    std::ptr::drop_in_place(inner);
-                    std::ptr::write(inner, None);
-                    Poll::Ready(None)
-                }
-                Poll::Pending => Poll::Ready(Some(Poll::Pending)),
+        let mut this = self.project();
+        let stream = match this.stream.as_mut().as_pin_mut() {
+            // inner is gone, so we can continue to signal that the stream is closed.
+            None => return Poll::Ready(None),
+            Some(inner) => inner,
+        };
+
+        match stream.poll_next(cx) {
+            Poll::Ready(Some(t)) => Poll::Ready(Some(Poll::Ready(t))),
+            Poll::Ready(None) => {
+                this.stream.set(None);
+                Poll::Ready(None)
             }
+            Poll::Pending => Poll::Ready(Some(Poll::Pending)),
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.0.as_ref().map_or((0, Some(0)), Stream::size_hint)
+        self.stream.as_ref().map_or((0, Some(0)), Stream::size_hint)
     }
 }
 
 impl<S: Stream> super::FusedStream for PollImmediate<S> {
     fn is_terminated(&self) -> bool {
-        self.0.is_none()
+        self.stream.is_none()
     }
 }
 
@@ -76,5 +73,5 @@ impl<S: Stream> super::FusedStream for PollImmediate<S> {
 /// # });
 /// ```
 pub fn poll_immediate<S: Stream>(s: S) -> PollImmediate<S> {
-    super::assert_stream::<Poll<S::Item>, PollImmediate<S>>(PollImmediate(Some(s)))
+    super::assert_stream::<Poll<S::Item>, PollImmediate<S>>(PollImmediate { stream: Some(s) })
 }

--- a/futures-util/src/stream/poll_immediate.rs
+++ b/futures-util/src/stream/poll_immediate.rs
@@ -4,7 +4,9 @@ use futures_core::Stream;
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Stream for the [`poll_immediate`](poll_immediate()) function.
+    /// Stream for the [poll_immediate](poll_immediate()) function.
+    ///
+    /// It will never return [Poll::Pending](core::task::Poll::Pending)
     #[derive(Debug, Clone)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct PollImmediate<S> {
@@ -48,8 +50,9 @@ impl<S: Stream> super::FusedStream for PollImmediate<S> {
     }
 }
 
-/// Creates a new stream that never blocks when awaiting it. This is useful
-/// when immediacy is more important than waiting for the next item to be ready
+/// Creates a new stream that always immediately returns [Poll::Ready](core::task::Poll::Ready) when awaiting it.
+///
+/// This is useful when immediacy is more important than waiting for the next item to be ready.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
I can open an issue as well if needed, but since I've already done the work I thought it would be just as easy to actually talk about the additions proposed in the pull request.

The reasons for these new functions are because I'm using a tokio::sync::mpsc::Receiver and sometimes I need to just wait until a value is ready and sometimes I need to check if one is ready and if not do some other processing. This can be accomplished by doing
```rust
    futures_util::select_biased! {
        msg = receiver.recv().await => {...}
        _ = futures_util::future::ready(()) => {...}
    }
```
but it seems like it would be nice to have a dedicated Future for this that works better with IDE's. 

I could probably use the `now_or_never()` function from `FuturesExt`, but that consumes the future and these new functions and futures allow for polling repeatedly (due to the Stream implementation) to see if they are done without blocking and they can also get the future back if it is `Unpin` which is useful if the futures are expensive to construct or if you want to just wait for them to be done at a later time.

Closes #2257