### PR TITLE
Remove doc URL from Cargo.toml

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-channel/0.4.0-alpha.0"
 description = """
 Channels for asynchronous communication using futures-rs.
 """

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-core/1.0.0-alpha.0"
 description = """
 The core traits and types in for the `futures` library.
 """

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-executor/0.4.0-alpha.0"
 description = """
 Executors for asynchronous tasks based on the futures-rs library.
 """

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-io/0.3"
 description = """
 The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the futures-rs library.
 """

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.co
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-macro/0.4.0-alpha.0"
 description = """
 The futures-rs procedural macro implementations.
 """

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-sink/0.4.0-alpha.0"
 description = """
 The asynchronous `Sink` trait for the futures-rs library.
 """

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-task/0.4.0-alpha.0"
 description = """
 Tools for working with tasks.
 """

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-test/0.4.0-alpha.0"
 description = """
 Common utilities for testing components built off futures-rs.
 """

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures-util/0.4.0-alpha.0"
 description = """
 Common utilities and extension traits for the futures-rs library.
 """

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -8,7 +8,6 @@ readme = "../README.md"
 keywords = ["futures", "async", "future"]
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"
-documentation = "https://docs.rs/futures/0.4.0-alpha.0"
 description = """
 An implementation of futures and streams featuring zero allocations,
 composability, and iterator-like interfaces.


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-documentation-field

> If no URL is specified in the manifest file, crates.io will
> automatically link your crate to the corresponding docs.rs page.