### PR TITLE
TryAny and TryAll equivalent of All and Any with TryStreamExt

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1089,6 +1089,14 @@ pub trait StreamExt: Stream {
         assert_future::<Result<T, Fut::Error>, _>(TryFold::new(self, f, init))
     }
 
+    /// Execute predicate over asynchronous stream, and return `true` if all element in stream satisfied a predicate.
+    /// 
+    /// Once the entire stream has been exhausted the returned future will
+    /// resolve to this value.
+    ///
+    /// This method is similar to [`all`](crate::stream::StreamExt::all), but
+    /// will exit early if an error is encountered in the provided closure.
+    ///
     /// # Examples
     ///
     /// ```
@@ -1096,7 +1104,7 @@ pub trait StreamExt: Stream {
     /// use futures::stream::{self, StreamExt};
     ///
     /// let number_stream = stream::iter(0..4);
-    /// let less_then_three = number_stream.try_all(|x| async move { println!("ITEM: {:?}", x); Ok::<bool, i32>(x < 3) });
+    /// let less_then_three = number_stream.try_all(|x| async move { Ok::<bool, i32>(x < 3) });
     /// assert_eq!(less_then_three.await, Ok(false));
     ///
     /// let number_stream_with_err = stream::iter(vec![Ok::<i32, i32>(1), Err(2), Ok(42)]);

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1094,7 +1094,6 @@ pub trait StreamExt: Stream {
     }
 
     /// Execute predicate over asynchronous stream, and return `true` if all element in stream satisfied a predicate.
-    /// 
     /// Once the entire stream has been exhausted the returned future will
     /// resolve to this value.
     ///
@@ -1126,7 +1125,6 @@ pub trait StreamExt: Stream {
     }
 
     /// Execute predicate over asynchronous stream, and return `true` if any element in stream satisfied a predicate.
-    /// 
     /// Once the entire stream has been exhausted the returned future will
     /// resolve to this value.
     ///

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -171,6 +171,10 @@ mod try_all;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_all::TryAll;
 
+mod try_any;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::try_any::TryAny;
+
 mod zip;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::zip::Zip;
@@ -1119,6 +1123,38 @@ pub trait StreamExt: Stream {
         Self: Sized,
     {
         assert_future::<Result<bool, Fut::Error>, _>(TryAll::new(self, f))
+    }
+
+    /// Execute predicate over asynchronous stream, and return `true` if any element in stream satisfied a predicate.
+    /// 
+    /// Once the entire stream has been exhausted the returned future will
+    /// resolve to this value.
+    ///
+    /// This method is similar to [`any`](crate::stream::StreamExt::any), but
+    /// will exit early if an error is encountered in the provided closure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::stream::{self, StreamExt};
+    ///
+    /// let number_stream = stream::iter(0..5);
+    /// let less_then_three = number_stream.try_any(|x| async move { Ok::<bool, i32>(x < 3) });
+    /// assert_eq!(less_then_three.await, Ok(true));
+    ///
+    /// let number_stream_with_err = stream::iter(vec![Ok::<i32, i32>(10), Err(2), Ok(42)]);
+    /// let less_then_five_error = number_stream_with_err.try_any(|x| async move { Ok(x? < 5) });
+    /// assert_eq!(less_then_five_error.await, Err(2));
+    /// # })
+    /// ```
+    fn try_any<Fut, F>(self, f: F) -> TryAny<Self, Fut, F>
+    where
+        F: FnMut(Self::Item) -> Fut,
+        Fut: TryFuture<Ok = bool>,
+        Self: Sized,
+    {
+        assert_future::<Result<bool, Fut::Error>, _>(TryAny::new(self, f))
     }
 
     /// Attempts to run this stream to completion, executing the provided

--- a/futures-util/src/stream/stream/try_all.rs
+++ b/futures-util/src/stream/stream/try_all.rs
@@ -1,0 +1,100 @@
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::ready;
+use futures_core::stream::Stream;
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`try_all`](super::TryStreamExt::try_all) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryAll<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<bool>,
+        #[pin]
+        future: Option<Fut>
+    }
+}
+
+impl<St, Fut, F> fmt::Debug for TryAll<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryAll")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
+
+impl<St, Fut, F> TryAll<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f, accum: Some(true), future: None }
+    }
+}
+
+impl<St, Fut, F> FusedFuture for TryAll<St, Fut, F>
+where
+    St: Stream ,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    fn is_terminated(&self) -> bool {
+        self.accum.is_none() && self.future.is_none()
+    }
+}
+
+impl<St, Fut, F> Future for TryAll<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    type Output = Result<bool, Fut::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        Poll::Ready(loop {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
+                println!("Some(fut), acc: {:?}", *this.accum);
+                // we're currently processing a future to produce a new accum value
+                let res = ready!(fut.try_poll(cx));
+                this.future.set(None);
+                match res {
+                    Ok(a) => {
+                        let acc= this.accum.unwrap() && a;
+                        println!("LAMBDA VALUE: {:?}, acc: {:?}", a, acc);
+                        if !acc{
+                            break Ok(false)
+                        }
+                    }
+                    Err(e) => break Err(e),
+                }
+            } else if this.accum.is_some() {
+                println!("this.accum.is_some(), acc: {:?}", *this.accum);
+                // we're waiting on a new item from the stream
+                match ready!(this.stream.as_mut().poll_next(cx)) {
+                    Some(item) => {
+                        let v = (this.f)(item);
+                        this.future.set(Some(v))
+                    },
+                    None => break Ok(this.accum.take().unwrap()),
+                }
+            } else {
+                panic!("Fold polled after completion")
+            }
+        })
+    }
+}

--- a/futures-util/src/stream/stream/try_any.rs
+++ b/futures-util/src/stream/stream/try_any.rs
@@ -1,0 +1,91 @@
+use core::fmt;
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future, TryFuture};
+use futures_core::ready;
+use futures_core::stream::Stream;
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`try_any`](super::TryStreamExt::try_any) method.
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryAny<St, Fut, F> {
+        #[pin]
+        stream: St,
+        f: F,
+        accum: Option<bool>,
+        #[pin]
+        future: Option<Fut>
+    }
+}
+
+impl<St, Fut, F> fmt::Debug for TryAny<St, Fut, F>
+where
+    St: fmt::Debug,
+    Fut: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TryAny")
+            .field("stream", &self.stream)
+            .field("accum", &self.accum)
+            .field("future", &self.future)
+            .finish()
+    }
+}
+
+impl<St, Fut, F> TryAny<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f, accum: Some(false), future: None }
+    }
+}
+
+impl<St, Fut, F> FusedFuture for TryAny<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    fn is_terminated(&self) -> bool {
+        self.accum.is_none() && self.future.is_none()
+    }
+}
+
+impl<St, Fut, F> Future for TryAny<St, Fut, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Fut,
+    Fut: TryFuture<Ok = bool>,
+{
+    type Output = Result<bool, Fut::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        Poll::Ready(loop {
+            if let Some(fut) = this.future.as_mut().as_pin_mut() {
+                match ready!(fut.try_poll(cx)) {
+                    Ok(a) => {
+                        let acc = this.accum.unwrap() || a;
+                        if acc {
+                            break Ok(true);
+                        }
+                        this.future.set(None);
+                    }
+                    Err(e) => break Err(e),
+                }
+            } else if this.accum.is_some() {
+                match ready!(this.stream.as_mut().poll_next(cx)) {
+                    Some(item) => this.future.set(Some((this.f)(item))),
+                    None => break Ok(this.accum.take().unwrap()),
+                }
+            } else {
+                panic!("All polled after completion")
+            }
+        })
+    }
+}


### PR DESCRIPTION
Implementation of TryAll and TryAny predicates for TrySteamExt.
Most of the code is reused from TryFold implementation.
The difference between TryFold and TryAll, TryAny is in an early exit.
TryAll, TryAny has 2 early exits
  1. On error (same as TryFold)
  2. On spec. boolean value [TryAll => false, TryAny => true].
But I'm not sure, what should happen if there is an error somewhere in the stream, but we exit early.