### PR TITLE
Correcting overly restrictive lifetimes in vectored IO

### DIFF
--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -217,7 +217,10 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// The returned future will resolve to the number of bytes read once the read
     /// operation is completed.
-    fn read_vectored<'a>(&'a mut self, bufs: &'a mut [IoSliceMut<'a>]) -> ReadVectored<'a, Self>
+    fn read_vectored<'a, 'b>(
+        &'a mut self,
+        bufs: &'a mut [IoSliceMut<'b>],
+    ) -> ReadVectored<'a, 'b, Self>
     where
         Self: Unpin,
     {
@@ -456,7 +459,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     ///
     /// The returned future will resolve to the number of bytes written once the write
     /// operation is completed.
-    fn write_vectored<'a>(&'a mut self, bufs: &'a [IoSlice<'a>]) -> WriteVectored<'a, Self>
+    fn write_vectored<'a, 'b>(&'a mut self, bufs: &'a [IoSlice<'b>]) -> WriteVectored<'a, 'b, Self>
     where
         Self: Unpin,
     {
@@ -535,10 +538,10 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
     #[cfg(feature = "write-all-vectored")]
-    fn write_all_vectored<'a>(
+    fn write_all_vectored<'a, 'b>(
         &'a mut self,
-        bufs: &'a mut [IoSlice<'a>],
-    ) -> WriteAllVectored<'a, Self>
+        bufs: &'a mut [IoSlice<'b>],
+    ) -> WriteAllVectored<'a, 'b, Self>
     where
         Self: Unpin,
     {

--- a/futures-util/src/io/read_vectored.rs
+++ b/futures-util/src/io/read_vectored.rs
@@ -7,20 +7,20 @@ use std::pin::Pin;
 /// Future for the [`read_vectored`](super::AsyncReadExt::read_vectored) method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ReadVectored<'a, R: ?Sized> {
+pub struct ReadVectored<'a, 'b, R: ?Sized> {
     reader: &'a mut R,
-    bufs: &'a mut [IoSliceMut<'a>],
+    bufs: &'a mut [IoSliceMut<'b>],
 }
 
-impl<R: ?Sized + Unpin> Unpin for ReadVectored<'_, R> {}
+impl<R: ?Sized + Unpin> Unpin for ReadVectored<'_, '_, R> {}
 
-impl<'a, R: AsyncRead + ?Sized + Unpin> ReadVectored<'a, R> {
-    pub(super) fn new(reader: &'a mut R, bufs: &'a mut [IoSliceMut<'a>]) -> Self {
+impl<'a, 'b, R: AsyncRead + ?Sized + Unpin> ReadVectored<'a, 'b, R> {
+    pub(super) fn new(reader: &'a mut R, bufs: &'a mut [IoSliceMut<'b>]) -> Self {
         Self { reader, bufs }
     }
 }
 
-impl<R: AsyncRead + ?Sized + Unpin> Future for ReadVectored<'_, R> {
+impl<R: AsyncRead + ?Sized + Unpin> Future for ReadVectored<'_, '_, R> {
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/futures-util/src/io/write_all_vectored.rs
+++ b/futures-util/src/io/write_all_vectored.rs
@@ -10,21 +10,21 @@ use std::pin::Pin;
 /// [`write_all_vectored`](super::AsyncWriteExt::write_all_vectored) method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct WriteAllVectored<'a, W: ?Sized + Unpin> {
+pub struct WriteAllVectored<'a, 'b, W: ?Sized + Unpin> {
     writer: &'a mut W,
-    bufs: &'a mut [IoSlice<'a>],
+    bufs: &'a mut [IoSlice<'b>],
 }
 
-impl<W: ?Sized + Unpin> Unpin for WriteAllVectored<'_, W> {}
+impl<W: ?Sized + Unpin> Unpin for WriteAllVectored<'_, '_, W> {}
 
-impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteAllVectored<'a, W> {
-    pub(super) fn new(writer: &'a mut W, mut bufs: &'a mut [IoSlice<'a>]) -> Self {
+impl<'a, 'b, W: AsyncWrite + ?Sized + Unpin> WriteAllVectored<'a, 'b, W> {
+    pub(super) fn new(writer: &'a mut W, mut bufs: &'a mut [IoSlice<'b>]) -> Self {
         IoSlice::advance_slices(&mut bufs, 0);
         Self { writer, bufs }
     }
 }
 
-impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteAllVectored<'_, W> {
+impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteAllVectored<'_, '_, W> {
     type Output = io::Result<()>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/futures-util/src/io/write_vectored.rs
+++ b/futures-util/src/io/write_vectored.rs
@@ -7,20 +7,20 @@ use std::pin::Pin;
 /// Future for the [`write_vectored`](super::AsyncWriteExt::write_vectored) method.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct WriteVectored<'a, W: ?Sized> {
+pub struct WriteVectored<'a, 'b, W: ?Sized> {
     writer: &'a mut W,
-    bufs: &'a [IoSlice<'a>],
+    bufs: &'a [IoSlice<'b>],
 }
 
-impl<W: ?Sized + Unpin> Unpin for WriteVectored<'_, W> {}
+impl<W: ?Sized + Unpin> Unpin for WriteVectored<'_, '_, W> {}
 
-impl<'a, W: AsyncWrite + ?Sized + Unpin> WriteVectored<'a, W> {
-    pub(super) fn new(writer: &'a mut W, bufs: &'a [IoSlice<'a>]) -> Self {
+impl<'a, 'b, W: AsyncWrite + ?Sized + Unpin> WriteVectored<'a, 'b, W> {
+    pub(super) fn new(writer: &'a mut W, bufs: &'a [IoSlice<'b>]) -> Self {
         Self { writer, bufs }
     }
 }
 
-impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteVectored<'_, W> {
+impl<W: AsyncWrite + ?Sized + Unpin> Future for WriteVectored<'_, '_, W> {
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -786,12 +786,12 @@ pub mod io {
     assert_impl!(ReadUntil<'_, ()>: Unpin);
     assert_not_impl!(ReadUntil<'_, PhantomPinned>: Unpin);
 
-    assert_impl!(ReadVectored<'_, ()>: Send);
-    assert_not_impl!(ReadVectored<'_, *const ()>: Send);
-    assert_impl!(ReadVectored<'_, ()>: Sync);
-    assert_not_impl!(ReadVectored<'_, *const ()>: Sync);
-    assert_impl!(ReadVectored<'_, ()>: Unpin);
-    assert_not_impl!(ReadVectored<'_, PhantomPinned>: Unpin);
+    assert_impl!(ReadVectored<'_, '_, ()>: Send);
+    assert_not_impl!(ReadVectored<'_, '_, *const ()>: Send);
+    assert_impl!(ReadVectored<'_, '_, ()>: Sync);
+    assert_not_impl!(ReadVectored<'_, '_, *const ()>: Sync);
+    assert_impl!(ReadVectored<'_, '_, ()>: Unpin);
+    assert_not_impl!(ReadVectored<'_, '_, PhantomPinned>: Unpin);
 
     assert_impl!(Repeat: Send);
     assert_impl!(Repeat: Sync);
@@ -843,15 +843,15 @@ pub mod io {
     assert_not_impl!(WriteAll<'_, PhantomPinned>: Unpin);
 
     #[cfg(feature = "write-all-vectored")]
-    assert_impl!(WriteAllVectored<'_, ()>: Send);
+    assert_impl!(WriteAllVectored<'_, '_, ()>: Send);
     #[cfg(feature = "write-all-vectored")]
-    assert_not_impl!(WriteAllVectored<'_, *const ()>: Send);
+    assert_not_impl!(WriteAllVectored<'_, '_, *const ()>: Send);
     #[cfg(feature = "write-all-vectored")]
-    assert_impl!(WriteAllVectored<'_, ()>: Sync);
+    assert_impl!(WriteAllVectored<'_, '_, ()>: Sync);
     #[cfg(feature = "write-all-vectored")]
-    assert_not_impl!(WriteAllVectored<'_, *const ()>: Sync);
+    assert_not_impl!(WriteAllVectored<'_, '_, *const ()>: Sync);
     #[cfg(feature = "write-all-vectored")]
-    assert_impl!(WriteAllVectored<'_, ()>: Unpin);
+    assert_impl!(WriteAllVectored<'_, '_, ()>: Unpin);
     // WriteAllVectored requires `W: Unpin`
     // #[cfg(feature = "write-all-vectored")]
     // assert_not_impl!(WriteAllVectored<'_, PhantomPinned>: Unpin);
@@ -862,12 +862,12 @@ pub mod io {
     assert_not_impl!(WriteHalf<*const ()>: Sync);
     assert_impl!(WriteHalf<PhantomPinned>: Unpin);
 
-    assert_impl!(WriteVectored<'_, ()>: Send);
-    assert_not_impl!(WriteVectored<'_, *const ()>: Send);
-    assert_impl!(WriteVectored<'_, ()>: Sync);
-    assert_not_impl!(WriteVectored<'_, *const ()>: Sync);
-    assert_impl!(WriteVectored<'_, ()>: Unpin);
-    assert_not_impl!(WriteVectored<'_, PhantomPinned>: Unpin);
+    assert_impl!(WriteVectored<'_, '_, ()>: Send);
+    assert_not_impl!(WriteVectored<'_, '_, *const ()>: Send);
+    assert_impl!(WriteVectored<'_, '_, ()>: Sync);
+    assert_not_impl!(WriteVectored<'_, '_, *const ()>: Sync);
+    assert_impl!(WriteVectored<'_, '_, ()>: Unpin);
+    assert_not_impl!(WriteVectored<'_, '_, PhantomPinned>: Unpin);
 }
 
 /// Assert Send/Sync/Unpin for all public types in `futures::lock`.


### PR DESCRIPTION
The current input lifetimes for `write_vectored` and `write_all_vectored` in `AsyncWriteExt` and `read_vectored` in `AsyncReadExt` are unnecessarily restrictive and disallow otherwise reasonable uses. This change fixes #2483 by relaxing that restriction, making the lifetime of the incoming references independent of the inner lifetime that the `IoSlice`s refer to. (They could be relaxed further, but I can't see any practical difference it would make so I have tried to be consistent with the surrounding code)

Please let me know if you'd like any other changes made for this issue, or any other comments you have.

(Edit: Apologies for any log/notification noise the repeated CI runs generated, some unrelated tests wouldn't run cleanly on my local machine)