### PR TITLE
Enable an option for portable-atomic

### DIFF
--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -16,6 +16,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
+portable-atomic = { version = "0.3.15", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures" }

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -1,8 +1,15 @@
 use core::cell::UnsafeCell;
 use core::fmt;
-use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
+
+use atomic::AtomicUsize;
+use atomic::Ordering::{AcqRel, Acquire, Release};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -21,6 +21,7 @@ io-compat = ["io", "compat", "tokio-io"]
 sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
+portable-atomic = ["futures-core/portable-atomic"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the


### PR DESCRIPTION
This PR enables an option in `futures-core` that replaces the atomic usage in `AtomicWaker` with `portable-atomic`, and also exposes that flag in `futures-util`. This intends to make it so `futures-core` can be used on platforms without atomics, like AVR.

I look through `futures-util` and didn't see any other usage of atomics that wasn't also locked behind allocation, so I think this is the best I can do here.