### PR TITLE
Fix sentence in `try_buffered` docs.

### DIFF
--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -802,7 +802,7 @@ pub trait TryStreamExt: TryStream {
     /// that matches the stream's `Error` type.
     ///
     /// This adaptor will buffer up to `n` futures and then return their
-    /// outputs in the order. If the underlying stream returns an error, it will
+    /// outputs in the same order as the underlying stream. If the underlying stream returns an error, it will
     /// be immediately propagated.
     ///
     /// The limit argument is of type `Into<Option<usize>>`, and so can be


### PR DESCRIPTION
Updates the docs to use the same phrasing as `.buffered()` https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.buffered