### PR TITLE
tests: Fix dead_code warning for tuple struct

### DIFF
--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -3,6 +3,7 @@ use futures::executor::LocalPool;
 use futures::future::{self, lazy, poll_fn, Future};
 use futures::task::{Context, LocalSpawn, LocalSpawnExt, Poll, Spawn, SpawnExt, Waker};
 use std::cell::{Cell, RefCell};
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,7 +11,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-struct Pending(Rc<()>);
+struct Pending(PhantomData<Rc<()>>);
 
 impl Future for Pending {
     type Output = ();
@@ -21,7 +22,7 @@ impl Future for Pending {
 }
 
 fn pending() -> Pending {
-    Pending(Rc::new(()))
+    Pending(PhantomData)
 }
 
 #[test]


### PR DESCRIPTION
```
error: field `0` is never read
  --> futures-executor/tests/local_pool.rs:13:16
   |
13 | struct Pending(Rc<()>);
   |        ------- ^^^^^^
   |        |
   |        field in this struct
   |
   = note: `-D dead-code` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(dead_code)]`
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
13 | struct Pending(());
   |                ~~
```

https://github.com/rust-lang/rust/issues/119645