### PR TITLE
Set to `None` only if necessary

### DIFF
--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -50,8 +50,9 @@ where
             if let Some(item) = ready!(first.poll_next(cx)) {
                 return Poll::Ready(Some(item));
             }
+
+            this.first.set(None);
         }
-        this.first.set(None);
         this.second.poll_next(cx)
     }
 


### PR DESCRIPTION
Setting `this.first` to `None` does not seem necessary if it is already `None`.