### PR TITLE
Add `StreamExt::wait_until` combinator

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -21,7 +21,7 @@ pub use self::stream::{
     Chain, Collect, Concat, Cycle, Enumerate, Filter, FilterMap, FlatMap, Flatten, Fold, ForEach,
     Fuse, Inspect, Map, Next, NextIf, NextIfEq, Peek, PeekMut, Peekable, Scan, SelectNextSome,
     Skip, SkipWhile, StreamExt, StreamFuture, Take, TakeUntil, TakeWhile, Then, TryFold,
-    TryForEach, Unzip, Zip,
+    TryForEach, Unzip, WaitUntil, Zip,
 };
 
 #[cfg(feature = "std")]

--- a/futures-util/src/stream/stream/wait_until.rs
+++ b/futures-util/src/stream/stream/wait_until.rs
@@ -1,0 +1,99 @@
+use core::pin::Pin;
+use futures_core::future::Future;
+use futures_core::ready;
+use futures_core::stream::{FusedStream, Stream};
+use futures_core::task::{Context, Poll};
+#[cfg(feature = "sink")]
+use futures_sink::Sink;
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Stream for the [`wait_until`](super::StreamExt::wait_until) method.
+    #[must_use = "streams do nothing unless polled"]
+    #[derive(Debug)]
+    pub struct WaitUntil<St: Stream, Fut: Future<Output = bool>>
+    {
+        is_fused: bool,
+        #[pin]
+        future: Option<Fut>,
+        #[pin]
+        stream: St,
+    }
+}
+
+impl<St, Fut> WaitUntil<St, Fut>
+where
+    St: Stream,
+    Fut: Future<Output = bool>,
+{
+    pub(super) fn new(stream: St, fut: Fut) -> Self {
+        Self { stream, future: Some(fut), is_fused: false }
+    }
+}
+
+impl<St, Fut> Stream for WaitUntil<St, Fut>
+where
+    St: Stream,
+    Fut: Future<Output = bool>,
+{
+    type Item = St::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        Poll::Ready(loop {
+            if *this.is_fused {
+                break None;
+            } else if let Some(future) = this.future.as_mut().as_pin_mut() {
+                let ok = ready!(future.poll(cx));
+                this.future.set(None);
+
+                if !ok {
+                    *this.is_fused = true;
+                    break None;
+                }
+            } else {
+                break ready!(this.stream.poll_next(cx));
+            }
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.is_fused {
+            // No future values if it is fused
+            (0, Some(0))
+        } else {
+            let (lower, upper) = self.stream.size_hint();
+
+            if self.future.is_some() {
+                // If future is not resolved yet, returns zero lower bound
+                (0, upper)
+            } else {
+                // Returns size hint from underlying stream if the future is resolved
+                (lower, upper)
+            }
+        }
+    }
+}
+
+impl<St, Fut> FusedStream for WaitUntil<St, Fut>
+where
+    St: FusedStream,
+    Fut: Future<Output = bool>,
+{
+    fn is_terminated(&self) -> bool {
+        self.is_fused || self.stream.is_terminated()
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+#[cfg(feature = "sink")]
+impl<S, Fut, Item> Sink<Item> for WaitUntil<S, Fut>
+where
+    S: Stream + Sink<Item>,
+    Fut: Future<Output = bool>,
+{
+    type Error = S::Error;
+
+    delegate_sink!(stream, Item);
+}


### PR DESCRIPTION
The `stream.wait_until(fut)` combinator lets the stream to wait until the future resovles. The stream start taking elements if the future resolves to true, otherwise the stream fuses if it resolve to false.

It is useful for initialization purpose. For example, the stream has to wait for user configuration to be ready to start producing values, and fuse the stream if the configuration is not correct. The code below illustrates the idea.

```rust
// Suppose a oneshot channel to receive the acknowledgement from user.
let (tx, rx) = oneshot::channel::<bool>();

// The sender is passed to user.
give_to_user(tx);

stream::iter(0..100)
    .wait_for(async move {
        if let Ok(yes) = rx.await {
            // forward to user opinion
            yes
        } else {
            // the sender is dropped so fuse the stream
            false
        }
    })
    .for_each(|val| async move { /* do something */ })
    .await;
``` 

A practical example is in my [par-stream](https://github.com/jerry73204/par-stream) crate. To broadcast the messages from a stream, it creates a builder to user. The user registers receivers using the builder. The receivers should wait until the builder is finished or dropped. It ensures that every receiver can read the first value from stream.