### PR TITLE
add scoped futures

### DIFF
--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -38,6 +38,12 @@ pub use self::future::{Remote, RemoteHandle};
 #[cfg(feature = "std")]
 pub use self::future::{Shared, WeakShared};
 
+mod scoped_future;
+pub use self::scoped_future::{ScopedFuture, ScopedFutureExt};
+
+#[cfg(feature = "alloc")]
+pub use self::scoped_future::{ScopedBoxFuture, ScopedLocalBoxFuture};
+
 mod try_future;
 pub use self::try_future::{
     AndThen, ErrInto, InspectErr, InspectOk, IntoFuture, MapErr, MapOk, MapOkOrElse, OkInto,

--- a/futures-util/src/future/scoped_future.rs
+++ b/futures-util/src/future/scoped_future.rs
@@ -1,0 +1,129 @@
+use crate::future::future::FutureExt;
+use core::marker::PhantomData;
+use core::pin::Pin;
+use futures_core::future::Future;
+use futures_core::task::{Context, Poll};
+
+#[cfg(feature = "alloc")]
+use futures_core::future::{BoxFuture, LocalBoxFuture};
+
+/// A [`Future`] wrapper that imposes a lower limit on the future's lifetime's duration.
+/// This is especially useful in combination with higher-tranked bounds when an lifetime
+/// bound is needed for the higher-ranked lifetime and a future is used in the bound.
+///
+/// # Example
+/// ```
+/// use futures::future::{ScopedBoxFuture, ScopedFutureExt};
+///
+/// pub struct Db {
+///     count: u8,
+/// }
+///
+/// impl Db {
+///     async fn transaction<'a, T: 'a, E: 'a, F: 'a>(&mut self, callback: F) -> Result<T, E>
+///     where
+///         F: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<T, E>> + Send,
+///     {
+///         callback(self).await
+///     }
+/// }
+///
+/// pub async fn test_transaction<'a, 'b>(
+///     db: &mut Db,
+///     ok: &'a str,
+///     err: &'b str,
+///     is_ok: bool,
+/// ) -> Result<&'a str, &'b str> {
+///     db.transaction(|db| async move {
+///         db.count += 1;
+///         if is_ok {
+///             Ok(ok)
+///         } else {
+///             Err(err)
+///         }
+///     }.scope_boxed()).await?;
+///
+///     // note that `async` is used instead of `async move`
+///     // since the callback parameter is unused
+///     db.transaction(|_| async {
+///         if is_ok {
+///             Ok(ok)
+///         } else {
+///             Err(err)
+///         }
+///     }.scope_boxed()).await
+/// }
+/// ```
+#[derive(Clone, Debug)]
+pub struct ScopedFuture<'lower_bound, 'a, Fut> {
+    future: Fut,
+    scope: PhantomData<&'a &'lower_bound ()>,
+}
+
+/// A boxed future whose lifetime is lower bounded.
+#[cfg(feature = "alloc")]
+pub type ScopedBoxFuture<'lower_bound, 'a, T> = ScopedFuture<'lower_bound, 'a, BoxFuture<'a, T>>;
+
+/// A non-Send boxed future whose lifetime is lower bounded.
+#[cfg(feature = "alloc")]
+pub type ScopedLocalBoxFuture<'lower_bound, 'a, T> =
+    ScopedFuture<'lower_bound, 'a, LocalBoxFuture<'a, T>>;
+
+/// An extension trait for `Future`s that provides methods for encoding lifetime information of captures.
+pub trait ScopedFutureExt: Sized {
+    /// Encodes the lifetimes of this `Future`'s captures.
+    fn scoped<'lower_bound, 'a>(self) -> ScopedFuture<'lower_bound, 'a, Self>;
+
+    /// Boxes this `Future` and encodes the lifetimes of its captures.
+    #[cfg(feature = "std")]
+    fn scope_boxed<'lower_bound, 'a>(
+        self,
+    ) -> ScopedBoxFuture<'lower_bound, 'a, <Self as Future>::Output>
+    where
+        Self: Send + Future + 'a;
+
+    /// Boxes this non-Send `Future` and encodes the lifetimes of its captures.
+    #[cfg(feature = "std")]
+    fn scope_boxed_local<'lower_bound, 'a>(
+        self,
+    ) -> ScopedLocalBoxFuture<'lower_bound, 'a, <Self as Future>::Output>
+    where
+        Self: Future + 'a;
+}
+
+impl<Fut> ScopedFuture<'_, '_, Fut> {
+    pin_utils::unsafe_pinned!(future: Fut);
+}
+
+impl<Fut: Future> Future for ScopedFuture<'_, '_, Fut> {
+    type Output = Fut::Output;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.future().poll(cx)
+    }
+}
+
+impl<Fut: Future> ScopedFutureExt for Fut {
+    fn scoped<'lower_bound, 'a>(self) -> ScopedFuture<'lower_bound, 'a, Self> {
+        ScopedFuture { future: self, scope: PhantomData }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn scope_boxed<'lower_bound, 'a>(
+        self,
+    ) -> ScopedFuture<'lower_bound, 'a, BoxFuture<'a, <Self as Future>::Output>>
+    where
+        Self: Send + Future + 'a,
+    {
+        ScopedFuture { future: self.boxed(), scope: PhantomData }
+    }
+
+    #[cfg(feature = "alloc")]
+    fn scope_boxed_local<'lower_bound, 'a>(
+        self,
+    ) -> ScopedFuture<'lower_bound, 'a, LocalBoxFuture<'a, <Self as Future>::Output>>
+    where
+        Self: Future + 'a,
+    {
+        ScopedFuture { future: self.boxed_local(), scope: PhantomData }
+    }
+}

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -104,7 +104,7 @@ compile_error!("The `bilock` feature requires the `unstable` feature as an expli
 #[doc(no_inline)]
 pub use futures_core::future::{Future, TryFuture};
 #[doc(no_inline)]
-pub use futures_util::future::{FutureExt, TryFutureExt};
+pub use futures_util::future::{FutureExt, ScopedFuture, ScopedFutureExt, TryFutureExt};
 
 #[doc(no_inline)]
 pub use futures_core::stream::{Stream, TryStream};

--- a/futures/tests/scoped_future.rs
+++ b/futures/tests/scoped_future.rs
@@ -20,24 +20,32 @@ async fn test_transaction<'a, 'b>(
     err: &'b str,
     is_ok: bool,
 ) -> Result<&'a str, &'b str> {
-    db.transaction(|db| async move {
-        db.count += 1;
-        if is_ok {
-            Ok(ok)
-        } else {
-            Err(err)
+    db.transaction(|db| {
+        async move {
+            db.count += 1;
+            if is_ok {
+                Ok(ok)
+            } else {
+                Err(err)
+            }
         }
-    }.scope_boxed()).await?;
+        .scope_boxed()
+    })
+    .await?;
 
     // note that `async` is used instead of `async move`
     // since the callback parameter is unused
-    db.transaction(|_| async {
-        if is_ok {
-            Ok(ok)
-        } else {
-            Err(err)
+    db.transaction(|_| {
+        async {
+            if is_ok {
+                Ok(ok)
+            } else {
+                Err(err)
+            }
         }
-    }.scope_boxed()).await
+        .scope_boxed()
+    })
+    .await
 }
 
 #[test]

--- a/futures/tests/scoped_future.rs
+++ b/futures/tests/scoped_future.rs
@@ -1,0 +1,53 @@
+use futures::executor::block_on;
+use futures::future::{ScopedBoxFuture, ScopedFutureExt};
+
+struct Db {
+    count: u8,
+}
+
+impl Db {
+    async fn transaction<'a, T: 'a, E: 'a, F: 'a>(&mut self, callback: F) -> Result<T, E>
+    where
+        F: for<'b> FnOnce(&'b mut Self) -> ScopedBoxFuture<'a, 'b, Result<T, E>> + Send,
+    {
+        callback(self).await
+    }
+}
+
+async fn test_transaction<'a, 'b>(
+    db: &mut Db,
+    ok: &'a str,
+    err: &'b str,
+    is_ok: bool,
+) -> Result<&'a str, &'b str> {
+    db.transaction(|db| async move {
+        db.count += 1;
+        if is_ok {
+            Ok(ok)
+        } else {
+            Err(err)
+        }
+    }.scope_boxed()).await?;
+
+    // note that `async` is used instead of `async move`
+    // since the callback parameter is unused
+    db.transaction(|_| async {
+        if is_ok {
+            Ok(ok)
+        } else {
+            Err(err)
+        }
+    }.scope_boxed()).await
+}
+
+#[test]
+fn test_transaction_works() {
+    block_on(async {
+        let mut db = Db { count: 0 };
+        let ok = String::from("ok");
+        let err = String::from("err");
+        let result = test_transaction(&mut db, &ok, &err, true).await;
+        assert_eq!(Ok(&*ok), result);
+        assert_eq!(1, db.count);
+    })
+}


### PR DESCRIPTION
Hi there! `futures` feels like the right crate for these additions, hopefully a pull request is ok.

Async callbacks (e.g. `FnOnce(...) -> BoxFuture<T>`) currently have difficulty returning `Future`s which effectively capture their environment without imposing `'static` bounds. This pull request introduces a struct `ScopedFuture` and a trait `ScopedFutureExt` along with a few convenience types that allow async callbacks to capture variables from their environment by imposing lifetime bounds on their higher-ranked trait lifetimes.

prior art on using implicit bounds on hrtbs:
[The Better Alternative to Lifetime GATs](https://sabrinajewson.org/blog/the-better-alternative-to-lifetime-gats#hrtb-implicit-bounds)
[Argument requires that … is borrowed for `’static`](https://users.rust-lang.org/t/argument-requires-that-is-borrowed-for-static/66503)
[Lifetime for (async) closure args / Problem with workaround: expected X found (same) X](https://users.rust-lang.org/t/lifetime-for-async-closure-args-problem-with-workaround-expected-x-found-same-x/71784)
[Lifetimes in asynchronous closure](https://users.rust-lang.org/t/lifetimes-in-asynchronous-closure/70269)
[Lifetimes of references for function taking async closure](https://users.rust-lang.org/t/lifetimes-of-references-for-function-taking-async-closure/73010)