### PR TITLE
FillBuf: don't poll a second time on EOF

### DIFF
--- a/futures-util/src/io/fill_buf.rs
+++ b/futures-util/src/io/fill_buf.rs
@@ -30,6 +30,8 @@ where
         let reader = this.reader.take().expect("Polled FillBuf after completion");
 
         match Pin::new(&mut *reader).poll_fill_buf(cx) {
+            // We don't need to poll a second time for EOF, and doing so is likely to return Poll::Pending
+            Poll::Ready(Ok(&[])) => Poll::Ready(Ok(&[])),
             // With polonius it is possible to remove this inner match and just have the correct
             // lifetime of the reference inferred based on which branch is taken
             Poll::Ready(Ok(_)) => match Pin::new(reader).poll_fill_buf(cx) {


### PR DESCRIPTION
There is no hard guarantee that polling a second time will return Poll::Ready, and this is particularly likely to break in the EOF case, which is precisely where we don't need to do so at all.

Both tokio::io::BufReader and futures::io::BufReader always attempt to read from the underlying reader when the buffer is empty, rather than fusing EOF.