### PR TITLE
Fix unused_imports warning

### DIFF
--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -31,9 +31,11 @@ mod select_mod;
 pub use self::select_mod::*;
 
 // Primary export is a macro
+#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 mod stream_select_mod;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/64762
+#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 pub use self::stream_select_mod::*;
 

--- a/futures-util/src/async_await/stream_select_mod.rs
+++ b/futures-util/src/async_await/stream_select_mod.rs
@@ -1,6 +1,5 @@
 //! The `stream_select` macro.
 
-#[cfg(feature = "std")]
 #[allow(unreachable_pub)]
 #[doc(hidden)]
 pub use futures_macro::stream_select_internal;
@@ -28,7 +27,6 @@ pub use futures_macro::stream_select_internal;
 /// }
 /// # });
 /// ```
-#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! stream_select {
     ($($tokens:tt)*) => {{


### PR DESCRIPTION
```
   error: unused import: `self::stream_select_mod::*`
    --> futures-util/src/async_await/mod.rs:38:9
     |
  38 | pub use self::stream_select_mod::*;
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `-D unused-imports` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(unused_imports)]`
```