### PR TITLE
Fix docs for `TryAll` and `TryAny` adapters

### DIFF
--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -52,8 +52,8 @@ pub use self::stream::{ReuniteError, SplitSink, SplitStream};
 
 mod try_stream;
 pub use self::try_stream::{
-    try_unfold, AndThen, ErrInto, InspectErr, InspectOk, IntoStream, MapErr, MapOk, OrElse,
-    TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext, TrySkipWhile,
+    try_unfold, AndThen, ErrInto, InspectErr, InspectOk, IntoStream, MapErr, MapOk, OrElse, TryAll,
+    TryAny, TryCollect, TryConcat, TryFilter, TryFilterMap, TryFlatten, TryNext, TrySkipWhile,
     TryStreamExt, TryTakeWhile, TryUnfold,
 };
 

--- a/futures-util/src/stream/try_stream/try_any.rs
+++ b/futures-util/src/stream/try_stream/try_any.rs
@@ -7,7 +7,7 @@ use futures_core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Future for the [`any`](super::StreamExt::any) method.
+    /// Future for the [`try_any`](super::TryStreamExt::try_any) method.
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct TryAny<St, Fut, F> {
         #[pin]


### PR DESCRIPTION
Just a tiny follow-up to #2783 to fix some issues with the documentation.