### PR TITLE
#2600 fix panic when Unfold sink return an error

### DIFF
--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -73,7 +73,10 @@ where
                     this.state.set(UnfoldState::Value { value: state });
                     Ok(())
                 }
-                Err(err) => Err(err),
+                Err(err) => {
+                    this.state.set(UnfoldState::Empty);
+                    Err(err)
+                }
             }
         } else {
             Ok(())


### PR DESCRIPTION
Fix issue #2600. When an Unfold sink return an error it is left in an invalid state. Calling after that flush/close cause the sink to panic due to re-calling a future already completed.
  This issue is really painful when using stream.forward(sink), as one may not know in case of an error if it is the stream or the sink that emitted this error.

 This patch aims to leave the sink in a valid state and allow calling flush/close without causing a panic if it is returning an error