### PR TITLE
FuturesUnordered: fix partial iteration

### DIFF
--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -2,6 +2,7 @@ use super::task::Task;
 use super::FuturesUnordered;
 use core::marker::PhantomData;
 use core::pin::Pin;
+use core::ptr;
 use core::sync::atomic::Ordering::Relaxed;
 
 /// Mutable iterator over all futures in the unordered set.
@@ -58,6 +59,9 @@ impl<Fut: Unpin> Iterator for IntoIter<Fut> {
             // valid `next_all` checks can be skipped.
             let next = (**task).next_all.load(Relaxed);
             *task = next;
+            if !task.is_null() {
+                *(**task).prev_all.get() = ptr::null_mut();
+            }
             self.len -= 1;
             Some(future)
         }

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -262,6 +262,20 @@ fn into_iter_len() {
 }
 
 #[test]
+fn into_iter_partial() {
+    let stream = vec![future::ready(1), future::ready(2), future::ready(3), future::ready(4)]
+        .into_iter()
+        .collect::<FuturesUnordered<_>>();
+
+    let mut into_iter = stream.into_iter();
+    assert!(into_iter.next().is_some());
+    assert!(into_iter.next().is_some());
+    assert!(into_iter.next().is_some());
+    assert_eq!(into_iter.len(), 1);
+    // don't panic when iterator is dropped before completing
+}
+
+#[test]
 fn futures_not_moved_after_poll() {
     // Future that will be ready after being polled twice,
     // asserting that it does not move.


### PR DESCRIPTION
The IntoIter impl advances the head pointer every iteration, but this breaks the linked list invariant that the head's prev should be null.

If the iteration is not done to completion (which sets head to null), on subsequent drop, FuturesUnordered::unlink relies on this broken invariant and ends up panicking.

The fix is to maintain the `head->prev == null` invariant while iterating.

Fixes #2573 