### PR TITLE
Use setup-cross-toolchain-action instead of cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,24 @@ jobs:
       - run: cargo test --workspace --all-features --release
 
   cross:
-    name: cross test --target ${{ matrix.target }}
+    name: cargo test --target ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
         target:
-          - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-      - run: cross test --target ${{ matrix.target }} --workspace --all-features
-      - run: cross test --target ${{ matrix.target }} --workspace --all-features --release
-        # TODO: https://github.com/rust-lang/futures-rs/issues/2451
-        if: matrix.target != 'aarch64-unknown-linux-gnu'
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test --target ${{ matrix.target }} --workspace --all-features --release $DOCTEST_XCOMPILE
 
   core-msrv:
     name: cargo +${{ matrix.rust }} build (futures-{core, io, sink})

--- a/futures-test/src/task/mod.rs
+++ b/futures-test/src/task/mod.rs
@@ -23,7 +23,7 @@
 //! Test wakers:
 //! - [`noop_waker`](crate::task::noop_waker) creates a waker that ignores calls to
 //!   [`wake`](futures_core::task::Waker).
-//! - [`panic_waker`](crate::task::panic_waker) creates a waker that panics when
+//! - [`panic_waker`](crate::task::panic_waker()) creates a waker that panics when
 //!   [`wake`](futures_core::task::Waker) is called.
 //! - [`new_count_waker`](crate::task::new_count_waker) creates a waker that increments a counter whenever
 //!   [`wake`](futures_core::task::Waker) is called.


### PR DESCRIPTION
[setup-cross-toolchain-action](https://github.com/taiki-e/setup-cross-toolchain-action) is a GitHub Action to set up CI environment for cross-testing, including doctest, without dockers.

This also enables test for armv7hf on CI.

Closes #2451 (I guess it is due to old qemu which cross uses)