### PR TITLE
Improve comment for `FuturesOrdered` and `FuturesUnordered`

### DIFF
--- a/futures-util/src/stream/futures_ordered.rs
+++ b/futures-util/src/stream/futures_ordered.rs
@@ -60,8 +60,9 @@ where
 ///
 /// This "combinator" is similar to [`FuturesUnordered`], but it imposes a FIFO order
 /// on top of the set of futures. While futures in the set will race to
-/// completion in parallel, results will only be returned in the order their
-/// originating futures were added to the queue.
+/// completion, results will only be returned in the order their originating futures
+/// were added to the queue. Note that the futures run to completion concurrently and
+/// not in parallel.
 ///
 /// Futures are pushed into this queue and their realized values are yielded in
 /// order. This structure is optimized to manage a large number of futures.

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -39,7 +39,8 @@ use self::ready_to_run_queue::{Dequeue, ReadyToRunQueue};
 /// This structure is optimized to manage a large number of futures.
 /// Futures managed by [`FuturesUnordered`] will only be polled when they
 /// generate wake-up notifications. This reduces the required amount of work
-/// needed to poll large numbers of futures.
+/// needed to poll large numbers of futures. Note that the futures run to
+/// completion concurrently and not in parallel.
 ///
 /// [`FuturesUnordered`] can be filled by [`collect`](Iterator::collect)ing an
 /// iterator of futures into a [`FuturesUnordered`], or by


### PR DESCRIPTION
For `FuturesOrdered` there is a comment that says the futures would run in parallel, which is misleading.

This PR makes clear that futures for `FuturesOrdered` and `FuturesUnordered` run to completion concurrently instead of parallel.