### PR TITLE
futures-util: Allow `missing_debug_implementations` on `WakerToHandle`

### DIFF
--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -321,6 +321,9 @@ where
 
 struct NotifyWaker(task03::Waker);
 
+// rustc regression is causing the missing_debug_implementations issue:
+// https://github.com/rust-lang/rust/issues/111359
+#[allow(missing_debug_implementations)]
 #[derive(Clone)]
 struct WakerToHandle<'a>(&'a task03::Waker);
 


### PR DESCRIPTION
Fixes this error on ToT:
```
error: type does not implement `Debug`; consider adding `#[derive(Debug)]` or a manual implementation
   --> futures-util/src/compat/compat01as03.rs:325:1
    |
325 | struct WakerToHandle<'a>(&'a task03::Waker);
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D missing-debug-implementations` implied by `-D warnings`
```

Tested:
- `cargo fmt`.
- `cargo doc`.
- `cargo test --all-features`.