### PR TITLE
Add esp32s2 to no CAS list

### DIFF
--- a/ci/no_atomic_cas.sh
+++ b/ci/no_atomic_cas.sh
@@ -26,6 +26,8 @@ EOF
 for target in "${no_atomic_cas[@]}"; do
     echo "    \"${target}\"," >>"${file}"
 done
+# special case: xtensa-esp32s2-none-elf only exists in the esp-rs/rust compiler
+echo "    \"xtensa-esp32s2-none-elf\"," >>"${file}"
 cat >>"${file}" <<EOF
 ];
 EOF

--- a/no_atomic_cas.rs
+++ b/no_atomic_cas.rs
@@ -14,4 +14,5 @@ const NO_ATOMIC_CAS: &[&str] = &[
     "thumbv4t-none-eabi",
     "thumbv5te-none-eabi",
     "thumbv6m-none-eabi",
+    "xtensa-esp32s2-none-elf",
 ];


### PR DESCRIPTION
Without this entry, esp32s2 users with `futures-*` dependencies in their tree, indirectly or not must somehow enable the portable atomic feature. This change makes it seamless like it is on RISCV etc.