### PR TITLE
Release 0.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.18 - 2021-11-23
+
+* Fix unusable `Sink` implementation on `stream::Scan` (#2499)
+* Make `task::noop_waker_ref` available without `std` feature (#2505)
+* Add async `LineWriter` (#2477)
+* Remove dependency on `proc-macro-hack`. This raises MSRV of utility crates to 1.45. (#2520)
+
 # 0.3.17 - 2021-08-30
 
 * Use `FuturesOrdered` in `join_all` (#2412)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.17", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.17", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.17", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.17", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.17", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.18", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.17", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.17", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.17", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.17", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.17", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.17", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.17", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.18", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.18", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.18", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.18", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.18", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.18", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.18", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.1"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -35,12 +35,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.17", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.17", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.17", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.17", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.17", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.17", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.18", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.18", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.18", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.17"
+version = "0.3.18"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.17", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.17", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.17", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.17", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.17", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.17", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.17", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.18", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.18", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.18", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.18", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }


### PR DESCRIPTION
Changes:

* Fix unusable `Sink` implementation on `stream::Scan` (#2499)
* Make `task::noop_waker_ref` available without `std` feature (#2505)
* Add async `LineWriter` (#2477)
* Remove dependency on `proc-macro-hack`. This raises MSRV of utility crates to 1.45. (#2520)