### PR TITLE
Implement `Default` trait for `OptionFuture`

### DIFF
--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -31,6 +31,12 @@ pin_project! {
     }
 }
 
+impl<F> Default for OptionFuture<F> {
+    fn default() -> Self {
+        Self { inner: None }
+    }
+}
+
 impl<F: Future> Future for OptionFuture<F> {
     type Output = Option<F::Output>;
 


### PR DESCRIPTION
This provides an easy way to create empty `OptionFuture`s.