### PR TITLE
Release 0.3.28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,24 +48,24 @@ jobs:
       - run: cargo test --workspace --all-features --release
 
   cross:
-    name: cross test --target ${{ matrix.target }}
+    name: cargo test --target ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
         target:
-          - i686-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
+          - i686-unknown-linux-gnu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
-      - name: Install cross
-        uses: taiki-e/install-action@cross
-      - run: cross test --target ${{ matrix.target }} --workspace --all-features
-      - run: cross test --target ${{ matrix.target }} --workspace --all-features --release
-        # TODO: https://github.com/rust-lang/futures-rs/issues/2451
-        if: matrix.target != 'aarch64-unknown-linux-gnu'
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+      - run: cargo test --target ${{ matrix.target }} --workspace --all-features $DOCTEST_XCOMPILE
+      - run: cargo test --target ${{ matrix.target }} --workspace --all-features --release $DOCTEST_XCOMPILE
 
   core-msrv:
     name: cargo +${{ matrix.rust }} build (futures-{core, io, sink})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         rust:
           # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
-          - '1.45'
+          - '1.56'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.28 - 2023-03-30
+
+* Update to syn 2. This raises MSRV of utility crates to 1.56. (#2730, #2733)
+* Fix bug in `FlattenUnordered` (#2726, #2728)
+
 # 0.3.27 - 2023-03-11
 
 * Add `TryFlattenUnordered` (#2577, #2590, #2606, #2607)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 futures = "0.3"
 ```
 
-The current `futures` requires Rust 1.45 or later.
+The current `futures` requires Rust 1.56 or later.
 
 ### Feature `std`
 

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-channel"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.27", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.27", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.28", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.28", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-channel/README.md
+++ b/futures-channel/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-channel = "0.3"
 ```
 
-The current `futures-channel` requires Rust 1.45 or later.
+The current `futures-channel` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-core/src/task/__internal/atomic_waker.rs
+++ b/futures-core/src/task/__internal/atomic_waker.rs
@@ -271,7 +271,12 @@ impl AtomicWaker {
             WAITING => {
                 unsafe {
                     // Locked acquired, update the waker cell
-                    *self.waker.get() = Some(waker.clone());
+
+                    // Avoid cloning the waker if the old waker will awaken the same task.
+                    match &*self.waker.get() {
+                        Some(old_waker) if old_waker.will_wake(waker) => (),
+                        _ => *self.waker.get() = Some(waker.clone()),
+                    }
 
                     // Release the lock. If the state transitioned to include
                     // the `WAKING` bit, this means that at least one wake has

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std", "num_cpus"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.27", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.27", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.27", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.28", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.28", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.28", default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 
 [dev-dependencies]

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-executor"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-executor/README.md
+++ b/futures-executor/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-executor = "0.3"
 ```
 
-The current `futures-executor` requires Rust 1.45 or later.
+The current `futures-executor` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-macro"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -18,4 +18,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0.56", features = ["full"] }
+syn = { version = "2.0.8", features = ["full"] }

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"

--- a/futures-macro/src/executor.rs
+++ b/futures-macro/src/executor.rs
@@ -44,6 +44,7 @@ pub(crate) fn test(args: TokenStream, item: TokenStream) -> TokenStream {
             #path::block_on(async #body)
         })
         .unwrap(),
+        None,
     )];
 
     let gen = quote! {

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -51,7 +51,7 @@ impl Parse for Select {
                 CaseKind::Default
             } else {
                 // `<pat> = <expr>`
-                let pat = input.parse()?;
+                let pat = Pat::parse_multi_with_leading_vert(input)?;
                 input.parse::<Token![=]>()?;
                 let expr = input.parse()?;
                 CaseKind::Normal(pat, expr)

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.36"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-task"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/README.md
+++ b/futures-task/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-task = "0.3"
 ```
 
-The current `futures-task` requires Rust 1.45 or later.
+The current `futures-task` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
@@ -11,13 +11,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.27", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.27", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.27", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.27", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.27", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.27", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.27", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.28", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.28", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.28", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.28", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.28", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.28", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.28", path = "../futures-macro", default-features = false }
 pin-utils = { version = "0.1.0", default-features = false }
 pin-project = "1.0.11"
 

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-test"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-test/README.md
+++ b/futures-test/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-test = "0.3"
 ```
 
-The current `futures-test` requires Rust 1.45 or later.
+The current `futures-test` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-test/src/task/mod.rs
+++ b/futures-test/src/task/mod.rs
@@ -23,7 +23,7 @@
 //! Test wakers:
 //! - [`noop_waker`](crate::task::noop_waker) creates a waker that ignores calls to
 //!   [`wake`](futures_core::task::Waker).
-//! - [`panic_waker`](crate::task::panic_waker) creates a waker that panics when
+//! - [`panic_waker`](crate::task::panic_waker()) creates a waker that panics when
 //!   [`wake`](futures_core::task::Waker) is called.
 //! - [`new_count_waker`](crate::task::new_count_waker) creates a waker that increments a counter whenever
 //!   [`wake`](futures_core::task::Waker) is called.

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
@@ -35,12 +35,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.27", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.27", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.27", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.27", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.27", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.27", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.28", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.28", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.28", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.28", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.28", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.28", default-features = false, optional = true }
 slab = { version = "0.4.2", optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-util"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-util/README.md
+++ b/futures-util/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-util = "0.3"
 ```
 
-The current `futures-util` requires Rust 1.45 or later.
+The current `futures-util` requires Rust 1.56 or later.
 
 ## License
 

--- a/futures-util/src/stream/select_all.rs
+++ b/futures-util/src/stream/select_all.rs
@@ -8,29 +8,24 @@ use futures_core::ready;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 
-use pin_project_lite::pin_project;
-
 use super::assert_stream;
 use crate::stream::{futures_unordered, FuturesUnordered, StreamExt, StreamFuture};
 
-pin_project! {
-    /// An unbounded set of streams
-    ///
-    /// This "combinator" provides the ability to maintain a set of streams
-    /// and drive them all to completion.
-    ///
-    /// Streams are pushed into this set and their realized values are
-    /// yielded as they become ready. Streams will only be polled when they
-    /// generate notifications. This allows to coordinate a large number of streams.
-    ///
-    /// Note that you can create a ready-made `SelectAll` via the
-    /// `select_all` function in the `stream` module, or you can start with an
-    /// empty set with the `SelectAll::new` constructor.
-    #[must_use = "streams do nothing unless polled"]
-    pub struct SelectAll<St> {
-        #[pin]
-        inner: FuturesUnordered<StreamFuture<St>>,
-    }
+/// An unbounded set of streams
+///
+/// This "combinator" provides the ability to maintain a set of streams
+/// and drive them all to completion.
+///
+/// Streams are pushed into this set and their realized values are
+/// yielded as they become ready. Streams will only be polled when they
+/// generate notifications. This allows to coordinate a large number of streams.
+///
+/// Note that you can create a ready-made `SelectAll` via the
+/// `select_all` function in the `stream` module, or you can start with an
+/// empty set with the `SelectAll::new` constructor.
+#[must_use = "streams do nothing unless polled"]
+pub struct SelectAll<St> {
+    inner: FuturesUnordered<StreamFuture<St>>,
 }
 
 impl<St: Debug> Debug for SelectAll<St> {

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures"
 version = "0.3.27"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
@@ -15,13 +15,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.27", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.27", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.27", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.27", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.27", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.27", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.27", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.28", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.28", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.28", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.28", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.28", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.28", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.28", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/no-std/src/lib.rs
+++ b/futures/tests/no-std/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(nightly)]
 #![no_std]
-#![allow(useless_anonymous_reexport)]
+#![allow(unused_imports)]
 
 #[cfg(feature = "futures-core-alloc")]
 #[cfg(target_has_atomic = "ptr")]

--- a/futures/tests/no-std/src/lib.rs
+++ b/futures/tests/no-std/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg(nightly)]
 #![no_std]
+#![allow(useless_anonymous_reexport)]
 
 #[cfg(feature = "futures-core-alloc")]
 #[cfg(target_has_atomic = "ptr")]

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -14,6 +14,7 @@ use futures::stream::{self, StreamExt};
 use futures::task::Poll;
 use futures::{ready, FutureExt};
 use futures_core::Stream;
+use futures_executor::ThreadPool;
 use futures_test::task::noop_context;
 
 #[test]
@@ -65,6 +66,7 @@ fn flatten_unordered() {
     use futures::task::*;
     use std::convert::identity;
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::thread;
     use std::time::Duration;
 
@@ -322,6 +324,47 @@ fn flatten_unordered() {
             assert_eq!(values, (0..60).collect::<Vec<u8>>());
         });
     }
+
+    // nested `flatten_unordered`
+    let te = ThreadPool::new().unwrap();
+    let handle = te
+        .spawn_with_handle(async move {
+            let inner = stream::iter(0..10)
+                .then(|_| {
+                    let task = Arc::new(AtomicBool::new(false));
+                    let mut spawned = false;
+
+                    future::poll_fn(move |cx| {
+                        if !spawned {
+                            let waker = cx.waker().clone();
+                            let task = task.clone();
+
+                            std::thread::spawn(move || {
+                                std::thread::sleep(Duration::from_millis(500));
+                                task.store(true, Ordering::Release);
+
+                                waker.wake_by_ref()
+                            });
+                            spawned = true;
+                        }
+
+                        if task.load(Ordering::Acquire) {
+                            Poll::Ready(Some(()))
+                        } else {
+                            Poll::Pending
+                        }
+                    })
+                })
+                .map(|_| stream::once(future::ready(())))
+                .flatten_unordered(None);
+
+            let stream = stream::once(future::ready(inner)).flatten_unordered(None);
+
+            assert_eq!(stream.count().await, 10);
+        })
+        .unwrap();
+
+    block_on(handle);
 }
 
 #[test]

--- a/futures/tests/stream.rs
+++ b/futures/tests/stream.rs
@@ -325,46 +325,77 @@ fn flatten_unordered() {
         });
     }
 
+    fn timeout<I: Clone>(time: Duration, value: I) -> impl Future<Output = I> {
+        let ready = Arc::new(AtomicBool::new(false));
+        let mut spawned = false;
+
+        future::poll_fn(move |cx| {
+            if !spawned {
+                let waker = cx.waker().clone();
+                let ready = ready.clone();
+
+                std::thread::spawn(move || {
+                    std::thread::sleep(time);
+                    ready.store(true, Ordering::Release);
+
+                    waker.wake_by_ref()
+                });
+                spawned = true;
+            }
+
+            if ready.load(Ordering::Acquire) {
+                Poll::Ready(value.clone())
+            } else {
+                Poll::Pending
+            }
+        })
+    }
+
+    fn build_nested_fu<S: Stream + Unpin>(st: S) -> impl Stream<Item = S::Item> + Unpin
+    where
+        S::Item: Clone,
+    {
+        let inner = st
+            .then(|item| timeout(Duration::from_millis(50), item))
+            .enumerate()
+            .map(|(idx, value)| {
+                stream::once(if idx % 2 == 0 {
+                    future::ready(value).left_future()
+                } else {
+                    timeout(Duration::from_millis(100), value).right_future()
+                })
+            })
+            .flatten_unordered(None);
+
+        stream::once(future::ready(inner)).flatten_unordered(None)
+    }
+
     // nested `flatten_unordered`
     let te = ThreadPool::new().unwrap();
-    let handle = te
+    let base_handle = te
         .spawn_with_handle(async move {
-            let inner = stream::iter(0..10)
-                .then(|_| {
-                    let task = Arc::new(AtomicBool::new(false));
-                    let mut spawned = false;
+            let fu = build_nested_fu(stream::iter(1..=10));
 
-                    future::poll_fn(move |cx| {
-                        if !spawned {
-                            let waker = cx.waker().clone();
-                            let task = task.clone();
-
-                            std::thread::spawn(move || {
-                                std::thread::sleep(Duration::from_millis(500));
-                                task.store(true, Ordering::Release);
-
-                                waker.wake_by_ref()
-                            });
-                            spawned = true;
-                        }
-
-                        if task.load(Ordering::Acquire) {
-                            Poll::Ready(Some(()))
-                        } else {
-                            Poll::Pending
-                        }
-                    })
-                })
-                .map(|_| stream::once(future::ready(())))
-                .flatten_unordered(None);
-
-            let stream = stream::once(future::ready(inner)).flatten_unordered(None);
-
-            assert_eq!(stream.count().await, 10);
+            assert_eq!(fu.count().await, 10);
         })
         .unwrap();
 
-    block_on(handle);
+    block_on(base_handle);
+
+    let empty_state_move_handle = te
+        .spawn_with_handle(async move {
+            let mut fu = build_nested_fu(stream::iter(1..10));
+            {
+                let mut cx = noop_context();
+                let _ = fu.poll_next_unpin(&mut cx);
+                let _ = fu.poll_next_unpin(&mut cx);
+            }
+
+            assert_eq!(fu.count().await, 9);
+        })
+        .unwrap();
+
+    block_on(empty_state_move_handle);
 }
 
 #[test]


### PR DESCRIPTION
Changes:

* Update to syn 2. This raises MSRV of utility crates to 1.56. (#2730, #2733)
* Fix bug in `FlattenUnordered` (#2726, #2728)

Backports:
- https://github.com/rust-lang/futures-rs/pull/2580
- https://github.com/rust-lang/futures-rs/pull/2726
- https://github.com/rust-lang/futures-rs/pull/2723
- https://github.com/rust-lang/futures-rs/pull/2728
- https://github.com/rust-lang/futures-rs/pull/2729
- https://github.com/rust-lang/futures-rs/pull/2732
- https://github.com/rust-lang/futures-rs/pull/2733
- https://github.com/rust-lang/futures-rs/pull/2730