### PR TITLE
Release 0.3.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
+# 0.3.19 - 2021-12-18
+
+* Remove unstable `read-initializer` feature (#2534)
+* Fix panic in `FuturesUnordered` (#2535)
+* Fix compatibility issue with `FuturesUnordered` and tokio's cooperative scheduling (#2527)
+* Add `StreamExt::count` (#2495)
+
 # 0.3.18 - 2021-11-23
+
+NOTE: This release has been yanked. See #2529 for details.
 
 * Fix unusable `Sink` implementation on `stream::Scan` (#2499)
 * Make `task::noop_waker_ref` available without `std` feature (#2505)
@@ -62,9 +71,13 @@
 
 # 0.3.10 - 2021-01-13
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Fixed type-inference in `sink::unfold` by specifying more of its types (breaking change -- see #2311)
 
 # 0.3.9 - 2021-01-08
+
+NOTE: This release has been yanked. See #2310 for details.
 
 * Significantly improved compile time when `async-await` crate feature is disabled (#2273)
 * Added `stream::repeat_with` (#2279)
@@ -77,6 +90,8 @@
 
 # 0.3.8 - 2020-11-04
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Switched proc-macros to use native `#[proc_macro]` at Rust 1.45+ (#2243)
 * Added `WeakShared` (#2169)
 * Added `TryStreamExt::try_buffered` (#2245)
@@ -86,11 +101,15 @@
 
 # 0.3.7 - 2020-10-23
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Fixed unsoundness in `MappedMutexGuard` (#2240)
 * Re-exported `TakeUntil` (#2235)
 * futures-test: Prevent double panic in `panic_waker` (#2236)
 
 # 0.3.6 - 2020-10-06
+
+NOTE: This release has been yanked. See #2310 for details.
 
 * Fixed UB due to missing 'static on `task::waker` (#2206)
 * Added `AsyncBufReadExt::fill_buf` (#2225)
@@ -105,6 +124,8 @@
 * futures-test: Implemented more traits for `AssertUnmoved` (#2208)
 
 # 0.3.5 - 2020-05-08
+
+NOTE: This release has been yanked. See #2310 for details.
 
 * Added `StreamExt::flat_map`.
 * Added `StreamExt::ready_chunks`.
@@ -124,13 +145,19 @@
 
 # 0.3.4 - 2020-02-06
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Fixed missing `Drop` for `UnboundedReceiver` (#2064)
 
 # 0.3.3 - 2020-02-04
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Fixed compatibility issue with pinned facade (#2062)
 
 # 0.3.2 - 2020-02-03
+
+NOTE: This release has been yanked. See #2310 for details.
 
 * Improved buffering performance of `SplitSink` (#1969)
 * Added `select_biased!` macro (#1976)
@@ -151,9 +178,13 @@
 
 # 0.3.1 - 2019-11-07
 
+NOTE: This release has been yanked. See #2310 for details.
+
 * Fix signature of `LocalSpawn` trait (breaking change -- see #1959)
 
 # 0.3.0 - 2019-11-05
+
+NOTE: This release has been yanked. See #2310 for details.
 
 * Stable release along with stable async/await!
 * Added async/await to default features (#1953)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.19", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.19", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.18", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.19", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.19", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.19", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.18", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.18", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.18", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.18", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.18", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.18", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.18", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.19", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.19", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.19", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.19", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.19", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.19", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.19", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.1"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -34,12 +34,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.18", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.18", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.18", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.19", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.19", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.19", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.19", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.19", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.19", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.18"
+version = "0.3.19"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.18", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.18", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.18", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.18", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.18", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.18", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.18", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.19", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.19", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.19", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.19", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.19", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.19", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.19", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }


### PR DESCRIPTION
Changes:

*  Remove unstable `read-initializer` feature (#2534)
* Fix panic in `FuturesUnordered` (#2535)
* Fix compatibility issue with `FuturesUnordered` and tokio's cooperative scheduling (#2527)
* Add `StreamExt::count` (#2495)
