### PR TITLE
Bump MSRV of utility crates to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         rust:
           # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
-          - '1.45'
+          - '1.56'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 futures = "0.3"
 ```
 
-The current `futures` requires Rust 1.45 or later.
+The current `futures` requires Rust 1.56 or later.
 
 ### Feature `std`
 

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-channel"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-channel/README.md
+++ b/futures-channel/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-channel = "0.3"
 ```
 
-The current `futures-channel` requires Rust 1.45 or later.
+The current `futures-channel` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-executor"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-executor/README.md
+++ b/futures-executor/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-executor = "0.3"
 ```
 
-The current `futures-executor` requires Rust 1.45 or later.
+The current `futures-executor` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-macro"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-task"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/README.md
+++ b/futures-task/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-task = "0.3"
 ```
 
-The current `futures-task` requires Rust 1.45 or later.
+The current `futures-task` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-test"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-test/README.md
+++ b/futures-test/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-test = "0.3"
 ```
 
-The current `futures-test` requires Rust 1.45 or later.
+The current `futures-test` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-util"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-util/README.md
+++ b/futures-util/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-util = "0.3"
 ```
 
-The current `futures-util` requires Rust 1.45 or later.
+The current `futures-util` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]


### PR DESCRIPTION
This bumps MSRV of utility crates (futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test) to 1.56.

syn 2.0 requires 1.56.
Unblock #2730 