### PR TITLE
Fix soundness hole in join macros

### DIFF
--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -352,14 +352,14 @@ fn join_size() {
         let ready = future::ready(0i32);
         join!(ready)
     };
-    assert_eq!(mem::size_of_val(&fut), 12);
+    assert_eq!(mem::size_of_val(&fut), 24);
 
     let fut = async {
         let ready1 = future::ready(0i32);
         let ready2 = future::ready(0i32);
         join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 20);
+    assert_eq!(mem::size_of_val(&fut), 40);
 }
 
 #[test]
@@ -368,14 +368,14 @@ fn try_join_size() {
         let ready = future::ready(Ok::<i32, i32>(0));
         try_join!(ready)
     };
-    assert_eq!(mem::size_of_val(&fut), 16);
+    assert_eq!(mem::size_of_val(&fut), 24);
 
     let fut = async {
         let ready1 = future::ready(Ok::<i32, i32>(0));
         let ready2 = future::ready(Ok::<i32, i32>(0));
         try_join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 28);
+    assert_eq!(mem::size_of_val(&fut), 48);
 }
 
 #[test]

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -346,6 +346,7 @@ fn stream_select() {
     });
 }
 
+#[cfg_attr(not(target_pointer_width = "64"), ignore)]
 #[test]
 fn join_size() {
     let fut = async {
@@ -362,6 +363,7 @@ fn join_size() {
     assert_eq!(mem::size_of_val(&fut), 40);
 }
 
+#[cfg_attr(not(target_pointer_width = "64"), ignore)]
 #[test]
 fn try_join_size() {
     let fut = async {

--- a/futures/tests/future_join.rs
+++ b/futures/tests/future_join.rs
@@ -1,0 +1,32 @@
+use futures::executor::block_on;
+use futures::future::Future;
+use std::task::Poll;
+
+/// This tests verifies (through miri) that self-referencing
+/// futures are not invalidated when joining them.
+#[test]
+fn futures_join_macro_self_referential() {
+    block_on(async { futures::join!(yield_now(), trouble()) });
+}
+
+async fn trouble() {
+    let lucky_number = 42;
+    let problematic_variable = &lucky_number;
+
+    yield_now().await;
+
+    // problematic dereference
+    let _ = { *problematic_variable };
+}
+
+fn yield_now() -> impl Future<Output = ()> {
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if core::mem::replace(&mut yielded, true) {
+            Poll::Ready(())
+        } else {
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
+}


### PR DESCRIPTION
There is a soundness bug in the join macros where a new exclusive reference is taken out every time a future is polled. Under the Stacked Borrows model, this invalidates self-referential futures. This is then in conflict with the safety requirements for `Pin::new_unchecked`, which say that the pointer may never be invalidated after pinning it - and this leads to undefined behavior in safe Rust code.

I added a miri regression test for completeness (this example was made by @jswrenn), and together with @RalfJung we pin-pointed the problem and created a fix ([Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/269128-miri/topic/Making.20Miri.20a.20subtree.20and.20toolstate.20always.20green)). There is a minor down-side to the fix, the joined future increased in size, due to having to store an extra pinned reference in it, and I updated the tests to account for the increased sizes.