### PR TITLE
Fix missing wake() in PendingOnce

### DIFF
--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -32,11 +32,12 @@ pub struct PendingOnce {
 
 impl Future for PendingOnce {
     type Output = ();
-    fn poll(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.is_ready {
             Poll::Ready(())
         } else {
             self.is_ready = true;
+            cx.waker().wake_by_ref();
             Poll::Pending
         }
     }


### PR DESCRIPTION
PendingOnce should wake() before returning Pending, otherwise executors may not poll() again.

Without this change, the following code blocks forever:
```rust
#[test]
fn test_block_on() {
    async fn test_fut() {
        futures::pending!();
    }
    futures::executor::block_on(test_fut())
}
```