### PR TITLE
Add a `ptr_eq` to `Shared` to test if two `Shared`s share the same underlying future.

### DIFF
--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -156,6 +156,22 @@ where
     pub fn weak_count(&self) -> Option<usize> {
         self.inner.as_ref().map(Arc::weak_count)
     }
+
+    /// Returns `true` if the two `Shared`s point to the same future (in a vein similar to
+    /// `Arc::ptr_eq`).
+    ///
+    /// Returns `false` if either `Shared` has terminated.
+    pub fn ptr_eq(lhs: &Self, rhs: &Self) -> bool {
+        let lhs = match lhs.inner.as_ref() {
+            Some(lhs) => lhs,
+            None => return false,
+        };
+        let rhs = match rhs.inner.as_ref() {
+            Some(rhs) => rhs,
+            None => return false,
+        };
+        Arc::ptr_eq(lhs, rhs)
+    }
 }
 
 impl<Fut> Inner<Fut>

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -176,8 +176,8 @@ where
     /// `Arc::ptr_eq`).
     ///
     /// Returns `false` if either `Shared` has terminated.
-    pub fn ptr_eq(lhs: &Self, rhs: &Self) -> bool {
-        let lhs = match lhs.inner.as_ref() {
+    pub fn ptr_eq(&self, rhs: &Self) -> bool {
+        let lhs = match self.inner.as_ref() {
             Some(lhs) => lhs,
             None => return false,
         };

--- a/futures/tests/future_shared.rs
+++ b/futures/tests/future_shared.rs
@@ -154,14 +154,23 @@ fn downgrade() {
 #[test]
 fn ptr_eq() {
     use future::{FusedFuture, Shared};
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
 
     let (tx, rx) = oneshot::channel::<i32>();
     let shared = rx.shared();
     let mut shared2 = shared.clone();
+    let mut hasher = DefaultHasher::new();
+    let mut hasher2 = DefaultHasher::new();
 
     // Because these two futures share the same underlying future,
     // `ptr_eq` should return true.
     assert!(Shared::ptr_eq(&shared, &shared2));
+
+    // If `ptr_eq` returns true, they should hash to the same value.
+    shared.ptr_hash(&mut hasher);
+    shared2.ptr_hash(&mut hasher2);
+    assert_eq!(hasher.finish(), hasher2.finish());
 
     tx.send(42).unwrap();
     assert_eq!(block_on(&mut shared2).unwrap(), 42);
@@ -172,7 +181,11 @@ fn ptr_eq() {
 
     // `ptr_eq` should continue to work for the other `Shared`.
     let shared3 = shared.clone();
+    let mut hasher3 = DefaultHasher::new();
     assert!(Shared::ptr_eq(&shared, &shared3));
+
+    shared3.ptr_hash(&mut hasher3);
+    assert_eq!(hasher.finish(), hasher3.finish());
 
     let (_tx, rx) = oneshot::channel::<i32>();
     let shared4 = rx.shared();

--- a/futures/tests/future_shared.rs
+++ b/futures/tests/future_shared.rs
@@ -165,7 +165,9 @@ fn ptr_eq() {
 
     // Because these two futures share the same underlying future,
     // `ptr_eq` should return true.
-    assert!(Shared::ptr_eq(&shared, &shared2));
+    assert!(shared.ptr_eq(&shared2));
+    // Equivalence relations are symmetric
+    assert!(shared2.ptr_eq(&shared));
 
     // If `ptr_eq` returns true, they should hash to the same value.
     shared.ptr_hash(&mut hasher);
@@ -177,12 +179,12 @@ fn ptr_eq() {
 
     // Now that `shared2` has completed, `ptr_eq` should return false.
     assert!(shared2.is_terminated());
-    assert!(!Shared::ptr_eq(&shared, &shared2));
+    assert!(!shared.ptr_eq(&shared2));
 
     // `ptr_eq` should continue to work for the other `Shared`.
     let shared3 = shared.clone();
     let mut hasher3 = DefaultHasher::new();
-    assert!(Shared::ptr_eq(&shared, &shared3));
+    assert!(shared.ptr_eq(&shared3));
 
     shared3.ptr_hash(&mut hasher3);
     assert_eq!(hasher.finish(), hasher3.finish());
@@ -192,7 +194,7 @@ fn ptr_eq() {
 
     // And `ptr_eq` should return false for two futures that don't share
     // the underlying future.
-    assert!(!Shared::ptr_eq(&shared, &shared4));
+    assert!(!shared.ptr_eq(&shared4));
 }
 
 #[test]

--- a/futures/tests/future_shared.rs
+++ b/futures/tests/future_shared.rs
@@ -153,7 +153,7 @@ fn downgrade() {
 
 #[test]
 fn ptr_eq() {
-    use future::{FusedFuture, Shared};
+    use future::FusedFuture;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::Hasher;
 


### PR DESCRIPTION
`Shared` already has `Arc`'s `strong_count` and `weak_count`. This will make it easier to implement `PartialEq`/`Eq` for structs containing a `Shared`.