### PR TITLE
Add `select` benchmark

### DIFF
--- a/futures-util/benches/select.rs
+++ b/futures-util/benches/select.rs
@@ -1,0 +1,35 @@
+#![feature(test)]
+
+extern crate test;
+use crate::test::Bencher;
+
+use futures::executor::block_on;
+use futures::stream::{repeat, select, StreamExt};
+
+#[bench]
+fn select_streams(b: &mut Bencher) {
+    const STREAM_COUNT: usize = 10_000;
+
+    b.iter(|| {
+        let stream1 = repeat(1).take(STREAM_COUNT);
+        let stream2 = repeat(2).take(STREAM_COUNT);
+        let stream3 = repeat(3).take(STREAM_COUNT);
+        let stream4 = repeat(4).take(STREAM_COUNT);
+        let stream5 = repeat(5).take(STREAM_COUNT);
+        let stream6 = repeat(6).take(STREAM_COUNT);
+        let stream7 = repeat(7).take(STREAM_COUNT);
+        let count = block_on(async {
+            let count = select(
+                stream1,
+                select(
+                    stream2,
+                    select(stream3, select(stream4, select(stream5, select(stream6, stream7)))),
+                ),
+            )
+            .count()
+            .await;
+            count
+        });
+        assert_eq!(count, STREAM_COUNT * 7);
+    });
+}


### PR DESCRIPTION
I was trying to optimize `select`, by making it take data that implements a `Strategy` trait, instead of a closure. Didn't seem to work, but it seems like a good function to benchmark.

Next try will be to make it stop calling `.poll_next()` on a stream when it terminates, and removing the `Fuse` layer. Might just be that these details are getting lost in the noise though.