### PR TITLE
provide a non-destructive mechanism to determine if a sink/stream are paired

### DIFF
--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -31,6 +31,13 @@ pub(super) fn split<T: AsyncRead + AsyncWrite>(t: T) -> (ReadHalf<T>, WriteHalf<
     (ReadHalf { handle: a }, WriteHalf { handle: b })
 }
 
+impl<T> ReadHalf<T> {
+    /// Checks if this `ReadHalf` and some `WriteHalf` were split from the same stream.
+    pub fn is_pair_of(&self, other: &WriteHalf<T>) -> bool {
+        self.handle.is_pair_of(&other.handle)
+    }
+}
+
 impl<T: Unpin> ReadHalf<T> {
     /// Attempts to put the two "halves" of a split `AsyncRead + AsyncWrite` back
     /// together. Succeeds only if the `ReadHalf<T>` and `WriteHalf<T>` are
@@ -39,6 +46,13 @@ impl<T: Unpin> ReadHalf<T> {
         self.handle
             .reunite(other.handle)
             .map_err(|err| ReuniteError(ReadHalf { handle: err.0 }, WriteHalf { handle: err.1 }))
+    }
+}
+
+impl<T> WriteHalf<T> {
+    /// Checks if this `WriteHalf` and some `ReadHalf` were split from the same stream.
+    pub fn is_pair_of(&self, other: &ReadHalf<T>) -> bool {
+        self.handle.is_pair_of(&other.handle)
     }
 }
 

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -149,6 +149,11 @@ impl<T> BiLock<T> {
         BiLockAcquire { bilock: self }
     }
 
+    /// Returns `true` only if the other `BiLock<T>` originated from the same call to `BiLock::new`.
+    pub fn is_pair_of(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.arc, &other.arc)
+    }
+
     /// Attempts to put the two "halves" of a `BiLock<T>` back together and
     /// recover the original value. Succeeds only if the two `BiLock<T>`s
     /// originated from the same call to `BiLock::new`.
@@ -156,7 +161,7 @@ impl<T> BiLock<T> {
     where
         T: Unpin,
     {
-        if Arc::ptr_eq(&self.arc, &other.arc) {
+        if self.is_pair_of(&other) {
             drop(other);
             let inner = Arc::try_unwrap(self.arc)
                 .ok()


### PR DESCRIPTION
The only mechanism I could find to determine if a sink and stream are paired is ```reunite``` which takes ownership of the values.  The mechanism proposed here allows the caller to determine if the values are paired without mutation.

This behavior is useful in the case where a service receives messages from multiple connections and would like to send messages to the non-originating sinks.  Currently there appears to be no way for the server to determine which sink is paired with the connection that originated the message.

I'm not tied to the function names and welcome any suggestions.