### PR TITLE
Ignore clippy::needless_pass_by_ref_mut lint

### DIFF
--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -27,6 +27,7 @@
     )
 ))]
 #![allow(clippy::arc_with_non_send_sync)] // false positive https://github.com/rust-lang/rust-clippy/issues/11076
+#![allow(clippy::needless_pass_by_ref_mut)]
 
 #[cfg(not(futures_no_atomic_cas))]
 #[cfg(feature = "alloc")]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -20,6 +20,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::needless_borrow)] // https://github.com/rust-lang/futures-rs/pull/2558#issuecomment-1030745203
 #![allow(clippy::arc_with_non_send_sync)] // false positive https://github.com/rust-lang/rust-clippy/issues/11076
+#![allow(clippy::needless_pass_by_ref_mut)]
 
 #[cfg(all(feature = "bilock", not(feature = "unstable")))]
 compile_error!("The `bilock` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_pass_by_ref_mut)]
+
 use futures::channel::{mpsc, oneshot};
 use futures::executor::block_on;
 use futures::future::{self, poll_fn, Future, FutureExt, TryFutureExt};


### PR DESCRIPTION
```
warning: this argument is a mutable reference, but not used mutably
   --> futures-channel/src/oneshot.rs:154:33
    |
154 |     fn poll_canceled(&self, cx: &mut Context<'_>) -> Poll<()> {
    |                                 ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
    = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default

warning: this argument is a mutable reference, but not used mutably
   --> futures-channel/src/oneshot.rs:256:24
    |
256 | ... recv(&self, cx: &mut Context<'_>) -> Poll<Result<T, Cancel...
    |                     ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: this argument is a mutable reference, but not used mutably
   --> futures-util/src/future/future/shared.rs:212:55
    |
212 | ... &mut usize, cx: &mut Context<'_>) {
    |                     ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
    = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default

warning: this argument is a mutable reference, but not used mutably
   --> futures-util/src/stream/stream/flatten_unordered.rs:212:39
    |
212 | ..._waker(self_arc: &mut Arc<Self>, cx: &Context<'_>) {
    |                     ^^^^^^^^^^^^^^ help: consider changing to: `&Arc<Self>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: this argument is a mutable reference, but not used mutably
  --> futures-util/src/compat/compat01as03.rs:36:36
   |
36 | ...>(&mut self, cx: &mut Context<'_>, f: impl FnOnce(&mut T) ->...
   |                     ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: this argument is a mutable reference, but not used mutably
   --> futures-util/src/compat/compat01as03.rs:199:36
    |
199 | ...>(&mut self, cx: &mut Context<'_>, f: impl FnOnce(&mut S) -...
    |                     ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: this argument is a mutable reference, but not used mutably
  --> futures-util/src/lock/bilock.rs:90:33
   |
90 | ..._lock(&self, cx: &mut Context<'_>) -> Poll<BiLockGuard<'_, T...
   |                     ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
   |
   = warning: changing this function will impact semver compatibility
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut

warning: this argument is a mutable reference, but not used mutably
   --> futures/tests/sink.rs:160:25
    |
160 |     fn check(&self, cx: &mut Context<'_>) -> bool {
    |                         ^^^^^^^^^^^^^^^^ help: consider changing to: `&Context<'_>`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
    = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default
```