### PR TITLE
Add `BlockAwait` trait

### DIFF
--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -56,7 +56,9 @@
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
-pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
+pub use crate::local_pool::{
+    block_on, block_on_stream, BlockAwait, BlockingStream, LocalPool, LocalSpawner,
+};
 
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -325,6 +325,25 @@ pub fn block_on_stream<S: Stream + Unpin>(stream: S) -> BlockingStream<S> {
     BlockingStream { stream }
 }
 
+/// A trait for awaiting a future in a non-async context. This is automatically implemented for anything implementing [`Future`].
+///
+/// This functions the same as [`block_on`], but allows for a chaining style similar to `.await` syntax.
+pub trait BlockAwait<F: Future> {
+    /// The output of running the future.
+    type Output;
+
+    /// Block until the future completes by passing the future to [`block_on`].
+    fn block_await(self) -> Self::Output;
+}
+
+impl<F: Future> BlockAwait<F> for F {
+    type Output = F::Output;
+
+    fn block_await(self) -> Self::Output {
+        block_on(self)
+    }
+}
+
 /// An iterator which blocks on values from a stream until they become available.
 #[derive(Debug)]
 pub struct BlockingStream<S: Stream + Unpin> {

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -194,7 +194,7 @@ pub mod executor {
     //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
     pub use futures_executor::{
-        block_on, block_on_stream, enter, BlockingStream, Enter, EnterError, LocalPool,
+        block_on, block_on_stream, enter, BlockAwait, BlockingStream, Enter, EnterError, LocalPool,
         LocalSpawner,
     };
 


### PR DESCRIPTION
This change adds in a trait called `BlockAwait`, which functions like `futures::executor::block_on`, but allows for a chaining style similar to `.await` syntax.

I wasn't positive if this would be wanted, but considering how simple it was I decided I'd just go ahead and make it. 

I also wasn't completely sure on how I should limit the trait to only be implemented on `Future` types (and possibly how to prevent it's implementation from being overridden), but I'm open to feedback in the area if my implementation isn't the best.