### PR TITLE
StreamExt::All / StreamExt::Any

### DIFF
--- a/futures-util/src/stream/stream/all.rs
+++ b/futures-util/src/stream/stream/all.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Future for the [`fold`](super::StreamExt::fold) method.
+    /// Future for the [`all`](super::StreamExt::all) method.
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct All<St, Fut, F> {
         #[pin]

--- a/futures-util/src/stream/stream/all.rs
+++ b/futures-util/src/stream/stream/all.rs
@@ -20,7 +20,7 @@ pin_project! {
 }
 
 impl<St, Fut, F> fmt::Debug for All<St, Fut, F>
-where 
+where
     St: fmt::Debug,
     Fut: fmt::Debug,
 {
@@ -69,7 +69,9 @@ where
             if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 // we're currently processing a future to produce a new accum value
                 let acc = this.accum.unwrap() && ready!(fut.poll(cx));
-                if acc == false { break false } // early exit
+                if !acc {
+                    break false;
+                } // early exit
                 *this.accum = Some(acc);
                 this.future.set(None);
             } else if this.accum.is_some() {
@@ -78,7 +80,7 @@ where
                     Some(item) => {
                         this.future.set(Some((this.f)(item)));
                     }
-                    None => { // we finish
+                    None => {
                         break this.accum.take().unwrap();
                     }
                 }

--- a/futures-util/src/stream/stream/all.rs
+++ b/futures-util/src/stream/stream/all.rs
@@ -1,0 +1,90 @@
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::ready;
+use futures_core::stream::Stream;
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`fold`](super::StreamExt::fold) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct All<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<bool>,
+        #[pin]
+        future: Option<Fut>,
+    }
+}
+
+impl<St, Fut, F> fmt::Debug for All<St, Fut, F>
+where 
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("All")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
+
+impl<St, Fut, F> All<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f, accum: Some(true), future: None }
+    }
+}
+
+impl<St, Fut, F> FusedFuture for All<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    fn is_terminated(&self) -> bool {
+        self.accum.is_none() && self.future.is_none()
+    }
+}
+
+impl<St, Fut, F> Future for All<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    type Output = bool;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<bool> {
+        let mut this = self.project();
+        Poll::Ready(loop {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
+                // we're currently processing a future to produce a new accum value
+                let acc = this.accum.unwrap() && ready!(fut.poll(cx));
+                if acc == false { break false } // early exit
+                *this.accum = Some(acc);
+                this.future.set(None);
+            } else if this.accum.is_some() {
+                // we're waiting on a new item from the stream
+                match ready!(this.stream.as_mut().poll_next(cx)) {
+                    Some(item) => {
+                        this.future.set(Some((this.f)(item)));
+                    }
+                    None => { // we finish
+                        break this.accum.take().unwrap();
+                    }
+                }
+            } else {
+                panic!("All polled after completion")
+            }
+        })
+    }
+}

--- a/futures-util/src/stream/stream/any.rs
+++ b/futures-util/src/stream/stream/any.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Future for the [`fold`](super::StreamExt::fold) method.
+    /// Future for the [`any`](super::StreamExt::any) method.
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Any<St, Fut, F> {
         #[pin]

--- a/futures-util/src/stream/stream/any.rs
+++ b/futures-util/src/stream/stream/any.rs
@@ -1,0 +1,90 @@
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::ready;
+use futures_core::stream::Stream;
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`fold`](super::StreamExt::fold) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Any<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<bool>,
+        #[pin]
+        future: Option<Fut>,
+    }
+}
+
+impl<St, Fut, F> fmt::Debug for Any<St, Fut, F>
+where 
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Any")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
+
+impl<St, Fut, F> Any<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f, accum: Some(false), future: None }
+    }
+}
+
+impl<St, Fut, F> FusedFuture for Any<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    fn is_terminated(&self) -> bool {
+        self.accum.is_none() && self.future.is_none()
+    }
+}
+
+impl<St, Fut, F> Future for Any<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: Future<Output = bool>,
+{
+    type Output = bool;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<bool> {
+        let mut this = self.project();
+        Poll::Ready(loop {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
+                // we're currently processing a future to produce a new accum value
+                let acc = this.accum.unwrap() && ready!(fut.poll(cx));
+                if acc == true { break true } // early exit
+                *this.accum = Some(acc);
+                this.future.set(None);
+            } else if this.accum.is_some() {
+                // we're waiting on a new item from the stream
+                match ready!(this.stream.as_mut().poll_next(cx)) {
+                    Some(item) => { // pulled
+                        this.future.set(Some((this.f)(item)));
+                    }
+                    None => { // we finish
+                        break this.accum.take().unwrap();
+                    }
+                }
+            } else {
+                panic!("Any polled after completion")
+            }
+        })
+    }
+}

--- a/futures-util/src/stream/stream/any.rs
+++ b/futures-util/src/stream/stream/any.rs
@@ -20,7 +20,7 @@ pin_project! {
 }
 
 impl<St, Fut, F> fmt::Debug for Any<St, Fut, F>
-where 
+where
     St: fmt::Debug,
     Fut: fmt::Debug,
 {
@@ -69,16 +69,18 @@ where
             if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 // we're currently processing a future to produce a new accum value
                 let acc = this.accum.unwrap() || ready!(fut.poll(cx));
-                if acc == true { break true } // early exit
+                if acc {
+                    break true;
+                } // early exit
                 *this.accum = Some(acc);
                 this.future.set(None);
             } else if this.accum.is_some() {
                 // we're waiting on a new item from the stream
                 match ready!(this.stream.as_mut().poll_next(cx)) {
-                    Some(item) => { // pulled
+                    Some(item) => {
                         this.future.set(Some((this.f)(item)));
                     }
-                    None => { // we finish
+                    None => {
                         break this.accum.take().unwrap();
                     }
                 }

--- a/futures-util/src/stream/stream/any.rs
+++ b/futures-util/src/stream/stream/any.rs
@@ -68,7 +68,7 @@ where
         Poll::Ready(loop {
             if let Some(fut) = this.future.as_mut().as_pin_mut() {
                 // we're currently processing a future to produce a new accum value
-                let acc = this.accum.unwrap() && ready!(fut.poll(cx));
+                let acc = this.accum.unwrap() || ready!(fut.poll(cx));
                 if acc == true { break true } // early exit
                 *this.accum = Some(acc);
                 this.future.set(None);

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -70,6 +70,14 @@ mod fold;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::fold::Fold;
 
+mod any;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::any::Any;
+
+mod all;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::all::All;
+
 #[cfg(feature = "sink")]
 mod forward;
 
@@ -641,6 +649,50 @@ pub trait StreamExt: Stream {
         Self: Sized,
     {
         assert_future::<T, _>(Fold::new(self, f, init))
+    }
+
+    /// Execute predicate over asynchronous stream, and return `true` if any element in stream satisfied a predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::stream::{self, StreamExt};
+    ///
+    /// let number_stream = stream::iter(0..10);
+    /// let contain_three = number_stream.any(|i| async move { i == 3 });
+    /// assert_eq!(contain_three.await, true);
+    /// # });
+    /// ```
+    fn any<Fut, F>(self, f: F) -> Any<Self, Fut, F>
+    where
+        F: FnMut(Self::Item) -> Fut,
+        Fut: Future<Output = bool>,
+        Self: Sized,
+    {
+        assert_future::<bool, _>(Any::new(self, f))
+    }
+
+    /// Execute predicate over asynchronous stream, and return `true` if all element in stream satisfied a predicate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::stream::{self, StreamExt};
+    ///
+    /// let number_stream = stream::iter(0..10);
+    /// let less_then_twenty = number_stream.all(|i| async move { i < 20 });
+    /// assert_eq!(less_then_twenty.await, true);
+    /// # });
+    /// ```
+    fn all<Fut, F>(self, f: F) -> All<Self, Fut, F>
+    where
+        F: FnMut(Self::Item) -> Fut,
+        Fut: Future<Output = bool>,
+        Self: Sized,
+    {
+        assert_future::<bool, _>(All::new(self, f))
     }
 
     /// Flattens a stream of streams into just one continuous stream.


### PR DESCRIPTION
Primitive implementation of All and Any predicates over the stream. Most of the code is reused from Fold implementation.
I was thinking about reusing Fold inside All and Any, but we lose the possibility of an early exit.