### PR TITLE
Include crate version for dev-dependencies

### DIFF
--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -21,8 +21,8 @@ futures-core = { path = "../futures-core", version = "=1.0.0-alpha.0", default-f
 futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", default-features = true }
-futures-test = { path = "../futures-test", default-features = true }
+futures = { path = "../futures", version = "=0.4.0-alpha.0", default-features = true }
+futures-test = { path = "../futures-test", version = "=0.4.0-alpha.0", default-features = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -18,7 +18,7 @@ alloc = []
 [dependencies]
 
 [dev-dependencies]
-futures = { path = "../futures" }
+futures = { path = "../futures", version = "=0.4.0-alpha.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { path = "../futures-util", version = "=0.4.0-alpha.0", default-f
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]
-futures = { path = "../futures", features = ["thread-pool"] }
+futures = { path = "../futures", version = "=0.4.0-alpha.0", features = ["thread-pool"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -18,7 +18,7 @@ alloc = []
 [dependencies]
 
 [dev-dependencies]
-futures = { path = "../futures" }
+futures = { path = "../futures", version = "=0.4.0-alpha.0" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -22,7 +22,7 @@ pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.1"
 
 [dev-dependencies]
-futures = { path = "../futures", default-features = false, features = ["std", "executor"] }
+futures = { path = "../futures", version = "=0.4.0-alpha.0", default-features = false, features = ["std", "executor"] }
 
 [features]
 default = ["std"]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -44,8 +44,8 @@ pin-utils = "0.1.0"
 pin-project-lite = "0.2.6"
 
 [dev-dependencies]
-futures = { path = "../futures", features = ["async-await", "thread-pool"] }
-futures-test = { path = "../futures-test" }
+futures = { path = "../futures", version = "=0.4.0-alpha.0", features = ["async-await", "thread-pool"] }
+futures-test = { path = "../futures-test", version = "=0.4.0-alpha.0" }
 tokio = "0.1.11"
 
 [package.metadata.docs.rs]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = { path = "../futures-util", version = "=0.4.0-alpha.0", default-f
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }
-futures-test = { path = "../futures-test" }
+futures-test = { path = "../futures-test", version = "=0.4.0-alpha.0" }
 assert_matches = "1.3.0"
 pin-project = "1.0.1"
 pin-utils = "0.1.0"


### PR DESCRIPTION
This ensures that test dependencies are included in the Cargo.toml
that is published to crates.io.

As noted in the Cargo book:
When a package is published, only dev-dependencies that specify a
version will be included in the published crate. For most use cases,
dev-dependencies are not needed when published, though some users
(like OS packagers) may want to run tests within a crate, so
providing a version if possible can still be beneficial.

This is helpful for running tests in the Android Open Source Project,
which uses crates.io as its source of truth, and prevents having to
carry local patches.

Test: cargo publish --dry-run
Confirm that dev-dependencies are listed in the resulting
Cargo.toml.