### PR TITLE
remove some double trait bounds

### DIFF
--- a/futures-util/src/stream/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/stream/buffer_unordered.rs
@@ -42,11 +42,7 @@ where
     St: Stream,
     St::Item: Future,
 {
-    pub(super) fn new(stream: St, n: Option<usize>) -> Self
-    where
-        St: Stream,
-        St::Item: Future,
-    {
+    pub(super) fn new(stream: St, n: Option<usize>) -> Self {
         Self {
             stream: super::Fuse::new(stream),
             in_progress_queue: FuturesUnordered::new(),

--- a/futures-util/src/stream/stream/chunks.rs
+++ b/futures-util/src/stream/stream/chunks.rs
@@ -21,10 +21,7 @@ pin_project! {
     }
 }
 
-impl<St: Stream> Chunks<St>
-where
-    St: Stream,
-{
+impl<St: Stream> Chunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -20,10 +20,7 @@ pin_project! {
     }
 }
 
-impl<St: Stream> ReadyChunks<St>
-where
-    St: Stream,
-{
+impl<St: Stream> ReadyChunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

Make the code clear.

I guess it's better to be a clippy rule, but at least we can make it cleaner manually.