### PR TITLE
Release 0.3.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.26 - 2023-01-30
+
+* Add `Either::as_pin_mut` and `Either::as_pin_ref` (#2691)
+* Add `Shared::ptr_eq` and `Shared::ptr_hash` (#2691)
+* Implement `FusedStream` for `Buffered` (#2676)
+* Implement `FusedStream` for all streams in `ReadyChunks` (#2693)
+* Fix bug in `FuturesOrdered::push_front` (#2664)
+* Remove `Fut::Output: Clone` bounds from some `Shared` methods (#2662)
+* Remove `T: Debug` bounds from `Debug` implementations of `mpsc` and `oneshot` types (#2666, #2667)
+
 # 0.3.25 - 2022-10-20
 
 * Fix soundness issue in `join!` and `try_join!` macros (#2649)

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 <p align="center">
   <a href="https://github.com/rust-lang/futures-rs/actions?query=branch%3Amaster">
-    <img alt="Build Status" src="https://img.shields.io/github/workflow/status/rust-lang/futures-rs/CI/master">
+    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/rust-lang/futures-rs/ci.yml?branch=master">
   </a>
 
   <a href="https://crates.io/crates/futures">
-    <img alt="Crates.io" src="https://img.shields.io/crates/v/futures.svg">
+    <img alt="crates.io" src="https://img.shields.io/crates/v/futures.svg">
   </a>
 </p>
 
 <p align="center">
-  <a href="https://docs.rs/futures/">
+  <a href="https://docs.rs/futures">
     Documentation
   </a> | <a href="https://rust-lang.github.io/futures-rs/">
     Website

--- a/examples/functional/src/main.rs
+++ b/examples/functional/src/main.rs
@@ -42,5 +42,5 @@ fn main() {
     // to drive all futures. Eventually fut_values will be driven to completion.
     let values: Vec<i32> = executor::block_on(fut_values);
 
-    println!("Values={:?}", values);
+    println!("Values={values:?}");
 }

--- a/examples/imperative/src/main.rs
+++ b/examples/imperative/src/main.rs
@@ -44,5 +44,5 @@ fn main() {
     // to drive all futures. Eventually fut_values will be driven to completion.
     let values: Vec<i32> = executor::block_on(fut_values);
 
-    println!("Values={:?}", values);
+    println!("Values={values:?}");
 }

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.26", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.26", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -1078,6 +1078,14 @@ impl<T> Stream for Receiver<T> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(inner) = &self.inner {
+            decode_state(inner.state.load(SeqCst)).size_hint()
+        } else {
+            (0, Some(0))
+        }
+    }
 }
 
 impl<T> Drop for Receiver<T> {
@@ -1222,6 +1230,14 @@ impl<T> Stream for UnboundedReceiver<T> {
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(inner) = &self.inner {
+            decode_state(inner.state.load(SeqCst)).size_hint()
+        } else {
+            (0, Some(0))
+        }
+    }
 }
 
 impl<T> Drop for UnboundedReceiver<T> {
@@ -1311,6 +1327,14 @@ unsafe impl<T: Send> Sync for BoundedInner<T> {}
 impl State {
     fn is_closed(&self) -> bool {
         !self.is_open && self.num_messages == 0
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.is_open {
+            (self.num_messages, None)
+        } else {
+            (self.num_messages, Some(self.num_messages))
+        }
     }
 }
 

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -94,13 +94,11 @@ mod queue;
 #[cfg(feature = "sink")]
 mod sink_impl;
 
-#[derive(Debug)]
 struct UnboundedSenderInner<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<UnboundedInner<T>>,
 }
 
-#[derive(Debug)]
 struct BoundedSenderInner<T> {
     // Channel state shared between the sender and receiver.
     inner: Arc<BoundedInner<T>>,
@@ -122,13 +120,11 @@ impl<T> Unpin for BoundedSenderInner<T> {}
 /// The transmission end of a bounded mpsc channel.
 ///
 /// This value is created by the [`channel`](channel) function.
-#[derive(Debug)]
 pub struct Sender<T>(Option<BoundedSenderInner<T>>);
 
 /// The transmission end of an unbounded mpsc channel.
 ///
 /// This value is created by the [`unbounded`](unbounded) function.
-#[derive(Debug)]
 pub struct UnboundedSender<T>(Option<UnboundedSenderInner<T>>);
 
 trait AssertKinds: Send + Sync + Clone {}
@@ -137,7 +133,6 @@ impl AssertKinds for UnboundedSender<u32> {}
 /// The receiving end of a bounded mpsc channel.
 ///
 /// This value is created by the [`channel`](channel) function.
-#[derive(Debug)]
 pub struct Receiver<T> {
     inner: Option<Arc<BoundedInner<T>>>,
 }
@@ -145,7 +140,6 @@ pub struct Receiver<T> {
 /// The receiving end of an unbounded mpsc channel.
 ///
 /// This value is created by the [`unbounded`](unbounded) function.
-#[derive(Debug)]
 pub struct UnboundedReceiver<T> {
     inner: Option<Arc<UnboundedInner<T>>>,
 }
@@ -261,7 +255,6 @@ impl fmt::Display for TryRecvError {
 
 impl std::error::Error for TryRecvError {}
 
-#[derive(Debug)]
 struct UnboundedInner<T> {
     // Internal channel state. Consists of the number of messages stored in the
     // channel as well as a flag signalling that the channel is closed.
@@ -277,7 +270,6 @@ struct UnboundedInner<T> {
     recv_task: AtomicWaker,
 }
 
-#[derive(Debug)]
 struct BoundedInner<T> {
     // Max buffer size of the channel. If `None` then the channel is unbounded.
     buffer: usize,
@@ -300,7 +292,7 @@ struct BoundedInner<T> {
 }
 
 // Struct representation of `Inner::state`.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 struct State {
     // `true` when the channel is open
     is_open: bool,
@@ -324,7 +316,6 @@ const MAX_CAPACITY: usize = !(OPEN_MASK);
 const MAX_BUFFER: usize = MAX_CAPACITY >> 1;
 
 // Sent to the consumer to wake up blocked producers
-#[derive(Debug)]
 struct SenderTask {
     task: Option<Waker>,
     is_parked: bool,
@@ -947,6 +938,18 @@ impl<T> Drop for BoundedSenderInner<T> {
     }
 }
 
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Sender").field("closed", &self.is_closed()).finish()
+    }
+}
+
+impl<T> fmt::Debug for UnboundedSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnboundedSender").field("closed", &self.is_closed()).finish()
+    }
+}
+
 /*
  *
  * ===== impl Receiver =====
@@ -1107,6 +1110,18 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let closed = if let Some(ref inner) = self.inner {
+            decode_state(inner.state.load(SeqCst)).is_closed()
+        } else {
+            false
+        };
+
+        f.debug_struct("Receiver").field("closed", &closed).finish()
+    }
+}
+
 impl<T> UnboundedReceiver<T> {
     /// Closes the receiving half of a channel, without dropping it.
     ///
@@ -1236,6 +1251,18 @@ impl<T> Drop for UnboundedReceiver<T> {
                 }
             }
         }
+    }
+}
+
+impl<T> fmt::Debug for UnboundedReceiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let closed = if let Some(ref inner) = self.inner {
+            decode_state(inner.state.load(SeqCst)).is_closed()
+        } else {
+            false
+        };
+
+        f.debug_struct("Receiver").field("closed", &closed).finish()
     }
 }
 

--- a/futures-channel/src/mpsc/queue.rs
+++ b/futures-channel/src/mpsc/queue.rs
@@ -61,7 +61,6 @@ pub(super) enum PopResult<T> {
     Inconsistent,
 }
 
-#[derive(Debug)]
 struct Node<T> {
     next: AtomicPtr<Self>,
     value: Option<T>,
@@ -70,7 +69,6 @@ struct Node<T> {
 /// The multi-producer single-consumer structure. This is not cloneable, but it
 /// may be safely shared so long as it is guaranteed that there is only one
 /// popper at a time (many pushers are allowed).
-#[derive(Debug)]
 pub(super) struct Queue<T> {
     head: AtomicPtr<Node<T>>,
     tail: UnsafeCell<*mut Node<T>>,

--- a/futures-channel/src/oneshot.rs
+++ b/futures-channel/src/oneshot.rs
@@ -390,7 +390,7 @@ impl<T> Drop for Sender<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Sender<T> {
+impl<T> fmt::Debug for Sender<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Sender").field("complete", &self.inner.complete).finish()
     }
@@ -481,7 +481,7 @@ impl<T> Drop for Receiver<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Receiver<T> {
+impl<T> fmt::Debug for Receiver<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Receiver").field("complete", &self.inner.complete).finish()
     }

--- a/futures-channel/tests/mpsc-size_hint.rs
+++ b/futures-channel/tests/mpsc-size_hint.rs
@@ -1,0 +1,40 @@
+use futures::channel::mpsc;
+use futures::stream::Stream;
+
+#[test]
+fn unbounded_size_hint() {
+    let (tx, mut rx) = mpsc::unbounded::<u32>();
+    assert_eq!((0, None), rx.size_hint());
+    tx.unbounded_send(1).unwrap();
+    assert_eq!((1, None), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((0, None), rx.size_hint());
+    tx.unbounded_send(2).unwrap();
+    tx.unbounded_send(3).unwrap();
+    assert_eq!((2, None), rx.size_hint());
+    drop(tx);
+    assert_eq!((2, Some(2)), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((1, Some(1)), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((0, Some(0)), rx.size_hint());
+}
+
+#[test]
+fn channel_size_hint() {
+    let (mut tx, mut rx) = mpsc::channel::<u32>(10);
+    assert_eq!((0, None), rx.size_hint());
+    tx.try_send(1).unwrap();
+    assert_eq!((1, None), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((0, None), rx.size_hint());
+    tx.try_send(2).unwrap();
+    tx.try_send(3).unwrap();
+    assert_eq!((2, None), rx.size_hint());
+    drop(tx);
+    assert_eq!((2, Some(2)), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((1, Some(1)), rx.size_hint());
+    rx.try_next().unwrap().unwrap();
+    assert_eq!((0, Some(0)), rx.size_hint());
+}

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -21,6 +21,7 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
+portable-atomic = { version = "0.3.15", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures" }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -21,7 +21,7 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-portable-atomic = { version = "0.3.15", default-features = false, optional = true }
+portable-atomic = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures" }

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -1,8 +1,15 @@
 use core::cell::UnsafeCell;
 use core::fmt;
-use core::sync::atomic::AtomicUsize;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use core::task::Waker;
+
+use atomic::AtomicUsize;
+use atomic::Ordering::{AcqRel, Acquire, Release};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic as atomic;
+
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
 
 /// A synchronization primitive for task wakeup.
 ///

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.25", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.26", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.26", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.26", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"

--- a/futures-task/src/future_obj.rs
+++ b/futures-task/src/future_obj.rs
@@ -149,6 +149,7 @@ pub unsafe trait UnsafeFutureObj<'a, T>: 'a {
     /// provided `*mut (dyn Future<Output = T> + 'a)` into a `Pin<&mut (dyn
     /// Future<Output = T> + 'a)>` and call methods on it, non-reentrantly,
     /// until `UnsafeFutureObj::drop` is called with it.
+    #[allow(clippy::unnecessary_safety_doc)]
     fn into_raw(self) -> *mut (dyn Future<Output = T> + 'a);
 
     /// Drops the future represented by the given fat pointer.

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.25", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.25", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.25", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.25", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.25", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.25", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.25", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.26", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.26", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.26", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.26", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.26", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.26", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.26", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.11"
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -21,6 +21,7 @@ io-compat = ["io", "compat", "tokio-io"]
 sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
+portable-atomic = ["futures-core/portable-atomic"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -35,12 +35,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.25", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.25", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.25", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.26", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.26", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.26", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.26", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.26", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.26", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -103,7 +103,6 @@ impl<Fut: Future> Shared<Fut> {
 impl<Fut> Shared<Fut>
 where
     Fut: Future,
-    Fut::Output: Clone,
 {
     /// Returns [`Some`] containing a reference to this [`Shared`]'s output if
     /// it has already been computed by a clone or [`None`] if it hasn't been
@@ -160,7 +159,6 @@ where
 impl<Fut> Inner<Fut>
 where
     Fut: Future,
-    Fut::Output: Clone,
 {
     /// Safety: callers must first ensure that `self.inner.state`
     /// is `COMPLETE`
@@ -170,6 +168,13 @@ where
             FutureOrOutput::Future(_) => unreachable!(),
         }
     }
+}
+
+impl<Fut> Inner<Fut>
+where
+    Fut: Future,
+    Fut::Output: Clone,
+{
     /// Registers the current task to receive a wakeup when we are awoken.
     fn record_waker(&self, waker_key: &mut usize, cx: &mut Context<'_>) {
         let mut wakers_guard = self.notifier.wakers.lock().unwrap();

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -4,7 +4,9 @@ use futures_core::task::{Context, Poll, Waker};
 use slab::Slab;
 use std::cell::UnsafeCell;
 use std::fmt;
+use std::hash::Hasher;
 use std::pin::Pin;
+use std::ptr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::{Acquire, SeqCst};
 use std::sync::{Arc, Mutex, Weak};
@@ -155,6 +157,35 @@ where
     #[allow(clippy::unnecessary_safety_doc)]
     pub fn weak_count(&self) -> Option<usize> {
         self.inner.as_ref().map(|arc| Arc::weak_count(arc))
+    }
+
+    /// Hashes the internal state of this `Shared` in a way that's compatible with `ptr_eq`.
+    pub fn ptr_hash<H: Hasher>(&self, state: &mut H) {
+        match self.inner.as_ref() {
+            Some(arc) => {
+                state.write_u8(1);
+                ptr::hash(Arc::as_ptr(arc), state);
+            }
+            None => {
+                state.write_u8(0);
+            }
+        }
+    }
+
+    /// Returns `true` if the two `Shared`s point to the same future (in a vein similar to
+    /// `Arc::ptr_eq`).
+    ///
+    /// Returns `false` if either `Shared` has terminated.
+    pub fn ptr_eq(&self, rhs: &Self) -> bool {
+        let lhs = match self.inner.as_ref() {
+            Some(lhs) => lhs,
+            None => return false,
+        };
+        let rhs = match rhs.inner.as_ref() {
+            Some(rhs) => rhs,
+            None => return false,
+        };
+        Arc::ptr_eq(lhs, rhs)
     }
 }
 

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -138,6 +138,7 @@ where
     /// This method by itself is safe, but using it correctly requires extra care. Another thread
     /// can change the strong count at any time, including potentially between calling this method
     /// and acting on the result.
+    #[allow(clippy::unnecessary_safety_doc)]
     pub fn strong_count(&self) -> Option<usize> {
         self.inner.as_ref().map(|arc| Arc::strong_count(arc))
     }
@@ -151,6 +152,7 @@ where
     /// This method by itself is safe, but using it correctly requires extra care. Another thread
     /// can change the weak count at any time, including potentially between calling this method
     /// and acting on the result.
+    #[allow(clippy::unnecessary_safety_doc)]
     pub fn weak_count(&self) -> Option<usize> {
         self.inner.as_ref().map(|arc| Arc::weak_count(arc))
     }

--- a/futures-util/src/future/select_all.rs
+++ b/futures-util/src/future/select_all.rs
@@ -58,6 +58,7 @@ impl<Fut: Future + Unpin> Future for SelectAll<Fut> {
         });
         match item {
             Some((idx, res)) => {
+                #[allow(clippy::let_underscore_future)]
                 let _ = self.inner.swap_remove(idx);
                 let rest = mem::take(&mut self.inner);
                 Poll::Ready((res, idx, rest))

--- a/futures-util/src/future/try_join_all.rs
+++ b/futures-util/src/future/try_join_all.rs
@@ -77,6 +77,20 @@ where
 /// This function is only available when the `std` or `alloc` feature of this
 /// library is activated, and it is activated by default.
 ///
+/// # See Also
+///
+/// `try_join_all` will switch to the more powerful [`FuturesOrdered`] for performance
+/// reasons if the number of futures is large. You may want to look into using it or
+/// it's counterpart [`FuturesUnordered`][crate::stream::FuturesUnordered] directly.
+///
+/// Some examples for additional functionality provided by these are:
+///
+///  * Adding new futures to the set even after it has been started.
+///
+///  * Only polling the specific futures that have been woken. In cases where
+///    you have a lot of futures this will result in much more efficient polling.
+///
+///
 /// # Examples
 ///
 /// ```

--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -73,7 +73,10 @@ where
                     this.state.set(UnfoldState::Value { value: state });
                     Ok(())
                 }
-                Err(err) => Err(err),
+                Err(err) => {
+                    this.state.set(UnfoldState::Empty);
+                    Err(err)
+                }
             }
         } else {
             Ok(())

--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -58,7 +58,7 @@ where
 
 /// An unbounded queue of futures.
 ///
-/// This "combinator" is similar to `FuturesUnordered`, but it imposes an order
+/// This "combinator" is similar to [`FuturesUnordered`], but it imposes a FIFO order
 /// on top of the set of futures. While futures in the set will race to
 /// completion in parallel, results will only be returned in the order their
 /// originating futures were added to the queue.

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -33,6 +33,9 @@ use self::ready_to_run_queue::{Dequeue, ReadyToRunQueue};
 
 /// A set of futures which may complete in any order.
 ///
+/// See [`FuturesOrdered`](crate::stream::FuturesOrdered) for a version of this
+/// type that preserves a FIFO order.
+///
 /// This structure is optimized to manage a large number of futures.
 /// Futures managed by [`FuturesUnordered`] will only be polled when they
 /// generate wake-up notifications. This reduces the required amount of work

--- a/futures-util/src/stream/stream/buffered.rs
+++ b/futures-util/src/stream/stream/buffered.rs
@@ -1,4 +1,4 @@
-use crate::stream::{Fuse, FuturesOrdered, StreamExt};
+use crate::stream::{Fuse, FusedStream, FuturesOrdered, StreamExt};
 use core::fmt;
 use core::pin::Pin;
 use futures_core::future::Future;
@@ -92,6 +92,16 @@ where
             None => None,
         };
         (lower, upper)
+    }
+}
+
+impl<St> FusedStream for Buffered<St>
+where
+    St: Stream,
+    St::Item: Future,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_done() && self.in_progress_queue.is_terminated()
     }
 }
 

--- a/futures-util/src/stream/stream/chain.rs
+++ b/futures-util/src/stream/stream/chain.rs
@@ -50,8 +50,9 @@ where
             if let Some(item) = ready!(first.poll_next(cx)) {
                 return Poll::Ready(Some(item));
             }
+
+            this.first.set(None);
         }
-        this.first.set(None);
         this.second.poll_next(cx)
     }
 

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1513,8 +1513,7 @@ pub trait StreamExt: Stream {
     /// be immediately returned.
     ///
     /// If the underlying stream ended and only a partial vector was created,
-    /// it'll be returned. Additionally if an error happens from the underlying
-    /// stream then the currently buffered items will be yielded.
+    /// it will be returned.
     ///
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -1,4 +1,4 @@
-use crate::stream::Fuse;
+use crate::stream::{Fuse, StreamExt};
 use alloc::vec::Vec;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
@@ -22,7 +22,7 @@ impl<St: Stream> ReadyChunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 
-        Self { stream: super::Fuse::new(stream), cap: capacity }
+        Self { stream: stream.fuse(), cap: capacity }
     }
 
     delegate_access_inner!(stream, St, (.));
@@ -75,7 +75,7 @@ impl<St: Stream> Stream for ReadyChunks<St> {
     }
 }
 
-impl<St: FusedStream> FusedStream for ReadyChunks<St> {
+impl<St: Stream> FusedStream for ReadyChunks<St> {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()
     }

--- a/futures-util/src/stream/stream/ready_chunks.rs
+++ b/futures-util/src/stream/stream/ready_chunks.rs
@@ -1,6 +1,5 @@
 use crate::stream::Fuse;
 use alloc::vec::Vec;
-use core::mem;
 use core::pin::Pin;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
@@ -15,7 +14,6 @@ pin_project! {
     pub struct ReadyChunks<St: Stream> {
         #[pin]
         stream: Fuse<St>,
-        items: Vec<St::Item>,
         cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
     }
 }
@@ -24,11 +22,7 @@ impl<St: Stream> ReadyChunks<St> {
     pub(super) fn new(stream: St, capacity: usize) -> Self {
         assert!(capacity > 0);
 
-        Self {
-            stream: super::Fuse::new(stream),
-            items: Vec::with_capacity(capacity),
-            cap: capacity,
-        }
+        Self { stream: super::Fuse::new(stream), cap: capacity }
     }
 
     delegate_access_inner!(stream, St, (.));
@@ -40,40 +34,33 @@ impl<St: Stream> Stream for ReadyChunks<St> {
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
+        let mut items: Vec<St::Item> = Vec::new();
+
         loop {
             match this.stream.as_mut().poll_next(cx) {
                 // Flush all collected data if underlying stream doesn't contain
                 // more ready values
                 Poll::Pending => {
-                    return if this.items.is_empty() {
-                        Poll::Pending
-                    } else {
-                        Poll::Ready(Some(mem::replace(this.items, Vec::with_capacity(*this.cap))))
-                    }
+                    return if items.is_empty() { Poll::Pending } else { Poll::Ready(Some(items)) }
                 }
 
                 // Push the ready item into the buffer and check whether it is full.
                 // If so, replace our buffer with a new and empty one and return
                 // the full one.
                 Poll::Ready(Some(item)) => {
-                    this.items.push(item);
-                    if this.items.len() >= *this.cap {
-                        return Poll::Ready(Some(mem::replace(
-                            this.items,
-                            Vec::with_capacity(*this.cap),
-                        )));
+                    if items.is_empty() {
+                        items.reserve(*this.cap);
+                    }
+                    items.push(item);
+                    if items.len() >= *this.cap {
+                        return Poll::Ready(Some(items));
                     }
                 }
 
                 // Since the underlying stream ran out of values, return what we
                 // have buffered, if we have anything.
                 Poll::Ready(None) => {
-                    let last = if this.items.is_empty() {
-                        None
-                    } else {
-                        let full_buf = mem::take(this.items);
-                        Some(full_buf)
-                    };
+                    let last = if items.is_empty() { None } else { Some(items) };
 
                     return Poll::Ready(last);
                 }
@@ -82,20 +69,15 @@ impl<St: Stream> Stream for ReadyChunks<St> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let chunk_len = usize::from(!self.items.is_empty());
         let (lower, upper) = self.stream.size_hint();
-        let lower = (lower / self.cap).saturating_add(chunk_len);
-        let upper = match upper {
-            Some(x) => x.checked_add(chunk_len),
-            None => None,
-        };
+        let lower = lower / self.cap;
         (lower, upper)
     }
 }
 
 impl<St: FusedStream> FusedStream for ReadyChunks<St> {
     fn is_terminated(&self) -> bool {
-        self.stream.is_terminated() && self.items.is_empty()
+        self.stream.is_terminated()
     }
 }
 

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.25", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.25", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.25", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.25", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.25", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.25", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.25", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.26", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.26", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.26", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.26", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.26", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.26", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.26", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -380,11 +380,13 @@ fn try_join_size() {
     assert_eq!(mem::size_of_val(&fut), 48);
 }
 
+#[allow(clippy::let_underscore_future)]
 #[test]
 fn join_doesnt_require_unpin() {
     let _ = async { join!(async {}, async {}) };
 }
 
+#[allow(clippy::let_underscore_future)]
 #[test]
 fn try_join_doesnt_require_unpin() {
     let _ = async { try_join!(async { Ok::<(), ()>(()) }, async { Ok::<(), ()>(()) },) };

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -1480,10 +1480,10 @@ pub mod stream {
     assert_not_impl!(PollImmediate<PinnedStream>: Unpin);
 
     assert_impl!(ReadyChunks<SendStream<()>>: Send);
-    assert_not_impl!(ReadyChunks<SendStream>: Send);
+    assert_impl!(ReadyChunks<SendStream>: Send);
     assert_not_impl!(ReadyChunks<LocalStream>: Send);
     assert_impl!(ReadyChunks<SyncStream<()>>: Sync);
-    assert_not_impl!(ReadyChunks<SyncStream>: Sync);
+    assert_impl!(ReadyChunks<SyncStream>: Sync);
     assert_not_impl!(ReadyChunks<LocalStream>: Sync);
     assert_impl!(ReadyChunks<UnpinStream>: Unpin);
     assert_not_impl!(ReadyChunks<PinnedStream>: Unpin);

--- a/futures/tests/eventual.rs
+++ b/futures/tests/eventual.rs
@@ -16,6 +16,8 @@ fn join1() {
     run(future::try_join(ok::<i32, i32>(1), ok(2)).map_ok(move |v| tx.send(v).unwrap()));
     assert_eq!(rx.recv(), Ok((1, 2)));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -30,6 +32,8 @@ fn join2() {
     c2.send(2).unwrap();
     assert_eq!(rx.recv(), Ok((1, 2)));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -43,6 +47,8 @@ fn join3() {
     assert_eq!(rx.recv(), Ok(1));
     assert!(rx.recv().is_err());
     drop(c2);
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -56,6 +62,8 @@ fn join4() {
     assert!(rx.recv().is_ok());
     drop(c2);
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -73,6 +81,8 @@ fn join5() {
     c3.send(3).unwrap();
     assert_eq!(rx.recv(), Ok(((1, 2), 3)));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -92,6 +102,8 @@ fn select1() {
     c2.send(2).unwrap();
     assert_eq!(rx.recv(), Ok(2));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -111,6 +123,8 @@ fn select2() {
     c2.send(2).unwrap();
     assert_eq!(rx.recv(), Ok(2));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -130,6 +144,8 @@ fn select3() {
     drop(c2);
     assert_eq!(rx.recv(), Ok(2));
     assert!(rx.recv().is_err());
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }
 
 #[test]
@@ -158,4 +174,6 @@ fn select4() {
     drop(tx);
 
     t.join().unwrap();
+
+    std::thread::sleep(std::time::Duration::from_millis(500)); // wait for background threads closed: https://github.com/rust-lang/miri/issues/1371
 }

--- a/no_atomic_cas.rs
+++ b/no_atomic_cas.rs
@@ -5,8 +5,6 @@ const NO_ATOMIC_CAS: &[&str] = &[
     "armv4t-none-eabi",
     "armv5te-none-eabi",
     "avr-unknown-gnu-atmega328",
-    "bpfeb-unknown-none",
-    "bpfel-unknown-none",
     "msp430-none-elf",
     "riscv32i-unknown-none-elf",
     "riscv32im-unknown-none-elf",

--- a/no_atomic_cas.rs
+++ b/no_atomic_cas.rs
@@ -5,6 +5,8 @@ const NO_ATOMIC_CAS: &[&str] = &[
     "armv4t-none-eabi",
     "armv5te-none-eabi",
     "avr-unknown-gnu-atmega328",
+    "bpfeb-unknown-none",
+    "bpfel-unknown-none",
     "msp430-none-elf",
     "riscv32i-unknown-none-elf",
     "riscv32im-unknown-none-elf",


### PR DESCRIPTION
Changes:
* Add `Either::as_pin_mut` and `Either::as_pin_ref` (#2691)
* Add `Shared::ptr_eq` and `Shared::ptr_hash` (#2691)
* Implement `FusedStream` for `Buffered` (#2676)
* Implement `FusedStream` for all streams in `ReadyChunks` (#2693)
* Fix bug in `FuturesOrdered::push_front` (#2664)
* Remove `Fut::Output: Clone` bounds from some `Shared` methods (#2662)
* Remove `T: Debug` bounds from `Debug` implementations of `mpsc` and `oneshot` types (#2666, #2667)

Closes #2698