### PR TITLE
remove redundant impl Unpin

### DIFF
--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -37,10 +37,6 @@ impl<Fut: Future> Clone for WeakShared<Fut> {
     }
 }
 
-// The future itself is polled behind the `Arc`, so it won't be moved
-// when `Shared` is moved.
-impl<Fut: Future> Unpin for Shared<Fut> {}
-
 impl<Fut: Future> fmt::Debug for Shared<Fut> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Shared")


### PR DESCRIPTION
It is automatically implemented.

<img width="880" alt="image" src="https://github.com/rust-lang/futures-rs/assets/1265027/edc5b060-b7d7-4124-9f30-3b47ecfd520a">
