### PR TITLE
for_each(_concurrent): Return the number of completed stream futures

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1093,16 +1093,14 @@ pub trait StreamExt: Stream {
     /// let step_size = 2;
     /// let count = 3;
     ///
-    /// let x = AtomicUsize::new(0);
+    /// let x = &AtomicUsize::new(0);
     ///
-    /// let num_completed = {
-    ///     let x = &x;
-    ///     stream::repeat(step_size).take(count).for_each(|item| async move {
-    ///         x.fetch_add(item, Ordering::SeqCst);
-    ///     }).await
-    /// };
+    /// let fut = stream::repeat(step_size).take(count).for_each(|item| async move {
+    ///     x.fetch_add(item, Ordering::Relaxed);
+    /// });
+    /// let num_completed = fut.await;
     ///
-    /// assert_eq!(x.load(Ordering::SeqCst), step_size * count);
+    /// assert_eq!(x.load(Ordering::Relaxed), step_size * count);
     /// assert_eq!(num_completed, count);
     /// # });
     /// ```


### PR DESCRIPTION
Keeping track of the number of completed stream futures comes at almost zero cost. It improves the versatility of these functions as the number of futures yielded by the stream is usually not known in advance. The caller would otherwise need to use an atomic counter to determine it.

Extending the corresponding `try_` variants accordingly seems legit but turns out to be convoluted. The number of completed stream futures would be relevant in case of both an `Ok` and an `Err` result.