### PR TITLE
Add `WithContext` future that runs a closure with `task::Context`

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -68,6 +68,9 @@ pub use self::option::OptionFuture;
 mod poll_fn;
 pub use self::poll_fn::{poll_fn, PollFn};
 
+mod with_context;
+pub use self::with_context::{with_context, WithContext};
+
 mod poll_immediate;
 pub use self::poll_immediate::{poll_immediate, PollImmediate};
 

--- a/futures-util/src/future/with_context.rs
+++ b/futures-util/src/future/with_context.rs
@@ -1,0 +1,34 @@
+use super::assert_future;
+use core::pin::Pin;
+use futures_core::future::Future;
+use futures_core::task::{Context, Poll};
+
+/// Future for the [`with_context`] function.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+#[derive(Debug)]
+pub struct WithContext<F> {
+    f: Option<F>,
+}
+
+impl<F> Unpin for WithContext<F> {}
+
+/// Runs the closure `F` with the task [`Context`].
+///
+/// This can be used to, for example, poll futures by hand.
+pub fn with_context<F, R>(f: F) -> WithContext<F>
+where
+    F: FnOnce(&mut Context<'_>) -> R,
+{
+    assert_future(WithContext { f: Some(f) })
+}
+
+impl<F, R> Future for WithContext<F>
+where
+    F: FnOnce(&mut Context<'_>) -> R,
+{
+    type Output = R;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready((self.f.take().expect("WithContext polled after completion"))(cx))
+    }
+}


### PR DESCRIPTION
This PR adds `WithContext<F>` future and `with_context` function that run a closure with `task::Context`.
This can be used to, for example, [poll futures by hand](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=fe1ff8c37a916528d09a212ec37d4f1c).