### PR TITLE
Remove authors field from Cargo.toml

### DIFF
--- a/examples/functional/Cargo.toml
+++ b/examples/functional/Cargo.toml
@@ -2,7 +2,6 @@
 name = "futures-example-functional"
 edition = "2018"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 publish = false
 
 [dependencies]

--- a/examples/imperative/Cargo.toml
+++ b/examples/imperative/Cargo.toml
@@ -2,7 +2,6 @@
 name = "futures-example-imperative"
 edition = "2018"
 version = "0.1.0"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 publish = false
 
 [dependencies]

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-channel"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-core"
 version = "1.0.0-alpha.0"
 edition = "2018"
 rust-version = "1.36"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-executor"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-io"
 version = "0.3.17"
 edition = "2018"
 rust-version = "1.36"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-macro"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Taylor Cramer <cramertj@google.com>", "Taiki Endo <te316e89@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-sink"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.36"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-task"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.36"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-test"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Wim Looman <wim@nemo157.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures-util"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -3,7 +3,6 @@ name = "futures"
 version = "0.4.0-alpha.0"
 edition = "2018"
 rust-version = "1.45"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]

--- a/futures/tests/macro-reexport/Cargo.toml
+++ b/futures/tests/macro-reexport/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "macro-reexport"
 version = "0.1.0"
-authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 publish = false
 

--- a/futures/tests/macro-tests/Cargo.toml
+++ b/futures/tests/macro-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "macro-tests"
 version = "0.1.0"
-authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 publish = false
 

--- a/futures/tests/no-std/Cargo.toml
+++ b/futures/tests/no-std/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "no-std"
 version = "0.1.0"
-authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 publish = false
 


### PR DESCRIPTION
This field is soft-deprecated, cargo no longer generates this field by default, and Rust's official services no longer reference this field at all.

See [RFC3052](https://rust-lang.github.io/rfcs/3052-optional-authors-field.html) for more.