### PR TITLE
Fix Unusable Sink Implementation on Scan

### DIFF
--- a/futures-util/src/stream/stream/scan.rs
+++ b/futures-util/src/stream/stream/scan.rs
@@ -115,11 +115,11 @@ where
 
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
-impl<S, Fut, F, Item> Sink<Item> for Scan<S, S, Fut, F>
+impl<St, S, Fut, F, Item> Sink<Item> for Scan<St, S, Fut, F>
 where
-    S: Stream + Sink<Item>,
+    St: Stream + Sink<Item>,
 {
-    type Error = S::Error;
+    type Error = St::Error;
 
     delegate_sink!(stream, Item);
 }


### PR DESCRIPTION
The `Sink` implementation for `futures::stream::Scan` has generic bounds on it that require the stream and state types on `Scan` to be the same type, which naturally makes it not useful to use the implementation. This change adds an extra generic to the `Sink` implementation to separate out the type of the state argument in `Scan`. 