### PR TITLE
Release 0.3.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,12 @@ on:
     tags:
       - '[0-9]+.*'
 
-env:
-  RUSTFLAGS: -D warnings
-  RUST_BACKTRACE: 1
-
 jobs:
   create-release:
     if: github.repository_owner == 'rust-lang'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo build --all
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.3.22 - 2022-08-14
+
+* Fix `Sync` impl of `BiLockGuard` (#2570)
+* Fix partial iteration in `FuturesUnordered` (#2574)
+* Fix false detection of inner panics in `Shared` (#2576)
+* Add `Mutex::lock_owned` and `Mutex::try_lock_owned` (#2571)
+* Add `io::copy_buf_abortable` (#2507)
+* Remove `Unpin` bound from `TryStreamExt::into_async_read` (#2599)
+* Make `run_until_stalled` handle self-waking futures (#2593)
+* Use `FuturesOrdered` in `try_join_all` (#2556)
+* Fix orderings in `LocalPool` waker (#2608)
+* Fix `stream::Chunk` adapters size hints (#2611)
+* Add `push_front` and `push_back` to `FuturesOrdered` (#2591)
+* Deprecate `FuturesOrdered::push` in favor of `FuturesOrdered::push_back` (#2591)
+* Performance improvements (#2583, #2626)
+* Documentation improvements (#2579, #2604, #2613)
+
 # 0.3.21 - 2022-02-06
 
 * Fix potential data race in `FlattenUnordered` that introduced in 0.3.20 (#2566)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.21", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.21", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.22", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.22", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.21", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.21", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.21", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.22", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.22", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.22", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -104,7 +104,7 @@ fn run_executor<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(mut f: F) -> T {
 
 /// Check for a wakeup, but don't consume it.
 fn woken() -> bool {
-    CURRENT_THREAD_NOTIFY.with(|thread_notify| thread_notify.unparked.load(Ordering::SeqCst))
+    CURRENT_THREAD_NOTIFY.with(|thread_notify| thread_notify.unparked.load(Ordering::Acquire))
 }
 
 impl LocalPool {

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.21", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.21", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.21", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.21", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.21", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.21", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.21", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.22", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.22", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.22", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.22", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.22", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.22", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.22", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.11"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -34,12 +34,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.21", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.21", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.21", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.21", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.21", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.21", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.22", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.22", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.22", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.22", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.22", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.22", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.21", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.21", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.21", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.21", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.21", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.21", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.21", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.22", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.22", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.22", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.22", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.22", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.22", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.22", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }


### PR DESCRIPTION

* Fix `Sync` impl of `BiLockGuard` (#2570)
* Fix partial iteration in `FuturesUnordered` (#2574)
* Fix false detection of inner panics in `Shared` (#2576)
* Add `Mutex::lock_owned` and `Mutex::try_lock_owned` (#2571)
* Add `io::copy_buf_abortable` (#2507)
* Remove `Unpin` bound from `TryStreamExt::into_async_read` (#2599)
* Make `run_until_stalled` handle self-waking futures (#2593)
* Use `FuturesOrdered` in `try_join_all` (#2556)
* Fix orderings in `LocalPool` waker (#2608)
* Fix `stream::Chunk` adapters size hints (#2611)
* Add `push_front` and `push_back` to `FuturesOrdered` (#2591)
* Deprecate `FuturesOrdered::push` in favor of `FuturesOrdered::push_back` (#2591)
* Performance improvements (#2583, #2626)
* Documentation improvements (#2579, #2604, #2613)
