### PR TITLE
Fix infinite loop caused by invalid UTF-8 bytes

### DIFF
--- a/futures-util/src/io/read_line.rs
+++ b/futures-util/src/io/read_line.rs
@@ -35,6 +35,7 @@ pub(super) fn read_line_internal<R: AsyncBufRead + ?Sized>(
 ) -> Poll<io::Result<usize>> {
     let ret = ready!(read_until_internal(reader, cx, b'\n', bytes, read));
     if str::from_utf8(bytes).is_err() {
+        bytes.clear();
         Poll::Ready(ret.and_then(|_| {
             Err(io::Error::new(io::ErrorKind::InvalidData, "stream did not contain valid UTF-8"))
         }))


### PR DESCRIPTION
Fix #2784