### PR TITLE
`TryFlattenUnordered`

### DIFF
--- a/futures-util/benches/flatten_unordered.rs
+++ b/futures-util/benches/flatten_unordered.rs
@@ -5,7 +5,7 @@ use crate::test::Bencher;
 
 use futures::channel::oneshot;
 use futures::executor::block_on;
-use futures::future::{self, FutureExt};
+use futures::future;
 use futures::stream::{self, StreamExt};
 use futures::task::Poll;
 use std::collections::VecDeque;
@@ -35,15 +35,14 @@ fn oneshot_streams(b: &mut Bencher) {
         });
 
         let mut flatten = stream::unfold(rxs.into_iter(), |mut vals| {
-            async {
+            Box::pin(async {
                 if let Some(next) = vals.next() {
                     let val = next.await.unwrap();
                     Some((val, vals))
                 } else {
                     None
                 }
-            }
-            .boxed()
+            })
         })
         .flatten_unordered(None);
 

--- a/futures-util/src/future/try_select.rs
+++ b/futures-util/src/future/try_select.rs
@@ -12,6 +12,9 @@ pub struct TrySelect<A, B> {
 
 impl<A: Unpin, B: Unpin> Unpin for TrySelect<A, B> {}
 
+type EitherOk<A, B> = Either<(<A as TryFuture>::Ok, B), (<B as TryFuture>::Ok, A)>;
+type EitherErr<A, B> = Either<(<A as TryFuture>::Error, B), (<B as TryFuture>::Error, A)>;
+
 /// Waits for either one of two differently-typed futures to complete.
 ///
 /// This function will return a new future which awaits for either one of both
@@ -56,9 +59,6 @@ where
         inner: Some((future1, future2)),
     })
 }
-
-type EitherOk<A, B> = Either<(<A as TryFuture>::Ok, B), (<B as TryFuture>::Ok, A)>;
-type EitherErr<A, B> = Either<(<A as TryFuture>::Error, B), (<B as TryFuture>::Error, A)>;
 
 impl<A: Unpin, B: Unpin> Future for TrySelect<A, B>
 where

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -53,8 +53,8 @@ pub use self::stream::{ReuniteError, SplitSink, SplitStream};
 mod try_stream;
 pub use self::try_stream::{
     try_unfold, AndThen, ErrInto, InspectErr, InspectOk, IntoStream, MapErr, MapOk, OrElse,
-    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryFlattenUnordered, TryNext,
-    TrySkipWhile, TryStreamExt, TryTakeWhile, TryUnfold,
+    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext, TrySkipWhile,
+    TryStreamExt, TryTakeWhile, TryUnfold,
 };
 
 #[cfg(feature = "io")]
@@ -64,7 +64,7 @@ pub use self::try_stream::IntoAsyncRead;
 
 #[cfg(not(futures_no_atomic_cas))]
 #[cfg(feature = "alloc")]
-pub use self::try_stream::{TryBufferUnordered, TryBuffered};
+pub use self::try_stream::{TryBufferUnordered, TryBuffered, TryFlattenUnordered};
 
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -18,10 +18,10 @@ pub use futures_core::stream::{FusedStream, Stream, TryStream};
 #[allow(clippy::module_inception)]
 mod stream;
 pub use self::stream::{
-    Chain, Collect, Concat, Cycle, Enumerate, Filter, FilterMap, FlatMap, Flatten, Fold, ForEach,
-    Fuse, Inspect, Map, Next, NextIf, NextIfEq, Peek, PeekMut, Peekable, Scan, SelectNextSome,
-    Skip, SkipWhile, StreamExt, StreamFuture, Take, TakeUntil, TakeWhile, Then, TryFold,
-    TryForEach, Unzip, Zip,
+    All, Any, Chain, Collect, Concat, Count, Cycle, Enumerate, Filter, FilterMap, FlatMap, Flatten,
+    Fold, ForEach, Fuse, Inspect, Map, Next, NextIf, NextIfEq, Peek, PeekMut, Peekable, Scan,
+    SelectNextSome, Skip, SkipWhile, StreamExt, StreamFuture, Take, TakeUntil, TakeWhile, Then,
+    TryFold, TryForEach, Unzip, Zip,
 };
 
 #[cfg(feature = "std")]

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -53,8 +53,8 @@ pub use self::stream::{ReuniteError, SplitSink, SplitStream};
 mod try_stream;
 pub use self::try_stream::{
     try_unfold, AndThen, ErrInto, InspectErr, InspectOk, IntoStream, MapErr, MapOk, OrElse,
-    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext, TrySkipWhile,
-    TryStreamExt, TryTakeWhile, TryUnfold,
+    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryFlattenUnordered, TryNext,
+    TrySkipWhile, TryStreamExt, TryTakeWhile, TryUnfold,
 };
 
 #[cfg(feature = "io")]

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -39,7 +39,10 @@ pub use self::stream::Forward;
 
 #[cfg(not(futures_no_atomic_cas))]
 #[cfg(feature = "alloc")]
-pub use self::stream::{BufferUnordered, Buffered, ForEachConcurrent, TryForEachConcurrent};
+pub use self::stream::{
+    BufferUnordered, Buffered, FlatMapUnordered, FlattenUnordered, ForEachConcurrent,
+    TryForEachConcurrent,
+};
 
 #[cfg(not(futures_no_atomic_cas))]
 #[cfg(feature = "sink")]

--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{boxed::Box, sync::Arc};
 use core::{
     cell::UnsafeCell,
     convert::identity,

--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -22,8 +22,7 @@ use futures_task::{waker, ArcWake};
 
 use crate::stream::FuturesUnordered;
 
-/// There is nothing to poll and stream isn't being
-/// polled or waking at the moment.
+/// There is nothing to poll and stream isn't being polled/waking/woken at the moment.
 const NONE: u8 = 0;
 
 /// Inner streams need to be polled.
@@ -32,26 +31,19 @@ const NEED_TO_POLL_INNER_STREAMS: u8 = 1;
 /// The base stream needs to be polled.
 const NEED_TO_POLL_STREAM: u8 = 0b10;
 
-/// It needs to poll base stream and inner streams.
+/// Both base stream and inner streams need to be polled.
 const NEED_TO_POLL_ALL: u8 = NEED_TO_POLL_INNER_STREAMS | NEED_TO_POLL_STREAM;
 
 /// The current stream is being polled at the moment.
 const POLLING: u8 = 0b100;
 
-/// Inner streams are being woken at the moment.
-const WAKING_INNER_STREAMS: u8 = 0b1000;
-
-/// The base stream is being woken at the moment.
-const WAKING_STREAM: u8 = 0b10000;
-
-/// The base stream and inner streams are being woken at the moment.
-const WAKING_ALL: u8 = WAKING_STREAM | WAKING_INNER_STREAMS;
+/// Stream is being woken at the moment.
+const WAKING: u8 = 0b1000;
 
 /// The stream was waked and will be polled.
-const WOKEN: u8 = 0b100000;
+const WOKEN: u8 = 0b10000;
 
-/// Determines what needs to be polled, and is stream being polled at the
-/// moment or not.
+/// Internal polling state of the stream.
 #[derive(Clone, Debug)]
 struct SharedPollState {
     state: Arc<AtomicU8>,
@@ -71,7 +63,7 @@ impl SharedPollState {
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
-                if value & WAKING_ALL == NONE {
+                if value & WAKING == NONE {
                     Some(POLLING)
                 } else {
                     None
@@ -83,23 +75,20 @@ impl SharedPollState {
         Some((value, bomb))
     }
 
-    /// Starts the waking process and performs bitwise or with the given value.
+    /// Attempts to start the waking process and performs bitwise or with the given value.
+    ///
+    /// If some waker is already in progress or stream is already woken/being polled, waking process won't start, however
+    /// state will be disjuncted with the given value.
     fn start_waking(
         &self,
         to_poll: u8,
-        waking: u8,
     ) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&SharedPollState) -> u8>)> {
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
-                // Waking process for this waker already started
-                if value & waking != NONE {
-                    return None;
-                }
                 let mut next_value = value | to_poll;
-                // Only start the waking process if we're not in the polling phase and the stream isn't woken already
                 if value & (WOKEN | POLLING) == NONE {
-                    next_value |= waking;
+                    next_value |= WAKING;
                 }
 
                 if next_value != value {
@@ -110,8 +99,9 @@ impl SharedPollState {
             })
             .ok()?;
 
-        if value & (WOKEN | POLLING) == NONE {
-            let bomb = PollStateBomb::new(self, move |state| state.stop_waking(waking));
+        // Only start the waking process if we're not in the polling phase and the stream isn't woken already
+        if value & (WOKEN | POLLING | WAKING) == NONE {
+            let bomb = PollStateBomb::new(self, SharedPollState::stop_waking);
 
             Some((value, bomb))
         } else {
@@ -123,7 +113,7 @@ impl SharedPollState {
     /// - `!POLLING` allowing to use wakers
     /// - `WOKEN` if the state was changed during `POLLING` phase as waker will be called,
     ///   or `will_be_woken` flag supplied
-    /// - `!WAKING_ALL` as
+    /// - `!WAKING` as
     ///   * Wakers called during the `POLLING` phase won't propagate their calls
     ///   * `POLLING` phase can't start if some of the wakers are active
     ///   So no wrapped waker can touch the inner waker's cell, it's safe to poll again.
@@ -138,20 +128,16 @@ impl SharedPollState {
                 }
                 next_value |= value;
 
-                Some(next_value & !POLLING & !WAKING_ALL)
+                Some(next_value & !POLLING & !WAKING)
             })
             .unwrap()
     }
 
     /// Toggles state to non-waking, allowing to start polling.
-    fn stop_waking(&self, waking: u8) -> u8 {
+    fn stop_waking(&self) -> u8 {
         self.state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
-                let mut next_value = value & !waking;
-                // Waker will be called only if the current waking state is the same as the specified waker state
-                if value & WAKING_ALL == waking {
-                    next_value |= WOKEN;
-                }
+                let next_value = value & !WAKING;
 
                 if next_value != value {
                     Some(next_value)
@@ -201,16 +187,16 @@ impl<F: FnOnce(&SharedPollState) -> u8> Drop for PollStateBomb<'_, F> {
 
 /// Will update state with the provided value on `wake_by_ref` call
 /// and then, if there is a need, call `inner_waker`.
-struct InnerWaker {
+struct WrappedWaker {
     inner_waker: UnsafeCell<Option<Waker>>,
     poll_state: SharedPollState,
     need_to_poll: u8,
 }
 
-unsafe impl Send for InnerWaker {}
-unsafe impl Sync for InnerWaker {}
+unsafe impl Send for WrappedWaker {}
+unsafe impl Sync for WrappedWaker {}
 
-impl InnerWaker {
+impl WrappedWaker {
     /// Replaces given waker's inner_waker for polling stream/futures which will
     /// update poll state on `wake_by_ref` call. Use only if you need several
     /// contexts.
@@ -218,7 +204,7 @@ impl InnerWaker {
     /// ## Safety
     ///
     /// This function will modify waker's `inner_waker` via `UnsafeCell`, so
-    /// it should be used only during `POLLING` phase.
+    /// it should be used only during `POLLING` phase by one thread at the time.
     unsafe fn replace_waker(self_arc: &mut Arc<Self>, cx: &Context<'_>) -> Waker {
         *self_arc.inner_waker.get() = cx.waker().clone().into();
         waker(self_arc.clone())
@@ -227,16 +213,11 @@ impl InnerWaker {
     /// Attempts to start the waking process for the waker with the given value.
     /// If succeeded, then the stream isn't yet woken and not being polled at the moment.
     fn start_waking(&self) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&SharedPollState) -> u8>)> {
-        self.poll_state.start_waking(self.need_to_poll, self.waking_state())
-    }
-
-    /// Returns the corresponding waking state toggled by this waker.
-    fn waking_state(&self) -> u8 {
-        self.need_to_poll << 3
+        self.poll_state.start_waking(self.need_to_poll)
     }
 }
 
-impl ArcWake for InnerWaker {
+impl ArcWake for WrappedWaker {
     fn wake_by_ref(self_arc: &Arc<Self>) {
         if let Some((_, state_bomb)) = self_arc.start_waking() {
             // Safety: now state is not `POLLING`
@@ -246,12 +227,8 @@ impl ArcWake for InnerWaker {
                 // Stop waking to allow polling stream
                 let poll_state_value = state_bomb.fire().unwrap();
 
-                // Here we want to call waker only if stream isn't woken yet and
-                // also to optimize the case when two wakers are called at the same time.
-                //
-                // In this case the best strategy will be to propagate only the latest waker's awake,
-                // and then poll both entities in a single `poll_next` call
-                if poll_state_value & (WOKEN | WAKING_ALL) == self_arc.waking_state() {
+                // We want to call waker only if the stream isn't woken yet
+                if poll_state_value & (WOKEN | WAKING) == WAKING {
                     // Wake up inner waker
                     inner_waker.wake();
                 }
@@ -308,14 +285,14 @@ pin_project! {
     #[must_use = "streams do nothing unless polled"]
     pub struct FlattenUnordered<St> where St: Stream {
         #[pin]
-        inner_streams: FuturesUnordered<PollStreamFut<St::Item>>,
+        inner_streams: FuturesUnordered<PollStreamFut<Pin<Box<St::Item>>>>,
         #[pin]
         stream: St,
         poll_state: SharedPollState,
         limit: Option<NonZeroUsize>,
         is_stream_done: bool,
-        inner_streams_waker: Arc<InnerWaker>,
-        stream_waker: Arc<InnerWaker>,
+        inner_streams_waker: Arc<WrappedWaker>,
+        stream_waker: Arc<WrappedWaker>,
     }
 }
 
@@ -338,7 +315,7 @@ where
 impl<St> FlattenUnordered<St>
 where
     St: Stream,
-    St::Item: Stream + Unpin,
+    St::Item: Stream,
 {
     pub(super) fn new(stream: St, limit: Option<usize>) -> FlattenUnordered<St> {
         let poll_state = SharedPollState::new(NEED_TO_POLL_STREAM);
@@ -348,12 +325,12 @@ where
             stream,
             is_stream_done: false,
             limit: limit.and_then(NonZeroUsize::new),
-            inner_streams_waker: Arc::new(InnerWaker {
+            inner_streams_waker: Arc::new(WrappedWaker {
                 inner_waker: UnsafeCell::new(None),
                 poll_state: poll_state.clone(),
                 need_to_poll: NEED_TO_POLL_INNER_STREAMS,
             }),
-            stream_waker: Arc::new(InnerWaker {
+            stream_waker: Arc::new(WrappedWaker {
                 inner_waker: UnsafeCell::new(None),
                 poll_state: poll_state.clone(),
                 need_to_poll: NEED_TO_POLL_STREAM,
@@ -369,7 +346,7 @@ impl<St> FlattenUnorderedProj<'_, St>
 where
     St: Stream,
 {
-    /// Checks if current `inner_streams` size is less than optional limit.
+    /// Checks if current `inner_streams` size is greater than optional limit.
     fn is_exceeded_limit(&self) -> bool {
         self.limit.map_or(false, |limit| self.inner_streams.len() >= limit.get())
     }
@@ -378,7 +355,7 @@ where
 impl<St> FusedStream for FlattenUnordered<St>
 where
     St: FusedStream,
-    St::Item: FusedStream + Unpin,
+    St::Item: Stream,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated() && self.inner_streams.is_empty()
@@ -388,7 +365,7 @@ where
 impl<St> Stream for FlattenUnordered<St>
 where
     St: Stream,
-    St::Item: Stream + Unpin,
+    St::Item: Stream,
 {
     type Item = <St::Item as Stream>::Item;
 
@@ -407,8 +384,7 @@ where
         };
 
         if poll_state_value & NEED_TO_POLL_STREAM != NONE {
-            // Safety: now state is `POLLING`.
-            let stream_waker = unsafe { InnerWaker::replace_waker(this.stream_waker, cx) };
+            let mut stream_waker = None;
 
             // Here we need to poll the base stream.
             //
@@ -424,15 +400,24 @@ where
 
                     break;
                 } else {
-                    match this.stream.as_mut().poll_next(&mut Context::from_waker(&stream_waker)) {
+                    // Initialize base stream waker if it's not yet initialized
+                    if stream_waker.is_none() {
+                        // Safety: now state is `POLLING`.
+                        stream_waker
+                            .replace(unsafe { WrappedWaker::replace_waker(this.stream_waker, cx) });
+                    }
+                    let mut cx = Context::from_waker(stream_waker.as_ref().unwrap());
+
+                    match this.stream.as_mut().poll_next(&mut cx) {
                         Poll::Ready(Some(inner_stream)) => {
+                            let next_item_fut = PollStreamFut::new(Box::pin(inner_stream));
                             // Add new stream to the inner streams bucket
-                            this.inner_streams.as_mut().push(PollStreamFut::new(inner_stream));
+                            this.inner_streams.as_mut().push(next_item_fut);
                             // Inner streams must be polled afterward
                             poll_state_value |= NEED_TO_POLL_INNER_STREAMS;
                         }
                         Poll::Ready(None) => {
-                            // Mark the stream as done
+                            // Mark the base stream as done
                             *this.is_stream_done = true;
                         }
                         Poll::Pending => {
@@ -446,13 +431,10 @@ where
         if poll_state_value & NEED_TO_POLL_INNER_STREAMS != NONE {
             // Safety: now state is `POLLING`.
             let inner_streams_waker =
-                unsafe { InnerWaker::replace_waker(this.inner_streams_waker, cx) };
+                unsafe { WrappedWaker::replace_waker(this.inner_streams_waker, cx) };
+            let mut cx = Context::from_waker(&inner_streams_waker);
 
-            match this
-                .inner_streams
-                .as_mut()
-                .poll_next(&mut Context::from_waker(&inner_streams_waker))
-            {
+            match this.inner_streams.as_mut().poll_next(&mut cx) {
                 Poll::Ready(Some(Some((item, next_item_fut)))) => {
                     // Push next inner stream item future to the list of inner streams futures
                     this.inner_streams.as_mut().push(next_item_fut);
@@ -472,15 +454,16 @@ where
         // We didn't have any `poll_next` panic, so it's time to deactivate the bomb
         state_bomb.deactivate();
 
+        // Call the waker at the end of polling if
         let mut force_wake =
             // we need to poll the stream and didn't reach the limit yet
             need_to_poll_next & NEED_TO_POLL_STREAM != NONE && !this.is_exceeded_limit()
-            // or we need to poll inner streams again
+            // or we need to poll the inner streams again
             || need_to_poll_next & NEED_TO_POLL_INNER_STREAMS != NONE;
 
         // Stop polling and swap the latest state
         poll_state_value = this.poll_state.stop_polling(need_to_poll_next, force_wake);
-        // If state was changed during `POLLING` phase, need to manually call a waker
+        // If state was changed during `POLLING` phase, we also need to manually call a waker
         force_wake |= poll_state_value & NEED_TO_POLL_ALL != NONE;
 
         let is_done = *this.is_stream_done && this.inner_streams.is_empty();

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -219,7 +219,7 @@ delegate_all!(
     FlatMapUnordered<St, U, F>(
         FlattenUnordered<Map<St, F>>
     ): Debug + Sink + Stream + FusedStream + AccessInner[St, (. .)] + New[|x: St, limit: Option<usize>, f: F| FlattenUnordered::new(Map::new(x, f), limit)]
-    where St: Stream, U: Stream, F: FnMut(St::Item) -> U
+    where St: Stream, U: Stream, U: Unpin, F: FnMut(St::Item) -> U
 );
 
 #[cfg(not(futures_no_atomic_cas))]
@@ -832,7 +832,7 @@ pub trait StreamExt: Stream {
     #[cfg(feature = "alloc")]
     fn flatten_unordered(self, limit: impl Into<Option<usize>>) -> FlattenUnordered<Self>
     where
-        Self::Item: Stream,
+        Self::Item: Stream + Unpin,
         Self: Sized,
     {
         assert_stream::<<Self::Item as Stream>::Item, _>(FlattenUnordered::new(self, limit.into()))
@@ -918,7 +918,7 @@ pub trait StreamExt: Stream {
         f: F,
     ) -> FlatMapUnordered<Self, U, F>
     where
-        U: Stream,
+        U: Stream + Unpin,
         F: FnMut(Self::Item) -> U,
         Self: Sized,
     {

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -682,13 +682,10 @@ pub trait TryStreamExt: TryStream {
     /// ```
     #[cfg(not(futures_no_atomic_cas))]
     #[cfg(feature = "alloc")]
-    fn try_flatten_unordered<I, E>(
-        self,
-        limit: impl Into<Option<usize>>,
-    ) -> TryFlattenUnordered<Self, I, E>
+    fn try_flatten_unordered(self, limit: impl Into<Option<usize>>) -> TryFlattenUnordered<Self>
     where
-        Self::Ok: futures_core::Stream<Item = Result<I, E>> + Unpin,
-        E: From<Self::Error>,
+        Self::Ok: TryStream + Unpin,
+        <Self::Ok as TryStream>::Error: From<Self::Error>,
         Self: Sized,
     {
         assert_stream::<Result<<Self::Ok as TryStream>::Ok, <Self::Ok as TryStream>::Error>, _>(

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -99,7 +99,9 @@ mod try_flatten;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_flatten::TryFlatten;
 
+#[cfg(feature = "alloc")]
 mod try_flatten_unordered;
+#[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_flatten_unordered::TryFlattenUnordered;
 
@@ -676,6 +678,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(values, vec![Ok(1), Ok(2), Ok(4), Err(3), Err(5)]);
     /// # });
     /// ```
+    #[cfg(feature = "alloc")]
     fn try_flatten_unordered(self, limit: impl Into<Option<usize>>) -> TryFlattenUnordered<Self>
     where
         Self: TryStream,

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -687,7 +687,6 @@ pub trait TryStreamExt: TryStream {
         limit: impl Into<Option<usize>>,
     ) -> TryFlattenUnordered<Self, I, E>
     where
-        Self: TryStream,
         Self::Ok: futures_core::Stream<Item = Result<I, E>>,
         E: From<Self::Error>,
         Self: Sized,

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -14,6 +14,7 @@ use crate::stream::{assert_stream, Inspect, Map};
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::pin::Pin;
+use futures_core::Stream;
 use futures_core::{
     future::{Future, TryFuture},
     stream::TryStream,
@@ -97,6 +98,10 @@ pub use self::try_filter_map::TryFilterMap;
 mod try_flatten;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_flatten::TryFlatten;
+
+mod try_flatten_unordered;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::try_flatten_unordered::TryFlattenUnordered;
 
 mod try_collect;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
@@ -626,6 +631,63 @@ pub trait TryStreamExt: TryStream {
         Self: Sized,
     {
         assert_stream::<Result<T, Self::Error>, _>(TryFilterMap::new(self, f))
+    }
+
+    /// Flattens a stream of streams into just one continuous stream. Produced streams
+    /// will be polled concurrently and any errors are passed through without looking at them.
+    ///
+    /// The only argument is an optional limit on the number of concurrently
+    /// polled streams. If this limit is not `None`, no more than `limit` streams
+    /// will be polled at the same time. The `limit` argument is of type
+    /// `Into<Option<usize>>`, and so can be provided as either `None`,
+    /// `Some(10)`, or just `10`. Note: a limit of zero is interpreted as
+    /// no limit at all, and will have the same result as passing in `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::channel::mpsc;
+    /// use futures::stream::{StreamExt, TryStreamExt};
+    /// use std::thread;
+    ///
+    /// let (tx1, rx1) = mpsc::unbounded();
+    /// let (tx2, rx2) = mpsc::unbounded();
+    /// let (tx3, rx3) = mpsc::unbounded();
+    ///
+    /// thread::spawn(move || {
+    ///     tx1.unbounded_send(Ok(1)).unwrap();
+    /// });
+    /// thread::spawn(move || {
+    ///     tx2.unbounded_send(Ok(2)).unwrap();
+    ///     tx2.unbounded_send(Err(3)).unwrap();
+    ///     tx2.unbounded_send(Ok(4)).unwrap();
+    /// });
+    /// thread::spawn(move || {
+    ///     tx3.unbounded_send(Ok(rx1)).unwrap();
+    ///     tx3.unbounded_send(Ok(rx2)).unwrap();
+    ///     tx3.unbounded_send(Err(5)).unwrap();
+    /// });
+    ///
+    /// let stream = rx3.try_flatten_unordered(None);
+    /// let mut values: Vec<_> = stream.collect().await;
+    /// values.sort();
+    ///
+    /// assert_eq!(values, vec![Ok(1), Ok(2), Ok(4), Err(3), Err(5)]);
+    /// # });
+    /// ```
+    fn try_flatten_unordered(self, limit: impl Into<Option<usize>>) -> TryFlattenUnordered<Self>
+    where
+        Self: TryStream,
+        Self::Ok: TryStream
+            // Needed because either way compiler can't infer types properly...
+            + Stream<Item = Result<<Self::Ok as TryStream>::Ok, <Self::Ok as TryStream>::Error>>,
+        <Self::Ok as TryStream>::Error: From<Self::Error>,
+        Self: Sized,
+    {
+        assert_stream::<Result<<Self::Ok as TryStream>::Ok, <Self::Ok as TryStream>::Error>, _>(
+            TryFlattenUnordered::new(self, limit),
+        )
     }
 
     /// Flattens a stream of streams into just one continuous stream.

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -687,7 +687,7 @@ pub trait TryStreamExt: TryStream {
         limit: impl Into<Option<usize>>,
     ) -> TryFlattenUnordered<Self, I, E>
     where
-        Self::Ok: futures_core::Stream<Item = Result<I, E>>,
+        Self::Ok: futures_core::Stream<Item = Result<I, E>> + Unpin,
         E: From<Self::Error>,
         Self: Sized,
     {

--- a/futures-util/src/stream/try_stream/try_chunks.rs
+++ b/futures-util/src/stream/try_stream/try_chunks.rs
@@ -41,8 +41,10 @@ impl<St: TryStream> TryChunks<St> {
     delegate_access_inner!(stream, St, (. .));
 }
 
+type TryChunksStreamError<St> = TryChunksError<<St as TryStream>::Ok, <St as TryStream>::Error>;
+
 impl<St: TryStream> Stream for TryChunks<St> {
-    type Item = Result<Vec<St::Ok>, TryChunksError<St::Ok, St::Error>>;
+    type Item = Result<Vec<St::Ok>, TryChunksStreamError<St>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.as_mut().project();

--- a/futures-util/src/stream/try_stream/try_flatten_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_flatten_unordered.rs
@@ -114,7 +114,6 @@ impl<S, Item> Sink<Item> for TryFlattenSuccessful<S>
 where
     S: TryStream + Sink<Item>,
     S::Ok: TryStream,
-    S::Ok: Stream<Item = Result<<S::Ok as TryStream>::Ok, <S::Ok as TryStream>::Error>>,
     <S::Ok as TryStream>::Error: From<<S as TryStream>::Error>,
 {
     type Error = <S as Sink<Item>>::Error;

--- a/futures-util/src/stream/try_stream/try_flatten_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_flatten_unordered.rs
@@ -1,0 +1,123 @@
+use core::pin::Pin;
+
+use futures_core::ready;
+use futures_core::stream::{FusedStream, Stream, TryStream};
+use futures_core::task::{Context, Poll};
+#[cfg(feature = "sink")]
+use futures_sink::Sink;
+
+use pin_project_lite::pin_project;
+
+use crate::future::Either;
+use crate::stream::stream::FlattenUnordered;
+use crate::StreamExt;
+
+delegate_all!(
+    /// Stream for the [`try_flatten_unordered`](super::TryStreamExt::try_flatten_unordered) method.
+    TryFlattenUnordered<St>(
+        FlattenUnordered<TryFlattenSuccessful<St>>
+    ): Debug + Sink + Stream + FusedStream + AccessInner[St, (. .)]
+        + New[
+            |stream: St, limit: impl Into<Option<usize>>|
+                TryFlattenSuccessful::new(stream).flatten_unordered(limit)
+        ]
+    where
+        St: TryStream,
+        St::Ok: TryStream,
+        <St::Ok as TryStream>::Error: From<St::Error>,
+        // Needed because either way compiler can't infer types properly...
+        St::Ok: Stream<Item = Result<<St::Ok as TryStream>::Ok, <St::Ok as TryStream>::Error>>
+);
+
+pin_project! {
+    /// Flattens successful streams from the given stream, bubbling up the errors.
+    /// This's a wrapper for `TryFlattenUnordered` to reuse `FlattenUnordered` logic over `TryStream`.
+    #[derive(Debug)]
+    pub struct TryFlattenSuccessful<St> {
+        #[pin]
+        stream: St,
+    }
+}
+
+impl<St> TryFlattenSuccessful<St> {
+    fn new(stream: St) -> Self {
+        Self { stream }
+    }
+
+    delegate_access_inner!(stream, St, ());
+}
+
+impl<St> FusedStream for TryFlattenSuccessful<St>
+where
+    St: TryStream + FusedStream,
+    St::Ok: TryStream,
+    <St::Ok as TryStream>::Error: From<St::Error>,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
+    }
+}
+
+/// Emits one item immediately, then stream will be terminated.
+#[derive(Debug, Clone)]
+pub struct One<T>(Option<T>);
+
+impl<T> Unpin for One<T> {}
+
+impl<T> Stream for One<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Ready(self.0.take())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.as_ref().map_or((0, Some(0)), |_| (1, Some(1)))
+    }
+}
+
+type OneResult<St> = One<
+    Result<<<St as TryStream>::Ok as TryStream>::Ok, <<St as TryStream>::Ok as TryStream>::Error>,
+>;
+
+impl<St> Stream for TryFlattenSuccessful<St>
+where
+    St: TryStream,
+    St::Ok: TryStream,
+    <St::Ok as TryStream>::Error: From<St::Error>,
+{
+    // Item is either an inner stream or a stream containing a single error.
+    // This will allow using `Either`'s `Stream` implementation as both branches are actually streams of `Result`'s.
+    type Item = Either<St::Ok, OneResult<St>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let item = ready!(self.project().stream.try_poll_next(cx));
+
+        let out = item.map(|res| match res {
+            // Emit inner stream as is
+            Ok(stream) => Either::Left(stream),
+            // Wrap an error into stream wrapper containing one item
+            err @ Err(_) => {
+                let res = err.map(|_: St::Ok| unreachable!()).map_err(Into::into);
+
+                Either::Right(One(Some(res)))
+            }
+        });
+
+        Poll::Ready(out)
+    }
+}
+
+// Forwarding impl of Sink from the underlying stream
+#[cfg(feature = "sink")]
+impl<S, Item> Sink<Item> for TryFlattenSuccessful<S>
+where
+    S: TryStream + Sink<Item>,
+    S::Ok: TryStream,
+    S::Ok: Stream<Item = Result<<S::Ok as TryStream>::Ok, <S::Ok as TryStream>::Error>>,
+    <S::Ok as TryStream>::Error: From<<S as TryStream>::Error>,
+{
+    type Error = <S as Sink<Item>>::Error;
+
+    delegate_sink!(stream, Item);
+}

--- a/futures/tests/stream_try_stream.rs
+++ b/futures/tests/stream_try_stream.rs
@@ -54,6 +54,7 @@ fn try_flatten_unordered() {
                 Err(val)
             }
         })
+        .map_ok(Box::pin)
         .try_flatten_unordered(None);
 
     block_on(async move {

--- a/futures/tests/stream_try_stream.rs
+++ b/futures/tests/stream_try_stream.rs
@@ -42,14 +42,14 @@ fn try_take_while_after_err() {
 
 #[test]
 fn try_flatten_unordered() {
-    let s = stream::iter(1..5)
+    let s = stream::iter(1..7)
         .map(|val: u32| {
             if val % 2 == 0 {
                 Ok(stream::unfold((val, 1), |(val, pow)| async move {
                     Some((val.pow(pow), (val, pow + 1)))
                 })
                 .take(3)
-                .map(move |val| if val % 2 == 0 { Ok(val) } else { Err(val) }))
+                .map(move |val| if val % 16 != 0 { Ok(val) } else { Err(val) }))
             } else {
                 Err(val)
             }
@@ -58,7 +58,22 @@ fn try_flatten_unordered() {
 
     block_on(async move {
         assert_eq!(
-            vec![Err(1), Ok(2), Err(3), Ok(4), Ok(4), Ok(16), Ok(8), Ok(64)],
+            // All numbers can be divided by 16 and odds must be `Err`
+            // For all basic evens we must have powers from 1 to 3
+            vec![
+                Err(1),
+                Ok(2),
+                Err(3),
+                Ok(4),
+                Err(5),
+                Ok(6),
+                Ok(4),
+                Err(16),
+                Ok(36),
+                Ok(8),
+                Err(64),
+                Ok(216)
+            ],
             s.collect::<Vec<_>>().await
         )
     })


### PR DESCRIPTION
- Basic `TryFlattenUnordered` implementation atop of `FlattenUnordered`.
- ~Improve the `FlattenUnordered` interface by removing the `Unpin` requirement for `Self::Item`~. This's much more convenient and I guess it's a good choice for simplification despite a possibly unneeded `Pin<Box<_>>`.
- `FusedStream` impl for `FlattenUnordered`: remove unneeded `Self::Item: FusedStream` requirement.
- Minor improvement of the `FlattenUnordered` internal logic.
- Export all underlying types.
- Docs improvements.