### PR TITLE
Inline WakerRef functions

### DIFF
--- a/futures-task/src/waker_ref.rs
+++ b/futures-task/src/waker_ref.rs
@@ -18,6 +18,7 @@ pub struct WakerRef<'a> {
 
 impl<'a> WakerRef<'a> {
     /// Create a new [`WakerRef`] from a [`Waker`] reference.
+    #[inline]
     pub fn new(waker: &'a Waker) -> Self {
         // copy the underlying (raw) waker without calling a clone,
         // as we won't call Waker::drop either.
@@ -31,6 +32,7 @@ impl<'a> WakerRef<'a> {
     /// an unsafe way (that will be valid only for a lifetime to be determined
     /// by the caller), and the [`Waker`] doesn't need to or must not be
     /// destroyed.
+    #[inline]
     pub fn new_unowned(waker: ManuallyDrop<Waker>) -> Self {
         Self { waker, _marker: PhantomData }
     }
@@ -39,6 +41,7 @@ impl<'a> WakerRef<'a> {
 impl Deref for WakerRef<'_> {
     type Target = Waker;
 
+    #[inline]
     fn deref(&self) -> &Waker {
         &self.waker
     }


### PR DESCRIPTION
Those functions are trivial and non-generic. It's necessary to use `#[inline]` to enable cross-crate inlining for non-generic functions when LTO is disabled.

See also https://internals.rust-lang.org/t/will-it-ever-be-possible-to-optimize-away-trivial-futures/17060/5?u=xfix