### PR TITLE
Fix unreachable match arm in FillBuf being reachable

### DIFF
--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -430,3 +430,16 @@ fn maybe_pending_seek() {
     Pin::new(&mut reader).consume(1);
     assert_eq!(run(reader.seek(SeekFrom::Current(-2))).ok(), Some(3));
 }
+
+#[test]
+fn fill_buf_pending_after_eof() {
+    let inner: &[u8] = &[1, 2];
+    let mut reader = BufReader::with_capacity(inner.len(), MaybePending::new(inner));
+
+    let buf = run(reader.fill_buf()).unwrap();
+    assert_eq!(buf, inner);
+    reader.consume_unpin(2);
+
+    let buf = run(reader.fill_buf()).unwrap();
+    assert_eq!(buf, []);
+}


### PR DESCRIPTION
I hit [this `unreachable!()`](https://github.com/rust-lang/futures-rs/blob/8253b784fd45c832ad208d5b8e259f639fc42684/futures-util/src/io/fill_buf.rs#L41) inside `FillBuf` with an `AsyncRead` implementation (wrapped in a `BufReader`) which calls a Javascript callback thru `neon` (which is an async operation) for the actual read, which means every "new" `poll_read` (i.e. either the first call ever or the first call after a `Ready` is returned) will return `Pending` at least once, including after EOF is hit, which is what triggers this bug. Of course, the `AsyncRead` implementation could track when EOF is hit and return `Ready(0)` forever after that, which is indeed what I used as a workaround, but I can't find anything in the `AsyncRead` documentation which actually requires implementors to do this.

Alternatively to this fix, the `AsyncRead` documentation could require implementors to always return `Ready(0)` after an EOF, and the `unreachable!()` changed to a `panic!()`, but that seems like more potential downstream work than merging this fix, and seems easy to screw up.

Another similar alternative would be for the `AsyncBufRead` documentation to require implementors to always return `Ready(&[])` after an EOF.

The added test triggers the panic if run without the bug fix.

