### PR TITLE
Fix clippy::uninlined_format_args warning

### DIFF
--- a/examples/functional/src/main.rs
+++ b/examples/functional/src/main.rs
@@ -42,5 +42,5 @@ fn main() {
     // to drive all futures. Eventually fut_values will be driven to completion.
     let values: Vec<i32> = executor::block_on(fut_values);
 
-    println!("Values={:?}", values);
+    println!("Values={values:?}");
 }

--- a/examples/imperative/src/main.rs
+++ b/examples/imperative/src/main.rs
@@ -44,5 +44,5 @@ fn main() {
     // to drive all futures. Eventually fut_values will be driven to completion.
     let values: Vec<i32> = executor::block_on(fut_values);
 
-    println!("Values={:?}", values);
+    println!("Values={values:?}");
 }


### PR DESCRIPTION
```
error: variables can be used directly in the `format!` string
  --> examples/functional/src/main.rs:45:5
   |
45 |     println!("Values={:?}", values);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
help: change this to
   |
45 -     println!("Values={:?}", values);
45 +     println!("Values={values:?}");
   |
```