### PR TITLE
Several tweaks

### DIFF
--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -56,14 +56,14 @@ impl SharedPollState {
     }
 
     /// Attempts to start polling, returning stored state in case of success.
-    /// Returns `None` if some waker is waking at the moment.
+    /// Returns `None` if either waker is waking at the moment or state is empty.
     fn start_polling(
         &self,
     ) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&SharedPollState) -> u8>)> {
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
-                if value & WAKING == NONE {
+                if value & WAKING == NONE && value & NEED_TO_POLL_ALL != NONE {
                     Some(POLLING)
                 } else {
                     None
@@ -99,8 +99,10 @@ impl SharedPollState {
             })
             .ok()?;
 
+        debug_assert!(value & WAKING == NONE);
+
         // Only start the waking process if we're not in the polling phase and the stream isn't woken already
-        if value & (WOKEN | POLLING | WAKING) == NONE {
+        if value & (WOKEN | POLLING) == NONE {
             let bomb = PollStateBomb::new(self, SharedPollState::stop_waking);
 
             Some((value, bomb))
@@ -135,7 +137,8 @@ impl SharedPollState {
 
     /// Toggles state to non-waking, allowing to start polling.
     fn stop_waking(&self) -> u8 {
-        self.state
+        let value = self
+            .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
                 let next_value = value & !WAKING | WOKEN;
 
@@ -145,7 +148,10 @@ impl SharedPollState {
                     None
                 }
             })
-            .unwrap_or_else(identity)
+            .unwrap_or_else(identity);
+
+        debug_assert!(value & (WOKEN | POLLING | WAKING) == WAKING);
+        value
     }
 
     /// Resets current state allowing to poll the stream and wake up wakers.
@@ -169,11 +175,6 @@ impl<'a, F: FnOnce(&SharedPollState) -> u8> PollStateBomb<'a, F> {
     /// Deactivates bomb, forces it to not call provided function when dropped.
     fn deactivate(mut self) {
         self.drop.take();
-    }
-
-    /// Manually fires the bomb, returning supplied state.
-    fn fire(mut self) -> Option<u8> {
-        self.drop.take().map(|drop| (drop)(self.state))
     }
 }
 
@@ -225,13 +226,10 @@ impl ArcWake for WrappedWaker {
 
             if let Some(inner_waker) = waker_opt.clone() {
                 // Stop waking to allow polling stream
-                let poll_state_value = state_bomb.fire().unwrap();
+                drop(state_bomb);
 
-                // We want to call waker only if the stream isn't woken yet
-                if poll_state_value & (WOKEN | WAKING) == WAKING {
-                    // Wake up inner waker
-                    inner_waker.wake();
-                }
+                // Wake up inner waker
+                inner_waker.wake();
             }
         }
     }

--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -137,7 +137,7 @@ impl SharedPollState {
     fn stop_waking(&self) -> u8 {
         self.state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
-                let next_value = value & !WAKING;
+                let next_value = value & !WAKING | WOKEN;
 
                 if next_value != value {
                     Some(next_value)

--- a/futures-util/src/stream/try_stream/try_flatten_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_flatten_unordered.rs
@@ -27,7 +27,7 @@ delegate_all!(
         St: TryStream,
         St::Ok: TryStream,
         St::Ok: Unpin,
-         <St::Ok as TryStream>::Error: From<St::Error>
+        <St::Ok as TryStream>::Error: From<St::Error>
 );
 
 pin_project! {
@@ -40,7 +40,7 @@ pin_project! {
             St: TryStream,
             St::Ok: TryStream,
             St::Ok: Unpin,
-             <St::Ok as TryStream>::Error: From<St::Error>
+            <St::Ok as TryStream>::Error: From<St::Error>
         {
             #[pin]
             stream: St,

--- a/futures-util/src/stream/try_stream/try_flatten_unordered.rs
+++ b/futures-util/src/stream/try_stream/try_flatten_unordered.rs
@@ -121,10 +121,10 @@ where
 
 // Forwarding impl of Sink from the underlying stream
 #[cfg(feature = "sink")]
-impl<St, I, E, Item> Sink<Item> for TryStreamOfTryStreamsIntoHomogeneousStreamOfTryStreams<St>
+impl<St, Item> Sink<Item> for TryStreamOfTryStreamsIntoHomogeneousStreamOfTryStreams<St>
 where
     St: TryStream + Sink<Item>,
-    St::Ok: Stream<Item = Result<I, E>> + Unpin,
+    St::Ok: TryStream + Unpin,
     <St::Ok as TryStream>::Error: From<<St as TryStream>::Error>,
 {
     type Error = <St as Sink<Item>>::Error;


### PR DESCRIPTION
- One fix is for the requirements of `Sink` for `TryFlattenUnordreded` is to allow using any `TryStream` rather than just `Stream<Result<..>>`
- The other one is for `FlattenUnordredered` to reduce the possible amount of wake calls.