### PR TITLE
add AbortRegistration::create_handle

### DIFF
--- a/futures-util/src/abortable.rs
+++ b/futures-util/src/abortable.rs
@@ -78,6 +78,17 @@ pub struct AbortRegistration {
     pub(crate) inner: Arc<AbortInner>,
 }
 
+impl AbortRegistration {
+    /// Create an [`AbortHandle`] from the given [`AbortRegistration`].
+    ///
+    /// The created [`AbortHandle`] is functionally the same as any other
+    /// [`AbortHandle`]s that are associated with the same [`AbortRegistration`],
+    /// such as the one created by [`AbortHandle::new_pair`].
+    pub fn create_handle(&self) -> AbortHandle {
+        AbortHandle { inner: self.inner.clone() }
+    }
+}
+
 /// A handle to an `Abortable` task.
 #[derive(Debug, Clone)]
 pub struct AbortHandle {


### PR DESCRIPTION
Allow to create `AbortHandle` from `AbortRegistration`. The implementation is obvious. Since `AbortHandle` is already `Clone`, this API should not create too much problem.

# Motivation
The intended use case is pretty niche. I'll try to explain. There is this single scenario where we have access to `AbortRegistration`, but can't have access to `AbortHandle`.

I'm trying to create a zero-cost abstraction over the different async executors. One major concern is to ensure the uniformity of cancellation propagation between different async executor backends. When I try to implement a cancel-on-drop semantic, due to limitations of `async-std`, it requires an `Abortable` wrapper to ensure the cancellation propagation. (as [others](https://github.com/najamelan/async_executors#performance) have also found out).

Users may well combine a cancel-on-drop spawn with an `Abortable`, which results in two consecutive `Abortable` wrappers in `async-std`, which may be flattened into one. From a zero-cost abstraction, a more specific "cancel-on-drop-with-Abortable` semantic is needed to avoid extra cost on `async-std`. Which, unfortunately, has no other signature than the following.

```
pub trait SpawnAbortableScoped: Send + Sync + 'static {
    type JoinHandle<Output: Send + 'static>: JoinHandle<Output>;
    fn spawn_abortable_scoped<F, T: Send + 'static>(
        &self,
        f: F,
        reg: futures::future::AbortRegistration,
    ) -> Self::JoinHandle<Result<T, futures::future::Aborted>>
    where
        F: Future<Output = T> + Send + 'static;
}
```
We cannot add an `AbortHandle` parameter since other executors do not need `AbortHandle` to propagate the cancellation. Adding one violates zero-cost abstraction. However, on `async-std` we do need an `AbortHandle` for cancellation propagation. This prompts the need for this API.