### PR TITLE
(futures v0.1) Fix logic bug in stream::Stream::filter_map doctest

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -399,7 +399,7 @@ pub trait Stream {
     ///
     /// let (_tx, rx) = mpsc::channel::<i32>(1);
     /// let evens_plus_one = rx.filter_map(|x| {
-    ///     if x % 0 == 2 {
+    ///     if x % 2 == 0 {
     ///         Some(x + 1)
     ///     } else {
     ///         None


### PR DESCRIPTION
If you're wondering why I'm submitting a PR with a patch for the ancient v0.1 branch: We're running `cargo test` for Rust crates that we have packaged for Fedora Linux (where possible), and this issue started happening once we updated to Rust 1.71.0 a few days ago. We still have futures v0.1 packaged since quite a few things are sadly still depending on it (mostly via tokio 0.1).

The operator for the modulo and the test were swapped, and using "modulo zero" is undefined and results in an unconditional panic, which is now caught with Rust 1.71 (unconditional_panic lint).

```
---- src/stream/mod.rs - stream::Stream::filter_map (line 396) stdout ----
error: this operation will panic at runtime
  --> src/stream/mod.rs:403:8
   |
10 |     if x % 0 == 2 {
   |        ^^^^^ attempt to calculate the remainder of `_` with a divisor of zero
   |
   = note: `#[deny(unconditional_panic)]` on by default
error: aborting due to previous error
Couldn't compile the test.
failures:
    src/stream/mod.rs - stream::Stream::filter_map (line 396)
```

It's a simple fix for an unimportant thing in an ancient branch, but since I patched this for our futures v0.1 package already, I thought I'd submit it upstream, even if you might just say "we don't care about this any more" (which would be fine with me!).