### PR TITLE
`doc(alias)` `pending()` to `never`

### DIFF
--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -33,7 +33,7 @@ impl<T> FusedFuture for Pending<T> {
 /// unreachable!();
 /// # });
 /// ```
-#[doc(alias = "never")]
+#[cfg_attr(docsrs, doc(alias = "never"))]
 pub fn pending<T>() -> Pending<T> {
     assert_future::<T, _>(Pending { _data: marker::PhantomData })
 }

--- a/futures-util/src/future/pending.rs
+++ b/futures-util/src/future/pending.rs
@@ -33,6 +33,7 @@ impl<T> FusedFuture for Pending<T> {
 /// unreachable!();
 /// # });
 /// ```
+#[doc(alias = "never")]
 pub fn pending<T>() -> Pending<T> {
     assert_future::<T, _>(Pending { _data: marker::PhantomData })
 }


### PR DESCRIPTION
It can be legitimate to look for the future that _never_ resolves using the name `never`. This PR ensures `pending()` shows up when making such queries.

cc @conradludgate