### PR TITLE
Fix incorrect feature flag documented on join! macro

### DIFF
--- a/futures-util/src/async_await/join_mod.rs
+++ b/futures-util/src/async_await/join_mod.rs
@@ -9,7 +9,7 @@ macro_rules! document_join_macro {
         /// `join!` polls both futures concurrently and therefore is more efficient.
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
-        /// It is also gated behind the `async-await` feature of this library, which is
+        /// It is also gated behind the `async-await-macro` feature of this library, which is
         /// activated by default.
         ///
         /// # Examples
@@ -38,7 +38,7 @@ macro_rules! document_join_macro {
         /// the futures return an error.
         ///
         /// This macro is only usable inside of async functions, closures, and blocks.
-        /// It is also gated behind the `async-await` feature of this library, which is
+        /// It is also gated behind the `async-await-macro` feature of this library, which is
         /// activated by default.
         ///
         /// # Examples


### PR DESCRIPTION
The join! and try_join! macros are behind the async-await-macro feature flag, not async-await.