### PR TITLE
Fix unknown_lints and unused_imports warnings in test

### DIFF
--- a/futures/tests/no-std/src/lib.rs
+++ b/futures/tests/no-std/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(nightly)]
 #![no_std]
-#![allow(useless_anonymous_reexport)]
+#![allow(unused_imports)]
 
 #[cfg(feature = "futures-core-alloc")]
 #[cfg(target_has_atomic = "ptr")]


### PR DESCRIPTION
```
error: unknown lint: `useless_anonymous_reexport`
 --> futures/tests/no-std/src/lib.rs:3:10
  |
3 | #![allow(useless_anonymous_reexport)]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D unknown-lints` implied by `-D warnings`

error: unused import: `futures_core::task::__internal::AtomicWaker as _`
 --> futures/tests/no-std/src/lib.rs:7:9
  |
7 | pub use futures_core::task::__internal::AtomicWaker as _;
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `-D unused-imports` implied by `-D warnings`

error: unused import: `futures_channel::oneshot as _`
  --> futures/tests/no-std/src/lib.rs:15:9
   |
15 | pub use futures_channel::oneshot as _;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unused import: `futures::task::AtomicWaker as _`
  --> futures/tests/no-std/src/lib.rs:19:9
   |
19 | pub use futures::task::AtomicWaker as _;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unused import: `futures::stream::FuturesOrdered as _`
  --> futures/tests/no-std/src/lib.rs:23:9
   |
23 | pub use futures::stream::FuturesOrdered as _;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unused import: `futures_util::task::AtomicWaker as _`
  --> futures/tests/no-std/src/lib.rs:27:9
   |
27 | pub use futures_util::task::AtomicWaker as _;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: unused import: `futures_util::stream::FuturesOrdered as _`
  --> futures/tests/no-std/src/lib.rs:31:9
   |
31 | pub use futures_util::stream::FuturesOrdered as _;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```