### PR TITLE
Ignore unreachable_pub false positives

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -177,10 +177,12 @@ pub mod prelude {
     pub use crate::stream::{self, Stream, TryStream};
 
     #[doc(no_inline)]
+    #[allow(unreachable_pub)]
     pub use crate::future::{FutureExt as _, TryFutureExt as _};
     #[doc(no_inline)]
     pub use crate::sink::SinkExt as _;
     #[doc(no_inline)]
+    #[allow(unreachable_pub)]
     pub use crate::stream::{StreamExt as _, TryStreamExt as _};
 
     #[cfg(feature = "std")]
@@ -188,6 +190,7 @@ pub mod prelude {
 
     #[cfg(feature = "std")]
     #[doc(no_inline)]
+    #[allow(unreachable_pub)]
     pub use crate::io::{
         AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
     };


### PR DESCRIPTION
https://github.com/rust-lang/futures-rs/runs/4783724442?check_suite_focus=true

```
error: unreachable `pub` item
   --> futures/src/lib.rs:180:29
    |
180 |     pub use crate::future::{FutureExt as _, TryFutureExt as _};
    |     ---                     ^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`
    |
    = note: `-D unreachable-pub` implied by `-D warnings`
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:180:45
    |
180 |     pub use crate::future::{FutureExt as _, TryFutureExt as _};
    |     ---                                     ^^^^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:184:29
    |
184 |     pub use crate::stream::{StreamExt as _, TryStreamExt as _};
    |     ---                     ^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:184:45
    |
184 |     pub use crate::stream::{StreamExt as _, TryStreamExt as _};
    |     ---                                     ^^^^^^^^^^^^^^^^^
    |     |
    |     help: consider restricting its visibility: `pub(crate)`
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:192:9
    |
191 |     pub use crate::io::{
    |     --- help: consider restricting its visibility: `pub(crate)`
192 |         AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
    |         ^^^^^^^^^^^^^^^^^^^^
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:192:31
    |
191 |     pub use crate::io::{
    |     --- help: consider restricting its visibility: `pub(crate)`
192 |         AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
    |                               ^^^^^^^^^^^^^^^^^
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:192:50
    |
191 |     pub use crate::io::{
    |     --- help: consider restricting its visibility: `pub(crate)`
192 |         AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
    |                                                  ^^^^^^^^^^^^^^^^^
    |
    = help: or consider exporting it for use by other crates

error: unreachable `pub` item
   --> futures/src/lib.rs:192:69
    |
191 |     pub use crate::io::{
    |     --- help: consider restricting its visibility: `pub(crate)`
192 |         AsyncBufReadExt as _, AsyncReadExt as _, AsyncSeekExt as _, AsyncWriteExt as _,
    |                                                                     ^^^^^^^^^^^^^^^^^^
    |
    = help: or consider exporting it for use by other crates
```