### PR TITLE
Make run_until_stalled handle self-waking futures

### DIFF
--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -256,11 +256,13 @@ impl LocalPool {
     /// in the pool will try to make progress.
     pub fn run_until_stalled(&mut self) {
         run_executor(|cx| match self.poll_pool(cx) {
+            // The pool is empty.
             Poll::Ready(()) => Poll::Ready(()),
             Poll::Pending => {
                 if woken() {
                     Poll::Pending
                 } else {
+                    // We're stalled for now.
                     Poll::Ready(())
                 }
             }

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -106,17 +106,9 @@ fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(mut f: F) -> T {
     })
 }
 
-fn poll_executor<T, F: FnMut(&mut Context<'_>) -> T>(mut f: F) -> T {
-    let _enter = enter().expect(
-        "cannot execute `LocalPool` executor from within \
-         another executor",
-    );
-
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| {
-        let waker = waker_ref(thread_notify);
-        let mut cx = Context::from_waker(&waker);
-        f(&mut cx)
-    })
+/// Check for a wakeup, but don't consume it.
+fn woken() -> bool {
+    CURRENT_THREAD_NOTIFY.with(|thread_notify| thread_notify.unparked.load(Ordering::SeqCst))
 }
 
 impl LocalPool {
@@ -212,20 +204,26 @@ impl LocalPool {
     /// further use of one of the pool's run or poll methods.
     /// Though only one task will be completed, progress may be made on multiple tasks.
     pub fn try_run_one(&mut self) -> bool {
-        poll_executor(|ctx| {
+        run_executor(|cx| {
             loop {
-                let ret = self.poll_pool_once(ctx);
+                self.drain_incoming();
 
-                // return if we have executed a future
-                if let Poll::Ready(Some(_)) = ret {
-                    return true;
+                match self.pool.poll_next_unpin(cx) {
+                    // Success!
+                    Poll::Ready(Some(())) => return Poll::Ready(true),
+                    // The pool was empty.
+                    Poll::Ready(None) => return Poll::Ready(false),
+                    Poll::Pending => (),
                 }
 
-                // if there are no new incoming futures
-                // then there is no feature that can make progress
-                // and we can return without having completed a single future
-                if self.incoming.borrow().is_empty() {
-                    return false;
+                if !self.incoming.borrow().is_empty() {
+                    // New tasks were spawned; try again.
+                    continue;
+                } else if woken() {
+                    // The pool yielded to us, but there's more progress to be made.
+                    return Poll::Pending;
+                } else {
+                    return Poll::Ready(false);
                 }
             }
         })
@@ -257,44 +255,50 @@ impl LocalPool {
     /// of the pool's run or poll methods. While the function is running, all tasks
     /// in the pool will try to make progress.
     pub fn run_until_stalled(&mut self) {
-        poll_executor(|ctx| {
-            let _ = self.poll_pool(ctx);
+        run_executor(|cx| match self.poll_pool(cx) {
+            Poll::Ready(()) => Poll::Ready(()),
+            Poll::Pending => {
+                if woken() {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }
         });
     }
 
-    // Make maximal progress on the entire pool of spawned task, returning `Ready`
-    // if the pool is empty and `Pending` if no further progress can be made.
+    /// Poll `self.pool`, re-filling it with any newly-spawned tasks.
+    /// Repeat until either the pool is empty, or it returns `Pending`.
+    ///
+    /// Returns `Ready` if the pool was empty, and `Pending` otherwise.
+    ///
+    /// NOTE: the pool may call `wake`, so `Pending` doesn't necessarily
+    /// mean that the pool can't make progress.
     fn poll_pool(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        // state for the FuturesUnordered, which will never be used
         loop {
-            let ret = self.poll_pool_once(cx);
+            self.drain_incoming();
 
-            // we queued up some new tasks; add them and poll again
+            let pool_ret = self.pool.poll_next_unpin(cx);
+
+            // We queued up some new tasks; add them and poll again.
             if !self.incoming.borrow().is_empty() {
                 continue;
             }
 
-            // no queued tasks; we may be done
-            match ret {
-                Poll::Pending => return Poll::Pending,
+            match pool_ret {
+                Poll::Ready(Some(())) => continue,
                 Poll::Ready(None) => return Poll::Ready(()),
-                _ => {}
+                Poll::Pending => return Poll::Pending,
             }
         }
     }
 
-    // Try make minimal progress on the pool of spawned tasks
-    fn poll_pool_once(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
-        // empty the incoming queue of newly-spawned tasks
-        {
-            let mut incoming = self.incoming.borrow_mut();
-            for task in incoming.drain(..) {
-                self.pool.push(task)
-            }
+    /// Empty the incoming queue of newly-spawned tasks.
+    fn drain_incoming(&mut self) {
+        let mut incoming = self.incoming.borrow_mut();
+        for task in incoming.drain(..) {
+            self.pool.push(task)
         }
-
-        // try to execute the next ready future
-        self.pool.poll_next_unpin(cx)
     }
 }
 

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -437,7 +437,7 @@ fn park_unpark_independence() {
 }
 
 struct SelfWaking {
-    wakeups_remaining: Arc<RefCell<usize>>,
+    wakeups_remaining: Rc<RefCell<usize>>,
 }
 
 impl Future for SelfWaking {

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -459,12 +459,12 @@ impl Future for SelfWaking {
 /// to exit early, even when progress could still be made.
 #[test]
 fn self_waking_run_until_stalled() {
-    let wakeups_remaining = Arc::new(RefCell::new(10));
+    let wakeups_remaining = Rc::new(RefCell::new(10));
 
     let mut pool = LocalPool::new();
     let spawner = pool.spawner();
     for _ in 0..3 {
-        let wakeups_remaining = Arc::clone(&wakeups_remaining);
+        let wakeups_remaining = Rc::clone(&wakeups_remaining);
         spawner.spawn_local(SelfWaking { wakeups_remaining }).unwrap();
     }
 
@@ -480,12 +480,12 @@ fn self_waking_run_until_stalled() {
 /// to exit early, even when progress could still be made.
 #[test]
 fn self_waking_try_run_one() {
-    let wakeups_remaining = Arc::new(RefCell::new(10));
+    let wakeups_remaining = Rc::new(RefCell::new(10));
 
     let mut pool = LocalPool::new();
     let spawner = pool.spawner();
     for _ in 0..3 {
-        let wakeups_remaining = Arc::clone(&wakeups_remaining);
+        let wakeups_remaining = Rc::clone(&wakeups_remaining);
         spawner.spawn_local(SelfWaking { wakeups_remaining }).unwrap();
     }
 


### PR DESCRIPTION
This fixes a bug in `LocalPool`'s `run_until_stalled` and `try_run_one`, where self-waking futures cause these methods to exit early.

The issue occurs when a future "yields" to the executor by simply waking its waker and returning `Pending`. As of #2551, when an underlying future "yields" in this way, the containing `FuturesUnordered` will do the same. Then, when this happens, the containing `LocalPool` assumes that this `Pending` means that the pool can't make any more progress.

<details>
<summary>repro</summary>

This [playground], where the output is:
```
`Pending(0)` polled!
`Pending(1)` polled!
```
But it should be:
```
`Pending(0)` polled!
`Pending(1)` polled!
`Pending(2)` polled!
`Ready` polled!
```
</details>

I believe this PR should fix it, but I'm new to open source (and async Rust) so feedback is welcome!

CC'ing @gmorenz who helped me track down the cause of the bug -- thanks Greg :)

[playground]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b4d238036a95b67260dbfb77b8b83b10