### PR TITLE
Remove an outdated comment from docs

### DIFF
--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -463,10 +463,6 @@ pub trait FutureExt: Future {
     /// ```
     ///
     /// ```
-    /// // Note, unlike most examples this is written in the context of a
-    /// // synchronous function to better illustrate the cross-thread aspect of
-    /// // the `shared` combinator.
-    ///
     /// # futures::executor::block_on(async {
     /// use futures::future::FutureExt;
     /// use futures::executor::block_on;


### PR DESCRIPTION
The comment in the example is wrong, since the example is actually wrapped in `async{}` (and this is used, note the `.await` at the end).