### PR TITLE
Provide AtomicWaker if portable-atomic feature is enabled, even if atomic CAS is not available

### DIFF
--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -16,7 +16,7 @@ std = ["alloc"]
 alloc = []
 
 [dependencies]
-portable-atomic = { version = "1", default-features = false, optional = true }
+portable-atomic = { version = "1.3", optional = true, default-features = false, features = ["require-cas"] }
 
 [dev-dependencies]
 futures = { path = "../futures" }

--- a/futures-core/src/task/__internal/mod.rs
+++ b/futures-core/src/task/__internal/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(not(futures_no_atomic_cas))]
+#[cfg(any(not(futures_no_atomic_cas), feature = "portable-atomic"))]
 mod atomic_waker;
-#[cfg(not(futures_no_atomic_cas))]
+#[cfg(any(not(futures_no_atomic_cas), feature = "portable-atomic"))]
 pub use self::atomic_waker::AtomicWaker;

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -30,7 +30,7 @@ pub use futures_task::waker;
 #[cfg(feature = "alloc")]
 pub use futures_task::{waker_ref, WakerRef};
 
-#[cfg(not(futures_no_atomic_cas))]
+#[cfg(any(not(futures_no_atomic_cas), feature = "portable-atomic"))]
 pub use futures_core::task::__internal::AtomicWaker;
 
 mod spawn;


### PR DESCRIPTION
Follow-up to #2670.