### PR TITLE
Fix stacked borrows violations in waker_ref and FuturesUnordered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,11 @@ jobs:
         if: matrix.target != 'aarch64-unknown-linux-gnu'
 
   core-msrv:
-    name: cargo +${{ matrix.rust }} build (futures-{core, io, sink, task})
+    name: cargo +${{ matrix.rust }} build (futures-{core, io, sink})
     strategy:
       matrix:
         rust:
-          # This is the minimum Rust version supported by futures-core, futures-io, futures-sink, futures-task.
+          # This is the minimum Rust version supported by futures-core, futures-io, futures-sink.
           # When updating this, the reminder to update the minimum required version in README.md, Cargo.toml, and .clippy.toml.
           - 1.36
     runs-on: ubuntu-latest
@@ -76,22 +76,22 @@ jobs:
       # Check no-default-features
       - run: |
           cargo hack build --workspace --ignore-private --no-default-features \
-            --exclude futures --exclude futures-util --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
+            --exclude futures --exclude futures-util --exclude futures-task --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
       # Check alloc feature
       - run: |
           cargo hack build --workspace --ignore-private --no-default-features --features alloc --ignore-unknown-features \
-            --exclude futures --exclude futures-util --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
+            --exclude futures --exclude futures-util --exclude futures-task --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
       # Check std feature
       - run: |
           cargo hack build --workspace --ignore-private --no-default-features --features std \
-            --exclude futures --exclude futures-util --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
+            --exclude futures --exclude futures-util --exclude futures-task --exclude futures-macro --exclude futures-executor --exclude futures-channel --exclude futures-test
 
   util-msrv:
     name: cargo +${{ matrix.rust }} build
     strategy:
       matrix:
         rust:
-          # This is the minimum Rust version supported by futures, futures-util, futures-macro, futures-executor, futures-channel, futures-test.
+          # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
           - 1.45
     runs-on: ubuntu-latest

--- a/futures-task/src/waker_ref.rs
+++ b/futures-task/src/waker_ref.rs
@@ -55,7 +55,7 @@ where
 {
     // simply copy the pointer instead of using Arc::into_raw,
     // as we don't actually keep a refcount by using ManuallyDrop.<
-    let ptr = (&**wake as *const W) as *const ();
+    let ptr = Arc::as_ptr(wake).cast::<()>();
 
     let waker =
         ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(ptr, waker_vtable::<W>())) });

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -150,7 +150,7 @@ impl<Fut> FuturesUnordered<Fut> {
             queued: AtomicBool::new(true),
             ready_to_run_queue: Weak::new(),
         });
-        let stub_ptr = &*stub as *const Task<Fut>;
+        let stub_ptr = Arc::as_ptr(&stub);
         let ready_to_run_queue = Arc::new(ReadyToRunQueue {
             waker: AtomicWaker::new(),
             head: AtomicPtr::new(stub_ptr as *mut _),
@@ -403,7 +403,7 @@ impl<Fut> FuturesUnordered<Fut> {
         // The `ReadyToRunQueue` stub is never inserted into the `head_all`
         // list, and its pointer value will remain valid for the lifetime of
         // this `FuturesUnordered`, so we can make use of its value here.
-        &*self.ready_to_run_queue.stub as *const _ as *mut _
+        Arc::as_ptr(&self.ready_to_run_queue.stub) as *mut _
     }
 }
 

--- a/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
+++ b/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
@@ -83,7 +83,7 @@ impl<Fut> ReadyToRunQueue<Fut> {
     }
 
     pub(super) fn stub(&self) -> *const Task<Fut> {
-        &*self.stub
+        Arc::as_ptr(&self.stub)
     }
 
     // Clear the queue of tasks.

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -62,7 +62,7 @@ impl<Fut> ArcWake for Task<Fut> {
         // still.
         let prev = arc_self.queued.swap(true, SeqCst);
         if !prev {
-            inner.enqueue(&**arc_self);
+            inner.enqueue(Arc::as_ptr(arc_self));
             inner.waker.wake();
         }
     }


### PR DESCRIPTION
Split from #2548

To fix this problem, we need to use [`Arc::as_ptr`](https://doc.rust-lang.org/nightly/std/sync/struct.Arc.html#method.as_ptr). Therefore, this increases the MSRV of futures-task to 1.45.

waker_ref:
```
MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers" cargo miri test -p futures-channel --test mpsc-close -- smoke
```
<details>
<summary>output</summary>

```
error: Undefined Behavior: trying to reborrow for SharedReadWrite at alloc366730, but parent tag <985917> does not have an appropriate item in the borrow stack
   --> /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:327:18
    |
327 |         unsafe { &*self.as_ptr() }
    |                  ^^^^^^^^^^^^^^^ trying to reborrow for SharedReadWrite at alloc366730, but parent tag <985917> does not have an appropriate item in the borrow stack
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
            
    = note: inside `std::ptr::NonNull::<alloc::sync::ArcInner<futures::futures_executor::local_pool::ThreadNotify>>::as_ref` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:327:18
    = note: inside `std::sync::Arc::<futures::futures_executor::local_pool::ThreadNotify>::inner` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:1071:18
    = note: inside `<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify> as std::clone::Clone>::clone` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:1329:24
    = note: inside `<std::mem::ManuallyDrop<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify>> as std::clone::Clone>::clone` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/mem/manually_drop.rs:50:5
    = note: inside `futures_task::waker::increase_refcount::<futures::futures_executor::local_pool::ThreadNotify>` at /Users/taiki/projects/futures-rs/futures-task/src/waker.rs:36:44
    = note: inside `futures_task::waker::clone_arc_raw::<futures::futures_executor::local_pool::ThreadNotify>` at /Users/taiki/projects/futures-rs/futures-task/src/waker.rs:41:5
    = note: inside `<std::task::Waker as std::clone::Clone>::clone` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/task/wake.rs:273:29
    = note: inside `futures::task::AtomicWaker::register` at /Users/taiki/projects/futures-rs/futures-core/src/task/__internal/atomic_waker.rs:267:46
    = note: inside `<futures::futures_channel::mpsc::Receiver<i32> as futures::Stream>::poll_next` at /Users/taiki/projects/futures-rs/futures-channel/src/mpsc/mod.rs:1070:17
    = note: inside `<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>> as futures::Stream>::poll_next` at /Users/taiki/projects/futures-rs/futures-util/src/stream/stream/take.rs:40:31
    = note: inside `<futures::stream::ForEach<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>>, futures::future::Ready<()>, [closure@futures-channel/tests/mpsc-close.rs:19:40: 19:70]> as futures::Future>::poll` at /Users/taiki/projects/futures-rs/futures-util/src/stream/stream/for_each.rs:70:47
    = note: inside closure at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:315:23
    = note: inside closure at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:90:37
    = note: inside `std::thread::LocalKey::<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify>>::try_with::<[closure@futures::futures_executor::local_pool::run_executor<(), [closure@futures::futures_executor::block_on<futures::stream::ForEach<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>>, futures::future::Ready<()>, [closure@futures-channel/tests/mpsc-close.rs:19:40: 19:70]>>::{closure#0}]>::{closure#0}], ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:412:16
    = note: inside `std::thread::LocalKey::<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify>>::with::<[closure@futures::futures_executor::local_pool::run_executor<(), [closure@futures::futures_executor::block_on<futures::stream::ForEach<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>>, futures::future::Ready<()>, [closure@futures-channel/tests/mpsc-close.rs:19:40: 19:70]>>::{closure#0}]>::{closure#0}], ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:388:9
    = note: inside `futures::futures_executor::local_pool::run_executor::<(), [closure@futures::futures_executor::block_on<futures::stream::ForEach<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>>, futures::future::Ready<()>, [closure@futures-channel/tests/mpsc-close.rs:19:40: 19:70]>>::{closure#0}]>` at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:86:5
    = note: inside `futures::futures_executor::block_on::<futures::stream::ForEach<futures::stream::Take<futures::futures_channel::mpsc::Receiver<i32>>, futures::future::Ready<()>, [closure@futures-channel/tests/mpsc-close.rs:19:40: 19:70]>>` at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:315:5
note: inside `smoke` at futures-channel/tests/mpsc-close.rs:19:5
   --> futures-channel/tests/mpsc-close.rs:19:5
    |
19  |     block_on(receiver.take(3).for_each(|_| futures::future::ready(())));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at futures-channel/tests/mpsc-close.rs:13:1
   --> futures-channel/tests/mpsc-close.rs:13:1
    |
12  |   #[test]
    |   ------- in this procedural macro expansion
13  | / fn smoke() {
14  | |     let (mut sender, receiver) = mpsc::channel(1);
15  | |
16  | |     let t = thread::spawn(move || while let Ok(()) = block_on(sender.send(42)) {});
...   |
21  | |     t.join().unwrap()
22  | | }
    | |_^
    = note: inside `<[closure@futures-channel/tests/mpsc-close.rs:13:1: 22:2] as std::ops::FnOnce<()>>::call_once - shim` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `<fn() as std::ops::FnOnce<()>>::call_once - shim(fn())` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `test::__rust_begin_short_backtrace::<fn()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:574:5
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:565:30
    = note: inside `<[closure@test::run_test::{closure#1}] as std::ops::FnOnce<()>>::call_once - shim(vtable)` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send> as std::ops::FnOnce<()>>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1854:9
    = note: inside `<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>> as std::ops::FnOnce<()>>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:271:9
    = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>, ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>, ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside `test::run_test_in_process` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:597:18
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:491:39
    = note: inside `test::run_test::run_test_inner` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:529:13
    = note: inside `test::run_test` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:561:28
    = note: inside `test::run_tests::<[closure@test::run_tests_console::{closure#2}]>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:304:17
    = note: inside `test::run_tests_console` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/console.rs:290:5
    = note: inside `test::test_main` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:115:15
    = note: inside `test::test_main_static` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:134:5
    = note: inside `main`
    = note: inside `<fn() as std::ops::FnOnce<()>>::call_once - shim(fn())` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:123:18
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:145:18
    = note: inside `std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:259:13
    = note: inside `std::panicking::r#try::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:128:48
    = note: inside `std::panicking::r#try::do_call::<[closure@std::rt::lang_start_internal::{closure#2}], isize>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<isize, [closure@std::rt::lang_start_internal::{closure#2}]>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<[closure@std::rt::lang_start_internal::{closure#2}], isize>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside `std::rt::lang_start_internal` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:128:20
    = note: inside `std::rt::lang_start::<()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:144:17
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>

FuturesUnordered:
```
MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers" cargo miri test -p futures:0.4.0-alpha.0 --test stream_futures_ordered -- works_1
```
<details>
<summary>output</summary>

```
error: Undefined Behavior: trying to reborrow for SharedReadWrite at alloc361699, but parent tag <920858> does not have an appropriate item in the borrow stack
   --> /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:327:18
    |
327 |         unsafe { &*self.as_ptr() }
    |                  ^^^^^^^^^^^^^^^ trying to reborrow for SharedReadWrite at alloc361699, but parent tag <920858> does not have an appropriate item in the borrow stack
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
            
    = note: inside `std::ptr::NonNull::<alloc::sync::ArcInner<futures::stream::futures_unordered::task::Task<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>>>>::as_ref` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:327:18
    = note: inside `std::sync::Arc::<futures::stream::futures_unordered::task::Task<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>>>::inner` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:1071:18
    = note: inside `<std::sync::Arc<futures::stream::futures_unordered::task::Task<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>>> as std::ops::Deref>::deref` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/sync.rs:1354:10
    = note: inside `futures::stream::FuturesUnordered::<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>>::unlink` at /Users/taiki/projects/futures-rs/futures-util/src/stream/futures_unordered/mod.rs:356:20
    = note: inside `<futures::stream::FuturesUnordered<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>> as futures::Stream>::poll_next` at /Users/taiki/projects/futures-rs/futures-util/src/stream/futures_unordered/mod.rs:481:33
    = note: inside `<futures::stream::FuturesUnordered<futures::stream::futures_ordered::OrderWrapper<futures::futures_channel::oneshot::Receiver<i32>>> as futures::StreamExt>::poll_next_unpin` at /Users/taiki/projects/futures-rs/futures-util/src/stream/stream/mod.rs:1668:9
    = note: inside `<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>> as futures::Stream>::poll_next` at /Users/taiki/projects/futures-rs/futures-util/src/stream/futures_ordered.rs:166:26
    = note: inside `<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>> as futures::StreamExt>::poll_next_unpin` at /Users/taiki/projects/futures-rs/futures-util/src/stream/stream/mod.rs:1668:9
    = note: inside `<futures::stream::Next<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>> as futures::Future>::poll` at /Users/taiki/projects/futures-rs/futures-util/src/stream/stream/next.rs:32:9
    = note: inside closure at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:175:30
    = note: inside closure at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:90:37
    = note: inside `std::thread::LocalKey::<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify>>::try_with::<[closure@futures::futures_executor::local_pool::run_executor<std::option::Option<std::result::Result<i32, futures::futures_channel::oneshot::Canceled>>, [closure@futures::futures_executor::LocalPool::run_until<futures::stream::Next<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>>>::{closure#0}]>::{closure#0}], std::option::Option<std::result::Result<i32, futures::futures_channel::oneshot::Canceled>>>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:412:16
    = note: inside `std::thread::LocalKey::<std::sync::Arc<futures::futures_executor::local_pool::ThreadNotify>>::with::<[closure@futures::futures_executor::local_pool::run_executor<std::option::Option<std::result::Result<i32, futures::futures_channel::oneshot::Canceled>>, [closure@futures::futures_executor::LocalPool::run_until<futures::stream::Next<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>>>::{closure#0}]>::{closure#0}], std::option::Option<std::result::Result<i32, futures::futures_channel::oneshot::Canceled>>>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:388:9
    = note: inside `futures::futures_executor::local_pool::run_executor::<std::option::Option<std::result::Result<i32, futures::futures_channel::oneshot::Canceled>>, [closure@futures::futures_executor::LocalPool::run_until<futures::stream::Next<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>>>::{closure#0}]>` at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:86:5
    = note: inside `futures::futures_executor::LocalPool::run_until::<futures::stream::Next<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>>>` at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:172:9
    = note: inside `<futures::futures_executor::BlockingStream<futures::stream::FuturesOrdered<futures::futures_channel::oneshot::Receiver<i32>>> as std::iter::Iterator>::next` at /Users/taiki/projects/futures-rs/futures-executor/src/local_pool.rs:356:9
note: inside `works_1` at futures/tests/stream_futures_ordered.rs:23:30
   --> futures/tests/stream_futures_ordered.rs:23:30
    |
23  |     assert_eq!(Some(Ok(33)), iter.next());
    |                              ^^^^^^^^^^^
note: inside closure at futures/tests/stream_futures_ordered.rs:9:1
   --> futures/tests/stream_futures_ordered.rs:9:1
    |
8   |   #[test]
    |   ------- in this procedural macro expansion
9   | / fn works_1() {
10  | |     let (a_tx, a_rx) = oneshot::channel::<i32>();
11  | |     let (b_tx, b_rx) = oneshot::channel::<i32>();
12  | |     let (c_tx, c_rx) = oneshot::channel::<i32>();
...   |
26  | |     assert_eq!(None, iter.next());
27  | | }
    | |_^
    = note: inside `<[closure@futures/tests/stream_futures_ordered.rs:9:1: 27:2] as std::ops::FnOnce<()>>::call_once - shim` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `<fn() as std::ops::FnOnce<()>>::call_once - shim(fn())` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `test::__rust_begin_short_backtrace::<fn()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:574:5
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:565:30
    = note: inside `<[closure@test::run_test::{closure#1}] as std::ops::FnOnce<()>>::call_once - shim(vtable)` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send> as std::ops::FnOnce<()>>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1854:9
    = note: inside `<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>> as std::ops::FnOnce<()>>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:271:9
    = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>, ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<(), std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<std::boxed::Box<dyn std::ops::FnOnce() + std::marker::Send>>, ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside `test::run_test_in_process` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:597:18
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:491:39
    = note: inside `test::run_test::run_test_inner` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:529:13
    = note: inside `test::run_test` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:561:28
    = note: inside `test::run_tests::<[closure@test::run_tests_console::{closure#2}]>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:304:17
    = note: inside `test::run_tests_console` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/console.rs:290:5
    = note: inside `test::test_main` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:115:15
    = note: inside `test::test_main_static` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/test/src/lib.rs:134:5
    = note: inside `main`
    = note: inside `<fn() as std::ops::FnOnce<()>>::call_once - shim(fn())` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
    = note: inside `std::sys_common::backtrace::__rust_begin_short_backtrace::<fn(), ()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:123:18
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:145:18
    = note: inside `std::ops::function::impls::<impl std::ops::FnOnce<()> for &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>::call_once` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:259:13
    = note: inside `std::panicking::r#try::do_call::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<i32, &dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<&dyn std::ops::Fn() -> i32 + std::marker::Sync + std::panic::RefUnwindSafe, i32>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside closure at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:128:48
    = note: inside `std::panicking::r#try::do_call::<[closure@std::rt::lang_start_internal::{closure#2}], isize>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:406:40
    = note: inside `std::panicking::r#try::<isize, [closure@std::rt::lang_start_internal::{closure#2}]>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:370:19
    = note: inside `std::panic::catch_unwind::<[closure@std::rt::lang_start_internal::{closure#2}], isize>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:133:14
    = note: inside `std::rt::lang_start_internal` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:128:20
    = note: inside `std::rt::lang_start::<()>` at /Users/taiki/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:144:17
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>