### PR TITLE
Implement `Clone` for `Drain`

### DIFF
--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -32,6 +32,12 @@ pub fn drain<T>() -> Drain<T> {
 
 impl<T> Unpin for Drain<T> {}
 
+impl<T> Clone for Drain<T> {
+    fn clone(&self) -> Self {
+        drain()
+    }
+}
+
 impl<T> Sink<T> for Drain<T> {
     type Error = Infallible;
 


### PR DESCRIPTION
This implementation makes it possible to use `Drain` in generic code accepting `S: Sink<T> + Clone`.

Thank you!