### PR TITLE
Make `futures::task::noop_waker_ref` available without `std`.

### DIFF
--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -16,7 +16,6 @@ pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj};
 
 pub use futures_task::noop_waker;
-#[cfg(feature = "std")]
 pub use futures_task::noop_waker_ref;
 
 #[cfg(not(futures_no_atomic_cas))]


### PR DESCRIPTION
#2332 removed the `std` dependency and some `#[cfg(feature = "std")]`, but missed the one on the reexport from `futures_util`. This PR removes that cfg attribute, so `noop_waker_ref` should be equally available from all places it is reexported. I searched for other mentions of `noop_waker_ref` in this repository and did not find any other changes needed.