### PR TITLE
Add stream selection early exit

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -100,10 +100,12 @@ mod poll_immediate;
 pub use self::poll_immediate::{poll_immediate, PollImmediate};
 
 mod select;
-pub use self::select::{select, Select};
+pub use self::select::{select, select_early_exit, Select};
 
 mod select_with_strategy;
-pub use self::select_with_strategy::{select_with_strategy, PollNext, SelectWithStrategy};
+pub use self::select_with_strategy::{
+    select_with_strategy, ExitStrategy, PollNext, SelectWithStrategy,
+};
 
 mod unfold;
 pub use self::unfold::{unfold, Unfold};

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -104,7 +104,7 @@ pub use self::select::{select, select_early_exit, Select};
 
 mod select_with_strategy;
 pub use self::select_with_strategy::{
-    select_with_strategy, ExitStrategy, PollNext, SelectWithStrategy,
+    select_with_strategy, ClosedStreams, ExitStrategy, PollNext, SelectWithStrategy,
 };
 
 mod unfold;

--- a/futures-util/src/stream/select.rs
+++ b/futures-util/src/stream/select.rs
@@ -1,18 +1,52 @@
 use super::assert_stream;
-use crate::stream::{select_with_strategy, ExitStrategy, PollNext, SelectWithStrategy};
+use crate::stream::{
+    select_with_strategy, ClosedStreams, ExitStrategy, PollNext, SelectWithStrategy,
+};
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
+type PollNextFn = fn(&mut PollNext) -> PollNext;
+
 pin_project! {
     /// Stream for the [`select()`] function.
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
-    pub struct Select<St1, St2> {
+    pub struct Select<St1, St2, Exit> {
         #[pin]
-        inner: SelectWithStrategy<St1, St2, fn(&mut PollNext)-> PollNext, PollNext>,
+        inner: SelectWithStrategy<St1, St2, PollNextFn, PollNext, Exit>,
     }
+}
+
+#[derive(Debug)]
+pub struct ExitWhenBothFinished {}
+
+impl ExitStrategy for ExitWhenBothFinished {
+    #[inline]
+    fn is_terminated(closed_streams: ClosedStreams) -> bool {
+        match closed_streams {
+            ClosedStreams::Both => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ExitWhenEitherFinished {}
+
+impl ExitStrategy for ExitWhenEitherFinished {
+    #[inline]
+    fn is_terminated(closed_streams: ClosedStreams) -> bool {
+        match closed_streams {
+            ClosedStreams::None => false,
+            _ => true,
+        }
+    }
+}
+
+fn round_robin(last: &mut PollNext) -> PollNext {
+    last.toggle()
 }
 
 /// This function will attempt to pull items from both streams. Each
@@ -44,42 +78,31 @@ pin_project! {
 /// }
 /// # });
 /// ```
-pub fn select<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2>
+pub fn select<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2, ExitWhenBothFinished>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
 {
-    select_with_exit(stream1, stream2, ExitStrategy::WhenBothFinish)
-}
-
-/// Same as `select`, but finishes when either stream finishes
-pub fn select_early_exit<St1, St2>(stream1: St1, stream2: St2) -> Select<St1, St2>
-where
-    St1: Stream,
-    St2: Stream<Item = St1::Item>,
-{
-    select_with_exit(stream1, stream2, ExitStrategy::WhenEitherFinish)
-}
-
-fn select_with_exit<St1, St2>(
-    stream1: St1,
-    stream2: St2,
-    exit_strategy: ExitStrategy,
-) -> Select<St1, St2>
-where
-    St1: Stream,
-    St2: Stream<Item = St1::Item>,
-{
-    fn round_robin(last: &mut PollNext) -> PollNext {
-        last.toggle()
-    }
-
     assert_stream::<St1::Item, _>(Select {
-        inner: select_with_strategy(stream1, stream2, round_robin, exit_strategy),
+        inner: select_with_strategy(stream1, stream2, round_robin),
     })
 }
 
-impl<St1, St2> Select<St1, St2> {
+/// Same as `select`, but finishes when either stream finishes
+pub fn select_early_exit<St1, St2>(
+    stream1: St1,
+    stream2: St2,
+) -> Select<St1, St2, ExitWhenEitherFinished>
+where
+    St1: Stream,
+    St2: Stream<Item = St1::Item>,
+{
+    assert_stream::<St1::Item, _>(Select {
+        inner: select_with_strategy(stream1, stream2, round_robin),
+    })
+}
+
+impl<St1, St2, Exit> Select<St1, St2, Exit> {
     /// Acquires a reference to the underlying streams that this combinator is
     /// pulling from.
     pub fn get_ref(&self) -> (&St1, &St2) {
@@ -114,20 +137,22 @@ impl<St1, St2> Select<St1, St2> {
     }
 }
 
-impl<St1, St2> FusedStream for Select<St1, St2>
+impl<St1, St2, Exit> FusedStream for Select<St1, St2, Exit>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
+    Exit: ExitStrategy,
 {
     fn is_terminated(&self) -> bool {
         self.inner.is_terminated()
     }
 }
 
-impl<St1, St2> Stream for Select<St1, St2>
+impl<St1, St2, Exit> Stream for Select<St1, St2, Exit>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
+    Exit: ExitStrategy,
 {
     type Item = St1::Item;
 

--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -1,4 +1,5 @@
 use super::assert_stream;
+use core::marker::PhantomData;
 use core::{fmt, pin::Pin};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -36,51 +37,40 @@ impl Default for PollNext {
     }
 }
 
-#[derive(PartialEq, Eq, Clone, Copy)]
-enum InternalState {
-    Start,
-    LeftFinished,
-    RightFinished,
-    BothFinished,
+/// Which streams are known to have finished?
+#[derive(PartialEq, Debug, Eq, Clone, Copy)]
+pub enum ClosedStreams {
+    /// Neither stream has finished
+    None,
+    /// The left stream has finished
+    Left,
+    /// The right stream has finished
+    Right,
+    /// Both streams have finished
+    Both,
 }
 
-impl InternalState {
+/// A trait for chosing to close the stream before both streams
+/// have finished.
+pub trait ExitStrategy {
+    /// Chose whether this stream is terminated based on the termination state of its
+    /// substreams.
+    fn is_terminated(closed_streams: ClosedStreams) -> bool;
+}
+
+impl ClosedStreams {
     fn finish(&mut self, ps: PollNext) {
         match (&self, ps) {
-            (InternalState::Start, PollNext::Left) => {
-                *self = InternalState::LeftFinished;
+            (ClosedStreams::None, PollNext::Left) => {
+                *self = ClosedStreams::Left;
             }
-            (InternalState::Start, PollNext::Right) => {
-                *self = InternalState::RightFinished;
+            (ClosedStreams::None, PollNext::Right) => {
+                *self = ClosedStreams::Right;
             }
-            (InternalState::LeftFinished, PollNext::Right)
-            | (InternalState::RightFinished, PollNext::Left) => {
-                *self = InternalState::BothFinished;
+            (ClosedStreams::Left, PollNext::Right) | (ClosedStreams::Right, PollNext::Left) => {
+                *self = ClosedStreams::Both;
             }
             _ => {}
-        }
-    }
-}
-
-/// Decides whether to exit when both streams are completed, or only one
-/// is completed. If you need to exit when a specific stream has finished,
-/// feel free to add a case here.
-#[derive(Clone, Copy, Debug)]
-pub enum ExitStrategy {
-    /// Select stream finishes when both substreams finish
-    WhenBothFinish,
-    /// Select stream finishes when either substream finishes
-    WhenEitherFinish,
-}
-
-impl ExitStrategy {
-    #[inline]
-    fn is_finished(self, state: InternalState) -> bool {
-        match (state, self) {
-            (InternalState::BothFinished, _) => true,
-            (InternalState::Start, ExitStrategy::WhenEitherFinish) => false,
-            (_, ExitStrategy::WhenBothFinish) => false,
-            _ => true,
         }
     }
 }
@@ -89,15 +79,15 @@ pin_project! {
     /// Stream for the [`select_with_strategy()`] function. See function docs for details.
     #[must_use = "streams do nothing unless polled"]
     #[project = SelectWithStrategyProj]
-    pub struct SelectWithStrategy<St1, St2, Clos, State> {
+    pub struct SelectWithStrategy<St1, St2, Clos, State, Exit> {
         #[pin]
         stream1: St1,
         #[pin]
         stream2: St2,
-        internal_state: InternalState,
+        closed_streams: ClosedStreams,
         state: State,
         clos: Clos,
-        exit_strategy: ExitStrategy,
+        _marker: PhantomData<Exit>,
     }
 }
 
@@ -120,7 +110,8 @@ pin_project! {
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
-/// use futures::stream::{ repeat, select_with_strategy, PollNext, StreamExt, ExitStrategy };
+/// use futures::stream::{ repeat, select_with_strategy, PollNext, StreamExt,
+///     ClosedStreams, ExitStrategy, SelectWithStrategy };
 ///
 /// let left = repeat(1);
 /// let right = repeat(2);
@@ -131,7 +122,18 @@ pin_project! {
 /// // use a function pointer instead of a closure.
 /// fn prio_left(_: &mut ()) -> PollNext { PollNext::Left }
 ///
-/// let mut out = select_with_strategy(left, right, prio_left, ExitStrategy::WhenBothFinish);
+/// struct ExitWhenBothFinished {}
+///
+/// impl ExitStrategy for ExitWhenBothFinished {
+///     fn is_terminated(closed_streams: ClosedStreams) -> bool {
+///         match closed_streams {
+///             ClosedStreams::Both => true,
+///             _ => false,
+///         }
+///     }
+/// }
+///
+/// let mut out: SelectWithStrategy<_, _, _, _, ExitWhenBothFinished> = select_with_strategy(left, right, prio_left);
 ///
 /// for _ in 0..100 {
 ///     // Whenever we poll out, we will always get `1`.
@@ -142,11 +144,34 @@ pin_project! {
 ///
 /// ### Round Robin
 /// This example shows how to select from both streams round robin.
-/// Note: this special case is provided by [`futures-util::stream::select`].
+/// Note: these special cases are provided by [`futures-util::stream::select`].
 ///
 /// ```rust
 /// # futures::executor::block_on(async {
-/// use futures::stream::{ repeat, select_with_strategy, FusedStream, PollNext, StreamExt, ExitStrategy };
+/// use futures::stream::{ repeat, select_with_strategy, FusedStream, PollNext, StreamExt,
+///     ClosedStreams, ExitStrategy, SelectWithStrategy };
+///
+/// struct ExitWhenBothFinished {}
+///
+/// impl ExitStrategy for ExitWhenBothFinished {
+///     fn is_terminated(closed_streams: ClosedStreams) -> bool {
+///         match closed_streams {
+///             ClosedStreams::Both => true,
+///             _ => false,
+///         }
+///     }
+/// }
+///
+/// struct ExitWhenEitherFinished {}
+///
+/// impl ExitStrategy for ExitWhenEitherFinished {
+///     fn is_terminated(closed_streams: ClosedStreams) -> bool {
+///         match closed_streams {
+///             ClosedStreams::None => false,
+///             _ => true,
+///         }
+///     }
+/// }
 ///
 /// // Finishes when both streams finish
 /// {
@@ -155,7 +180,7 @@ pin_project! {
 ///
 ///     let rrobin = |last: &mut PollNext| last.toggle();
 ///
-///     let mut out = select_with_strategy(left, right, rrobin, ExitStrategy::WhenBothFinish);
+///     let mut out: SelectWithStrategy<_, _, _, _, ExitWhenBothFinished> = select_with_strategy(left, right, rrobin);
 ///
 ///     for _ in 0..10 {
 ///         // We should be alternating now.
@@ -176,7 +201,7 @@ pin_project! {
 ///
 ///     let rrobin = |last: &mut PollNext| last.toggle();
 ///
-///     let mut out = select_with_strategy(left, right, rrobin, ExitStrategy::WhenEitherFinish);
+///     let mut out: SelectWithStrategy<_, _, _, _, ExitWhenEitherFinished>  = select_with_strategy(left, right, rrobin);
 ///
 ///     for _ in 0..10 {
 ///         // We should be alternating now.
@@ -189,29 +214,29 @@ pin_project! {
 /// # });
 /// ```
 ///
-pub fn select_with_strategy<St1, St2, Clos, State>(
+pub fn select_with_strategy<St1, St2, Clos, State, Exit>(
     stream1: St1,
     stream2: St2,
     which: Clos,
-    exit_strategy: ExitStrategy,
-) -> SelectWithStrategy<St1, St2, Clos, State>
+) -> SelectWithStrategy<St1, St2, Clos, State, Exit>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
     Clos: FnMut(&mut State) -> PollNext,
     State: Default,
+    Exit: ExitStrategy,
 {
     assert_stream::<St1::Item, _>(SelectWithStrategy {
         stream1,
         stream2,
         state: Default::default(),
-        internal_state: InternalState::Start,
         clos: which,
-        exit_strategy,
+        closed_streams: ClosedStreams::None,
+        _marker: PhantomData,
     })
 }
 
-impl<St1, St2, Clos, State> SelectWithStrategy<St1, St2, Clos, State> {
+impl<St1, St2, Clos, State, Exit> SelectWithStrategy<St1, St2, Clos, State, Exit> {
     /// Acquires a reference to the underlying streams that this combinator is
     /// pulling from.
     pub fn get_ref(&self) -> (&St1, &St2) {
@@ -246,20 +271,21 @@ impl<St1, St2, Clos, State> SelectWithStrategy<St1, St2, Clos, State> {
     }
 }
 
-impl<St1, St2, Clos, State> FusedStream for SelectWithStrategy<St1, St2, Clos, State>
+impl<St1, St2, Clos, State, Exit> FusedStream for SelectWithStrategy<St1, St2, Clos, State, Exit>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
     Clos: FnMut(&mut State) -> PollNext,
+    Exit: ExitStrategy,
 {
     fn is_terminated(&self) -> bool {
-        self.exit_strategy.is_finished(self.internal_state)
+        Exit::is_terminated(self.closed_streams)
     }
 }
 
 #[inline]
-fn poll_side<St1, St2, Clos, State>(
-    select: &mut SelectWithStrategyProj<'_, St1, St2, Clos, State>,
+fn poll_side<St1, St2, Clos, State, Exit>(
+    select: &mut SelectWithStrategyProj<'_, St1, St2, Clos, State, Exit>,
     side: PollNext,
     cx: &mut Context<'_>,
 ) -> Poll<Option<St1::Item>>
@@ -274,21 +300,21 @@ where
 }
 
 #[inline]
-fn poll_inner<St1, St2, Clos, State>(
-    select: &mut SelectWithStrategyProj<'_, St1, St2, Clos, State>,
+fn poll_inner<St1, St2, Clos, State, Exit>(
+    select: &mut SelectWithStrategyProj<'_, St1, St2, Clos, State, Exit>,
     side: PollNext,
     cx: &mut Context<'_>,
-    exit_strat: ExitStrategy,
 ) -> Poll<Option<St1::Item>>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
+    Exit: ExitStrategy,
 {
     match poll_side(select, side, cx) {
         Poll::Ready(Some(item)) => return Poll::Ready(Some(item)),
         Poll::Ready(None) => {
-            select.internal_state.finish(side);
-            if exit_strat.is_finished(*select.internal_state) {
+            select.closed_streams.finish(side);
+            if Exit::is_terminated(*select.closed_streams) {
                 return Poll::Ready(None);
             }
         }
@@ -297,54 +323,54 @@ where
     let other = side.other();
     match poll_side(select, other, cx) {
         Poll::Ready(None) => {
-            select.internal_state.finish(other);
+            select.closed_streams.finish(other);
             Poll::Ready(None)
         }
         a => a,
     }
 }
 
-impl<St1, St2, Clos, State> Stream for SelectWithStrategy<St1, St2, Clos, State>
+impl<St1, St2, Clos, State, Exit> Stream for SelectWithStrategy<St1, St2, Clos, State, Exit>
 where
     St1: Stream,
     St2: Stream<Item = St1::Item>,
     Clos: FnMut(&mut State) -> PollNext,
+    Exit: ExitStrategy,
 {
     type Item = St1::Item;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St1::Item>> {
-        let mut this = self.project();
-        let exit_strategy: ExitStrategy = *this.exit_strategy;
-
-        if exit_strategy.is_finished(*this.internal_state) {
+        if self.is_terminated() {
             return Poll::Ready(None);
         }
 
-        match this.internal_state {
-            InternalState::Start => {
+        let mut this = self.project();
+
+        match this.closed_streams {
+            ClosedStreams::None => {
                 let next_side = (this.clos)(this.state);
-                poll_inner(&mut this, next_side, cx, exit_strategy)
+                poll_inner(&mut this, next_side, cx)
             }
-            InternalState::LeftFinished => match this.stream2.poll_next(cx) {
+            ClosedStreams::Left => match this.stream2.poll_next(cx) {
                 Poll::Ready(None) => {
-                    *this.internal_state = InternalState::BothFinished;
+                    *this.closed_streams = ClosedStreams::Both;
                     Poll::Ready(None)
                 }
                 a => a,
             },
-            InternalState::RightFinished => match this.stream1.poll_next(cx) {
+            ClosedStreams::Right => match this.stream1.poll_next(cx) {
                 Poll::Ready(None) => {
-                    *this.internal_state = InternalState::BothFinished;
+                    *this.closed_streams = ClosedStreams::Both;
                     Poll::Ready(None)
                 }
                 a => a,
             },
-            InternalState::BothFinished => Poll::Ready(None),
+            ClosedStreams::Both => Poll::Ready(None),
         }
     }
 }
 
-impl<St1, St2, Clos, State> fmt::Debug for SelectWithStrategy<St1, St2, Clos, State>
+impl<St1, St2, Clos, State, Exit> fmt::Debug for SelectWithStrategy<St1, St2, Clos, State, Exit>
 where
     St1: fmt::Debug,
     St2: fmt::Debug,

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -1536,15 +1536,15 @@ pub mod stream {
     assert_not_impl!(Scan<PinnedStream, (), (), ()>: Unpin);
     assert_not_impl!(Scan<UnpinStream, (), PhantomPinned, ()>: Unpin);
 
-    assert_impl!(Select<(), ()>: Send);
-    assert_not_impl!(Select<*const (), ()>: Send);
-    assert_not_impl!(Select<(), *const ()>: Send);
-    assert_impl!(Select<(), ()>: Sync);
-    assert_not_impl!(Select<*const (), ()>: Sync);
-    assert_not_impl!(Select<(), *const ()>: Sync);
-    assert_impl!(Select<(), ()>: Unpin);
-    assert_not_impl!(Select<PhantomPinned, ()>: Unpin);
-    assert_not_impl!(Select<(), PhantomPinned>: Unpin);
+    assert_impl!(Select<(), (), ()>: Send);
+    assert_not_impl!(Select<*const (), (), ()>: Send);
+    assert_not_impl!(Select<(), *const (), ()>: Send);
+    assert_impl!(Select<(), (), ()>: Sync);
+    assert_not_impl!(Select<*const (), (), ()>: Sync);
+    assert_not_impl!(Select<(), *const (), ()>: Sync);
+    assert_impl!(Select<(), (), ()>: Unpin);
+    assert_not_impl!(Select<PhantomPinned, (), ()>: Unpin);
+    assert_not_impl!(Select<(), PhantomPinned, ()>: Unpin);
 
     assert_impl!(SelectAll<()>: Send);
     assert_not_impl!(SelectAll<*const ()>: Send);

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -26,6 +26,22 @@ fn select() {
 }
 
 #[test]
+fn select_early_exit() {
+    fn select_and_compare(a: Vec<u32>, b: Vec<u32>, expected: Vec<u32>) {
+        let a = stream::iter(a);
+        let b = stream::iter(b);
+        let vec = block_on(stream::select_early_exit(a, b).collect::<Vec<_>>());
+        assert_eq!(vec, expected);
+    }
+
+    select_and_compare(vec![1, 2, 3], vec![4, 5, 6], vec![1, 4, 2, 5, 3, 6]);
+    select_and_compare(vec![], vec![4, 5], vec![]);
+    select_and_compare(vec![4, 5], vec![], vec![4]);
+    select_and_compare(vec![1, 2, 3], vec![4, 5], vec![1, 4, 2, 5, 3]);
+    select_and_compare(vec![1, 2], vec![4, 5, 6], vec![1, 4, 2, 5]);
+}
+
+#[test]
 fn flat_map() {
     block_on(async {
         let st =


### PR DESCRIPTION
`select_early_exit` creates a stream that produces elements while either substream contains elements, and terminates when either substream runs out of elements.

## Previous work

https://github.com/rust-lang/futures-rs/pull/1881
https://github.com/rust-lang/futures-rs/pull/1422

## Benchmarks:

| Old | New |
| --- | --- |
| 1,065,438ns/iter | 1,159,341ns/iter |

Performance hit: +8.8%.

The `select_streams` [benchmark](https://github.com/rust-lang/futures-rs/pull/2582/files) is quite contrived, using long streams nested deeply under multiple `Select`s to produce statistically significant results. As such, I'm happy with the +8.8% performance hit, and would prefer it over a separate version of `SelectWithStrategy` just for early exit.

Side note, if you leave out the `#[inline]` over the `is_finished` function, you get `1,830,713ns/iter`, or a +71.8% performance hit.

I've tried to specialize `SelectWithStrategy` over an exit strategy trait in [this branch](https://github.com/414owen/futures-rs/tree/early-exit-streams-as-type-param), but surprisingly, got a small performance hit.

I can't say for sure what's going on, but my best guess is that the performance difference between this branch and the one linked above is due to a layout change, rather than how the logic is encoded.

It would be possible to use something like [`stabilizer`](https://github.com/ccurtsinger/stabilizer) to know for sure, but I doubt we actually want to go that deep on this.