### PR TITLE
Fix minor typo in enter doc comment

### DIFF
--- a/futures-executor/src/enter.rs
+++ b/futures-executor/src/enter.rs
@@ -34,7 +34,7 @@ impl std::error::Error for EnterError {}
 /// executor.
 ///
 /// Executor implementations should call this function before beginning to
-/// execute a tasks, and drop the returned [`Enter`](Enter) value after
+/// execute a task, and drop the returned [`Enter`](Enter) value after
 /// completing task execution:
 ///
 /// ```


### PR DESCRIPTION
Fixes a minor typo by changing "a tasks" to "a task" in the
documentation comment for enter.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>