### PR TITLE
Do not allocate capacity in ready_chunks

### DIFF
--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -45,12 +45,8 @@ impl<St: Stream> Stream for ReadyChunks<St> {
                 }
 
                 // Push the ready item into the buffer and check whether it is full.
-                // If so, replace our buffer with a new and empty one and return
-                // the full one.
+                // If so, return it.
                 Poll::Ready(Some(item)) => {
-                    if items.is_empty() {
-                        items.reserve(*this.cap);
-                    }
                     items.push(item);
                     if items.len() >= *this.cap {
                         return Poll::Ready(Some(items));


### PR DESCRIPTION
`read_chunks` practically often returns items when not all capacity filled.  So always allocating full capacity results in excessive allocation.

This is especially an issue when `capacity` parameter passed is large (to be able to handle streams efficiently under high load).