### PR TITLE
Release 0.3.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.25 - 2022-10-20
+
+* Fix soundness issue in `join!` and `try_join!` macros (#2649)
+* Implement `Clone` for `sink::Drain` (#2650)
+
 # 0.3.24 - 2022-08-29
 
 * Fix incorrect termination of `select_with_strategy` streams (#2635)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.24", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.24", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.24", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.24", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.24", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.25", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.24", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.24", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.24", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.24", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.24", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.24", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.24", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.25", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.25", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.25", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.25", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.25", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.25", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.25", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.11"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -34,12 +34,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.24", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.24", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.24", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.24", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.24", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.24", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.25", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.25", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.25", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures-util/src/sink/drain.rs
+++ b/futures-util/src/sink/drain.rs
@@ -32,6 +32,12 @@ pub fn drain<T>() -> Drain<T> {
 
 impl<T> Unpin for Drain<T> {}
 
+impl<T> Clone for Drain<T> {
+    fn clone(&self) -> Self {
+        drain()
+    }
+}
+
 impl<T> Sink<T> for Drain<T> {
     type Error = Never;
 

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -22,6 +22,7 @@ use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
 mod abort;
 
 mod iter;
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/102352
 pub use self::iter::{IntoIter, Iter, IterMut, IterPinMut, IterPinRef};
 
 mod task;

--- a/futures-util/src/stream/stream/buffer_unordered.rs
+++ b/futures-util/src/stream/stream/buffer_unordered.rs
@@ -41,11 +41,7 @@ where
     St: Stream,
     St::Item: Future,
 {
-    pub(super) fn new(stream: St, n: usize) -> Self
-    where
-        St: Stream,
-        St::Item: Future,
-    {
+    pub(super) fn new(stream: St, n: usize) -> Self {
         Self {
             stream: super::Fuse::new(stream),
             in_progress_queue: FuturesUnordered::new(),

--- a/futures-util/src/stream/stream/chunks.rs
+++ b/futures-util/src/stream/stream/chunks.rs
@@ -21,10 +21,7 @@ pin_project! {
     }
 }
 
-impl<St: Stream> Chunks<St>
-where
-    St: Stream,
-{
+impl<St: Stream> Chunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 

--- a/futures-util/src/stream/stream/chunks.rs
+++ b/futures-util/src/stream/stream/chunks.rs
@@ -77,7 +77,7 @@ impl<St: Stream> Stream for Chunks<St> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let chunk_len = if self.items.is_empty() { 0 } else { 1 };
+        let chunk_len = usize::from(!self.items.is_empty());
         let (lower, upper) = self.stream.size_hint();
         let lower = (lower / self.cap).saturating_add(chunk_len);
         let upper = match upper {

--- a/futures-util/src/stream/stream/filter.rs
+++ b/futures-util/src/stream/stream/filter.rs
@@ -93,7 +93,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending_len = if self.pending_item.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending_item.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/stream/filter_map.rs
+++ b/futures-util/src/stream/stream/filter_map.rs
@@ -87,7 +87,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending_len = if self.pending.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -204,7 +204,7 @@ impl<S: Stream> Stream for Peekable<S> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let peek_len = if self.peeked.is_some() { 1 } else { 0 };
+        let peek_len = usize::from(self.peeked.is_some());
         let (lower, upper) = self.stream.size_hint();
         let lower = lower.saturating_add(peek_len);
         let upper = match upper {

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -20,10 +20,7 @@ pin_project! {
     }
 }
 
-impl<St: Stream> ReadyChunks<St>
-where
-    St: Stream,
-{
+impl<St: Stream> ReadyChunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -85,7 +85,7 @@ impl<St: Stream> Stream for ReadyChunks<St> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let chunk_len = if self.items.is_empty() { 0 } else { 1 };
+        let chunk_len = usize::from(!self.items.is_empty());
         let (lower, upper) = self.stream.size_hint();
         let lower = (lower / self.cap).saturating_add(chunk_len);
         let upper = match upper {

--- a/futures-util/src/stream/stream/skip_while.rs
+++ b/futures-util/src/stream/stream/skip_while.rs
@@ -99,7 +99,7 @@ where
         if self.done_skipping {
             self.stream.size_hint()
         } else {
-            let pending_len = if self.pending_item.is_some() { 1 } else { 0 };
+            let pending_len = usize::from(self.pending_item.is_some());
             let (_, upper) = self.stream.size_hint();
             let upper = match upper {
                 Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/stream/take.rs
+++ b/futures-util/src/stream/stream/take.rs
@@ -54,11 +54,11 @@ where
 
         let (lower, upper) = self.stream.size_hint();
 
-        let lower = cmp::min(lower, self.remaining as usize);
+        let lower = cmp::min(lower, self.remaining);
 
         let upper = match upper {
-            Some(x) if x < self.remaining as usize => Some(x),
-            _ => Some(self.remaining as usize),
+            Some(x) if x < self.remaining => Some(x),
+            _ => Some(self.remaining),
         };
 
         (lower, upper)

--- a/futures-util/src/stream/stream/take_while.rs
+++ b/futures-util/src/stream/stream/take_while.rs
@@ -91,7 +91,7 @@ where
             return (0, Some(0));
         }
 
-        let pending_len = if self.pending_item.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending_item.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/stream/then.rs
+++ b/futures-util/src/stream/stream/then.rs
@@ -78,7 +78,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let future_len = if self.future.is_some() { 1 } else { 0 };
+        let future_len = usize::from(self.future.is_some());
         let (lower, upper) = self.stream.size_hint();
         let lower = lower.saturating_add(future_len);
         let upper = match upper {

--- a/futures-util/src/stream/stream/zip.rs
+++ b/futures-util/src/stream/stream/zip.rs
@@ -102,8 +102,8 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let queued1_len = if self.queued1.is_some() { 1 } else { 0 };
-        let queued2_len = if self.queued2.is_some() { 1 } else { 0 };
+        let queued1_len = usize::from(self.queued1.is_some());
+        let queued2_len = usize::from(self.queued2.is_some());
         let (stream1_lower, stream1_upper) = self.stream1.size_hint();
         let (stream2_lower, stream2_upper) = self.stream2.size_hint();
 

--- a/futures-util/src/stream/try_stream/and_then.rs
+++ b/futures-util/src/stream/try_stream/and_then.rs
@@ -71,7 +71,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let future_len = if self.future.is_some() { 1 } else { 0 };
+        let future_len = usize::from(self.future.is_some());
         let (lower, upper) = self.stream.size_hint();
         let lower = lower.saturating_add(future_len);
         let upper = match upper {

--- a/futures-util/src/stream/try_stream/or_else.rs
+++ b/futures-util/src/stream/try_stream/or_else.rs
@@ -75,7 +75,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let future_len = if self.future.is_some() { 1 } else { 0 };
+        let future_len = usize::from(self.future.is_some());
         let (lower, upper) = self.stream.size_hint();
         let lower = lower.saturating_add(future_len);
         let upper = match upper {

--- a/futures-util/src/stream/try_stream/try_chunks.rs
+++ b/futures-util/src/stream/try_stream/try_chunks.rs
@@ -81,7 +81,7 @@ impl<St: TryStream> Stream for TryChunks<St> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let chunk_len = if self.items.is_empty() { 0 } else { 1 };
+        let chunk_len = usize::from(!self.items.is_empty());
         let (lower, upper) = self.stream.size_hint();
         let lower = (lower / self.cap).saturating_add(chunk_len);
         let upper = match upper {

--- a/futures-util/src/stream/try_stream/try_filter.rs
+++ b/futures-util/src/stream/try_stream/try_filter.rs
@@ -90,7 +90,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending_len = if self.pending_fut.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending_fut.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/try_stream/try_filter_map.rs
+++ b/futures-util/src/stream/try_stream/try_filter_map.rs
@@ -84,7 +84,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending_len = if self.pending.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/try_stream/try_skip_while.rs
+++ b/futures-util/src/stream/try_stream/try_skip_while.rs
@@ -87,7 +87,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let pending_len = if self.pending_item.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending_item.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures-util/src/stream/try_stream/try_take_while.rs
+++ b/futures-util/src/stream/try_stream/try_take_while.rs
@@ -96,7 +96,7 @@ where
             return (0, Some(0));
         }
 
-        let pending_len = if self.pending_item.is_some() { 1 } else { 0 };
+        let pending_len = usize::from(self.pending_item.is_some());
         let (_, upper) = self.stream.size_hint();
         let upper = match upper {
             Some(x) => x.checked_add(pending_len),

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.24"
+version = "0.3.25"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.24", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.24", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.24", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.24", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.24", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.24", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.24", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.25", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.25", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.25", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.25", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -352,14 +352,14 @@ fn join_size() {
         let ready = future::ready(0i32);
         join!(ready)
     };
-    assert_eq!(mem::size_of_val(&fut), 16);
+    assert_eq!(mem::size_of_val(&fut), 12);
 
     let fut = async {
         let ready1 = future::ready(0i32);
         let ready2 = future::ready(0i32);
         join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 28);
+    assert_eq!(mem::size_of_val(&fut), 20);
 }
 
 #[test]

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -346,36 +346,38 @@ fn stream_select() {
     });
 }
 
+#[cfg_attr(not(target_pointer_width = "64"), ignore)]
 #[test]
 fn join_size() {
     let fut = async {
         let ready = future::ready(0i32);
         join!(ready)
     };
-    assert_eq!(mem::size_of_val(&fut), 12);
+    assert_eq!(mem::size_of_val(&fut), 24);
 
     let fut = async {
         let ready1 = future::ready(0i32);
         let ready2 = future::ready(0i32);
         join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 20);
+    assert_eq!(mem::size_of_val(&fut), 40);
 }
 
+#[cfg_attr(not(target_pointer_width = "64"), ignore)]
 #[test]
 fn try_join_size() {
     let fut = async {
         let ready = future::ready(Ok::<i32, i32>(0));
         try_join!(ready)
     };
-    assert_eq!(mem::size_of_val(&fut), 16);
+    assert_eq!(mem::size_of_val(&fut), 24);
 
     let fut = async {
         let ready1 = future::ready(Ok::<i32, i32>(0));
         let ready2 = future::ready(Ok::<i32, i32>(0));
         try_join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 28);
+    assert_eq!(mem::size_of_val(&fut), 48);
 }
 
 #[test]

--- a/futures/tests/future_join.rs
+++ b/futures/tests/future_join.rs
@@ -1,0 +1,32 @@
+use futures::executor::block_on;
+use futures::future::Future;
+use std::task::Poll;
+
+/// This tests verifies (through miri) that self-referencing
+/// futures are not invalidated when joining them.
+#[test]
+fn futures_join_macro_self_referential() {
+    block_on(async { futures::join!(yield_now(), trouble()) });
+}
+
+async fn trouble() {
+    let lucky_number = 42;
+    let problematic_variable = &lucky_number;
+
+    yield_now().await;
+
+    // problematic dereference
+    let _ = { *problematic_variable };
+}
+
+fn yield_now() -> impl Future<Output = ()> {
+    let mut yielded = false;
+    std::future::poll_fn(move |cx| {
+        if core::mem::replace(&mut yielded, true) {
+            Poll::Ready(())
+        } else {
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
+}

--- a/no_atomic_cas.rs
+++ b/no_atomic_cas.rs
@@ -3,6 +3,7 @@
 
 const NO_ATOMIC_CAS: &[&str] = &[
     "armv4t-none-eabi",
+    "armv5te-none-eabi",
     "avr-unknown-gnu-atmega328",
     "bpfeb-unknown-none",
     "bpfel-unknown-none",
@@ -11,5 +12,6 @@ const NO_ATOMIC_CAS: &[&str] = &[
     "riscv32im-unknown-none-elf",
     "riscv32imc-unknown-none-elf",
     "thumbv4t-none-eabi",
+    "thumbv5te-none-eabi",
     "thumbv6m-none-eabi",
 ];


### PR DESCRIPTION
Backports:
- https://github.com/rust-lang/futures-rs/pull/2649
- https://github.com/rust-lang/futures-rs/pull/2650
- https://github.com/rust-lang/futures-rs/pull/2645
- https://github.com/rust-lang/futures-rs/pull/2644

Changes:

* Fix soundness issue in `join!` and `try_join!` macros (#2649)
* Implement `Clone` for `sink::Drain` (#2650)