### PR TITLE
futures-util: add `StreamExt::count` method

### DIFF
--- a/futures-util/src/stream/stream/count.rs
+++ b/futures-util/src/stream/stream/count.rs
@@ -1,0 +1,53 @@
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::ready;
+use futures_core::stream::{FusedStream, Stream};
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`count`](super::StreamExt::count) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Count<St> {
+        #[pin]
+        stream: St,
+        count: usize
+    }
+}
+
+impl<St> fmt::Debug for Count<St>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Count").field("stream", &self.stream).field("count", &self.count).finish()
+    }
+}
+
+impl<St: Stream> Count<St> {
+    pub(super) fn new(stream: St) -> Self {
+        Self { stream, count: 0 }
+    }
+}
+
+impl<St: FusedStream> FusedFuture for Count<St> {
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+impl<St: Stream> Future for Count<St> {
+    type Output = usize;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        Poll::Ready(loop {
+            match ready!(this.stream.as_mut().poll_next(cx)) {
+                Some(_) => *this.count += 1,
+                None => break *this.count,
+            }
+        })
+    }
+}

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -38,6 +38,10 @@ mod concat;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::concat::Concat;
 
+mod count;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::count::Count;
+
 mod cycle;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::cycle::Cycle;
@@ -588,6 +592,38 @@ pub trait StreamExt: Stream {
         Self::Item: Extend<<<Self as Stream>::Item as IntoIterator>::Item> + IntoIterator + Default,
     {
         assert_future::<Self::Item, _>(Concat::new(self))
+    }
+
+    /// Drives the stream to completion, counting the number of items.
+    ///
+    /// # Overflow Behavior
+    ///
+    /// The method does no guarding against overflows, so counting elements of a
+    /// stream with more than [`usize::MAX`] elements either produces the wrong
+    /// result or panics. If debug assertions are enabled, a panic is guaranteed.
+    ///
+    /// # Panics
+    ///
+    /// This function might panic if the iterator has more than [`usize::MAX`]
+    /// elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::stream::{self, StreamExt};
+    ///
+    /// let stream = stream::iter(1..=10);
+    /// let count = stream.count().await;
+    ///
+    /// assert_eq!(count, 10);
+    /// # });
+    /// ```
+    fn count(self) -> Count<Self>
+    where
+        Self: Sized,
+    {
+        assert_future::<usize, _>(Count::new(self))
     }
 
     /// Repeats a stream endlessly.


### PR DESCRIPTION
Works the same way as its `Iterator::count` counterpart