### PR TITLE
Fix rustdoc::broken_intra_doc_links warning

### DIFF
--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -302,6 +302,9 @@ pub trait TryFutureExt: TryFuture {
     /// assert_eq!(future.await, Ok(1));
     /// # });
     /// ```
+    ///
+    /// [`join!`]: crate::join
+    /// [`select!`]: crate::select
     fn map_err<E, F>(self, f: F) -> MapErr<Self, F>
     where
         F: FnOnce(Self::Error) -> E,
@@ -332,6 +335,9 @@ pub trait TryFutureExt: TryFuture {
     /// let future_err_i32 = future_err_u8.err_into::<i32>();
     /// # });
     /// ```
+    ///
+    /// [`join!`]: crate::join
+    /// [`select!`]: crate::select
     fn err_into<E>(self) -> ErrInto<Self, E>
     where
         Self: Sized,

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1839,6 +1839,8 @@ pub trait StreamExt: Stream {
     /// assert_eq!(total, 6);
     /// # });
     /// ```
+    ///
+    /// [`select!`]: crate::select
     fn select_next_some(&mut self) -> SelectNextSome<'_, Self>
     where
         Self: Unpin + FusedStream,


### PR DESCRIPTION
```
error: unresolved link to `select`
   --> futures-util/src/future/try_future/mod.rs:272:17
    |
272 |     /// using [`select!`] or [`join!`].
    |                 ^^^^^^^ no item named `select` in scope
    |
    = note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
    = note: `macro_rules` named `select` exists in this crate, but it is not in scope at this link's location

error: unresolved link to `join`
   --> futures-util/src/future/try_future/mod.rs:272:32
    |
272 |     /// using [`select!`] or [`join!`].
    |                                ^^^^^ no item named `join` in scope
    |
    = note: `macro_rules` named `join` exists in this crate, but it is not in scope at this link's location

error: unresolved link to `select`
   --> futures-util/src/future/try_future/mod.rs:320:27
    |
320 |     /// type when using [`select!`] or [`join!`].
    |                           ^^^^^^^ no item named `select` in scope
    |
    = note: `macro_rules` named `select` exists in this crate, but it is not in scope at this link's location

error: unresolved link to `join`
   --> futures-util/src/future/try_future/mod.rs:320:42
    |
320 |     /// type when using [`select!`] or [`join!`].
    |                                          ^^^^^ no item named `join` in scope
    |
    = note: `macro_rules` named `join` exists in this crate, but it is not in scope at this link's location

error: unresolved link to `select`
    --> futures-util/src/stream/stream/mod.rs:1802:15
     |
1802 |     /// the [`select!`] macro.
     |               ^^^^^^^ no item named `select` in scope
     |
     = note: `macro_rules` named `select` exists in this crate, but it is not in scope at this link's location
```