### PR TITLE
Improve example for TryStreamExt::try_flatten.

### DIFF
--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -368,8 +368,7 @@ pub trait TryStreamExt: TryStream {
     /// # }
     /// fn take_stream(stream: impl Stream<Item = Result<T, E>>) { /* ... */ }
     ///
-    /// take_stream(make_
-    ().into_stream());
+    /// take_stream(make_try_stream().into_stream());
     /// ```
     fn into_stream(self) -> IntoStream<Self>
     where

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -653,17 +653,20 @@ pub trait TryStreamExt: TryStream {
     /// thread::spawn(move || {
     ///     tx2.unbounded_send(Ok(2)).unwrap();
     ///     tx2.unbounded_send(Err(3)).unwrap();
+    ///     tx2.unbounded_send(Ok(4)).unwrap();
     /// });
     /// thread::spawn(move || {
     ///     tx3.unbounded_send(Ok(rx1)).unwrap();
     ///     tx3.unbounded_send(Ok(rx2)).unwrap();
-    ///     tx3.unbounded_send(Err(4)).unwrap();
+    ///     tx3.unbounded_send(Err(5)).unwrap();
     /// });
     ///
     /// let mut stream = rx3.try_flatten();
     /// assert_eq!(stream.next().await, Some(Ok(1)));
-    /// assert_eq!(stream.next().await, Some(Ok(2)));
     /// assert_eq!(stream.next().await, Some(Err(3)));
+    /// assert_eq!(stream.next().await, Some(Ok(4)));
+    /// assert_eq!(stream.next().await, Some(Err(5)));
+    /// assert_eq!(stream.next().await, None);
     /// # });
     /// ```
     fn try_flatten(self) -> TryFlatten<Self>

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -368,7 +368,8 @@ pub trait TryStreamExt: TryStream {
     /// # }
     /// fn take_stream(stream: impl Stream<Item = Result<T, E>>) { /* ... */ }
     ///
-    /// take_stream(make_try_stream().into_stream());
+    /// take_stream(make_
+    ().into_stream());
     /// ```
     fn into_stream(self) -> IntoStream<Self>
     where
@@ -663,6 +664,7 @@ pub trait TryStreamExt: TryStream {
     ///
     /// let mut stream = rx3.try_flatten();
     /// assert_eq!(stream.next().await, Some(Ok(1)));
+    /// assert_eq!(stream.next().await, Some(Ok(2)));
     /// assert_eq!(stream.next().await, Some(Err(3)));
     /// assert_eq!(stream.next().await, Some(Ok(4)));
     /// assert_eq!(stream.next().await, Some(Err(5)));


### PR DESCRIPTION
The previous example was confusing because it didn't show what happened to `Err(4)`. I also added some more examples to show that entries after `Err(_)` are preserved.