### PR TITLE
Ensure unreachable branch is eliminated

### DIFF
--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -99,14 +99,24 @@ where
     type Output = Either<(A::Output, B), (B::Output, A)>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        /// When compiled with `-C opt-level=z`, this function will help the compiler eliminate the `None` branch, where
+        /// `Option::unwrap` does not.
+        #[inline(always)]
+        fn unwrap_option<T>(value: Option<T>) -> T {
+            match value {
+                None => unreachable!(),
+                Some(value) => value,
+            }
+        }
+
         let (a, b) = self.inner.as_mut().expect("cannot poll Select twice");
 
         if let Poll::Ready(val) = a.poll_unpin(cx) {
-            return Poll::Ready(Either::Left((val, self.inner.take().unwrap().1)));
+            return Poll::Ready(Either::Left((val, unwrap_option(self.inner.take()).1)));
         }
 
         if let Poll::Ready(val) = b.poll_unpin(cx) {
-            return Poll::Ready(Either::Right((val, self.inner.take().unwrap().0)));
+            return Poll::Ready(Either::Right((val, unwrap_option(self.inner.take()).0)));
         }
 
         Poll::Pending


### PR DESCRIPTION
With #2704, I introduced two `unwrap()` calls in `Select::poll`, but I found that with `opt-level=z`, the compiler won’t be able to optimize these `unwrap()` calls, so maybe changing them to `unwrap_unchecked()` is a better idea? See <https://godbolt.org/z/cef118zKe> for comparison with `opt-level=z`.

Also, since `unwrap_unchecked()` is introduced in Rust 1.58.0, I have to implement this function manually.