### PR TITLE
Custom `Debug` implementations for `mpsc`

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -94,13 +94,11 @@ mod queue;
 #[cfg(feature = "sink")]
 mod sink_impl;
 
-#[derive(Debug)]
 struct UnboundedSenderInner<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<UnboundedInner<T>>,
 }
 
-#[derive(Debug)]
 struct BoundedSenderInner<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<BoundedInner<T>>,
@@ -122,13 +120,11 @@ impl<T> Unpin for BoundedSenderInner<T> {}
 /// The transmission end of a bounded mpsc channel.
 ///
 /// This value is created by the [`channel`](channel) function.
-#[derive(Debug)]
 pub struct Sender<T>(Option<BoundedSenderInner<T>>);
 
 /// The transmission end of an unbounded mpsc channel.
 ///
 /// This value is created by the [`unbounded`](unbounded) function.
-#[derive(Debug)]
 pub struct UnboundedSender<T>(Option<UnboundedSenderInner<T>>);
 
 trait AssertKinds: Send + Sync + Clone {}
@@ -137,7 +133,6 @@ impl AssertKinds for UnboundedSender<u32> {}
 /// The receiving end of a bounded mpsc channel.
 ///
 /// This value is created by the [`channel`](channel) function.
-#[derive(Debug)]
 pub struct Receiver<T> {
     inner: Option<Arc<BoundedInner<T>>>,
 }
@@ -145,7 +140,6 @@ pub struct Receiver<T> {
 /// The receiving end of an unbounded mpsc channel.
 ///
 /// This value is created by the [`unbounded`](unbounded) function.
-#[derive(Debug)]
 pub struct UnboundedReceiver<T> {
     inner: Option<Arc<UnboundedInner<T>>>,
 }
@@ -255,7 +249,6 @@ impl fmt::Display for TryRecvError {
 
 impl std::error::Error for TryRecvError {}
 
-#[derive(Debug)]
 struct UnboundedInner<T> {
     // Internal channel state. Consists of the number of messages stored in the
     // channel as well as a flag signalling that the channel is closed.
@@ -271,7 +264,6 @@ struct UnboundedInner<T> {
     recv_task: AtomicWaker,
 }
 
-#[derive(Debug)]
 struct BoundedInner<T> {
     // Max buffer size of the channel.
     buffer: usize,
@@ -294,7 +286,7 @@ struct BoundedInner<T> {
 }
 
 // Struct representation of `Inner::state`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 struct State {
     // `true` when the channel is open
     is_open: bool,
@@ -318,7 +310,6 @@ const MAX_CAPACITY: usize = !(OPEN_MASK);
 const MAX_BUFFER: usize = MAX_CAPACITY >> 1;
 
 // Sent to the consumer to wake up blocked producers
-#[derive(Debug)]
 struct SenderTask {
     task: Option<Waker>,
     is_parked: bool,
@@ -941,6 +932,18 @@ impl<T> Drop for BoundedSenderInner<T> {
     }
 }
 
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").field("closed", &self.is_closed()).finish()
+    }
+}
+
+impl<T> fmt::Debug for UnboundedSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnboundedSender").field("closed", &self.is_closed()).finish()
+    }
+}
+
 /*
  *
  * ===== impl Receiver =====
@@ -1101,6 +1104,18 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let closed = if let Some(ref inner) = self.inner {
+            decode_state(inner.state.load(SeqCst)).is_closed()
+        } else {
+            false
+        };
+
+        f.debug_struct("Receiver").field("closed", &closed).finish()
+    }
+}
+
 impl<T> UnboundedReceiver<T> {
     /// Closes the receiving half of a channel, without dropping it.
     ///
@@ -1230,6 +1245,18 @@ impl<T> Drop for UnboundedReceiver<T> {
                 }
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for UnboundedReceiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let closed = if let Some(ref inner) = self.inner {
+            decode_state(inner.state.load(SeqCst)).is_closed()
+        } else {
+            false
+        };
+
+        f.debug_struct("Receiver").field("closed", &closed).finish()
     }
 }
 

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -61,7 +61,6 @@ pub(super) enum PopResult<T> {
     Inconsistent,
 }
 
-#[derive(Debug)]
 struct Node<T> {
     next: AtomicPtr<Self>,
     value: Option<T>,
@@ -70,7 +69,6 @@ struct Node<T> {
 /// The multi-producer single-consumer structure. This is not cloneable, but it
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
-#[derive(Debug)]
 pub(super) struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: UnsafeCell<*mut Node<T>>,


### PR DESCRIPTION
This is the same PR as #2414 but for `mpsc` instead of `oneshot`. I'm not sure if it is considered okay to do atomic operations in a `Debug` implementation, but I can't think of a reason why not to.

This also removes the `Debug` constraint on `Debug` implementations on all `mpsc` types, similar to #2666.