### PR TITLE
add is_some and is_none to OptionFuture

### DIFF
--- a/futures-util/src/future/option.rs
+++ b/futures-util/src/future/option.rs
@@ -62,3 +62,15 @@ impl<T> From<Option<T>> for OptionFuture<T> {
         Self { inner: option }
     }
 }
+
+impl<T> OptionFuture<T> {
+    /// Returns `true` if the future is present.
+    pub fn is_some(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    /// Returns `true` if the future is absent.
+    pub fn is_node(&self) -> bool {
+        self.inner.is_none()
+    }
+}


### PR DESCRIPTION
This PR adds `is_some` and `is_none` to OptionFuture. This is useful when you only want to poll the `OptionFuture` if it contains a future (i.e treat `None` as `never`).
