### PR TITLE
Implement the `UnwindSafe`/`RefUnwindSafe` traits on channels

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -82,6 +82,7 @@ use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::__internal::AtomicWaker;
 use futures_core::task::{Context, Poll, Waker};
 use std::fmt;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -146,6 +147,35 @@ pub struct UnboundedReceiver<T> {
 
 // `Pin<&mut UnboundedReceiver<T>>` is never projected to `Pin<&mut T>`
 impl<T> Unpin for UnboundedReceiver<T> {}
+
+// The `UnwindSafe` trait is not easy to reason about. Rather than demonstrate
+// why `UnwindSafe` is required on `T`, it is easier to give counter-examples
+// where unwind safety would be broken without this requirement.
+// For the `Receiver`, a counter-example is trivial: without the trait bound
+// requirement, one could pass a `Receiver` through the `catch_unwind`
+// boundary then send a non-`UnwindSafe` trait to it from the outside.
+// For the `Sender`, a counter-example is:
+// let (tx, rx) = channel::<Arc<RefCell<Foo>>>();
+// catch_unwind(|| {
+//   let a = Arc::new(RefCell::new(...));
+//   tx.send(a.clone());
+//   a.borrow_mut().half_modification();
+//   panic!();
+// })
+// let a = rx.recv().unwrap(); // `a` is in a corrupted state.
+impl<T: UnwindSafe> UnwindSafe for UnboundedReceiver<T> {}
+impl<T: UnwindSafe> UnwindSafe for UnboundedSender<T> {}
+impl<T: UnwindSafe> UnwindSafe for Receiver<T> {}
+impl<T: UnwindSafe> UnwindSafe for Sender<T> {}
+// There's nothing the API user can do with a `&Sender<T>` or `&Receiver<T>`.
+// They act as a potential container for a `T` and are thus similar to, say,
+// a `Box` for unwind-safety-related purposes. If it was possible to
+// send/receive items through a `&Sender` or `&Receiver`, then this would
+// require `T: UnwindSafe` instead.
+impl<T: RefUnwindSafe> RefUnwindSafe for UnboundedReceiver<T> {}
+impl<T: RefUnwindSafe> RefUnwindSafe for UnboundedSender<T> {}
+impl<T: RefUnwindSafe> RefUnwindSafe for Receiver<T> {}
+impl<T: RefUnwindSafe> RefUnwindSafe for Sender<T> {}
 
 /// The error type for [`Sender`s](Sender) used as `Sink`s.
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
To my surprise, this trait isn't implemented on channels, even though channels are kind of a critical component to unwind safety.

See the code comment for an explanation of the reasoning.

I'm not 100% confident in what I'm doing, so feel free to summon unwind-safety experts, if there is any.
