### PR TITLE
Remove incorrect error behavior from `ready_chunks` docs

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1682,8 +1682,7 @@ pub trait StreamExt: Stream {
     /// be immediately returned.
     ///
     /// If the underlying stream ended and only a partial vector was created,
-    /// it'll be returned. Additionally if an error happens from the underlying
-    /// stream then the currently buffered items will be yielded.
+    /// it will be returned.
     ///
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.


### PR DESCRIPTION
Unlike `TryStream::try_chunks`, which has similar documentation and can handle `Some(Err(_))` specially, `Stream::ready_chunks` does not and cannot know whether the stream item represents an error condition, and does not include any code to return early on an error.