### PR TITLE
Parse rhs of `select!` arms using match-arm rules

### DIFF
--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1.0"
-syn = { version = "2.0.8", features = ["full"] }
+syn = { version = "2.0.52", features = ["full"] }
 
 [lints]
 workspace = true

--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -59,7 +59,7 @@ impl Parse for Select {
 
             // `=> <expr>`
             input.parse::<Token![=>]>()?;
-            let expr = input.parse::<Expr>()?;
+            let expr = Expr::parse_with_earlier_boundary_rule(input)?;
 
             // Commas after the expression are only optional if it's a `Block`
             // or it is the last branch in the `match`.
@@ -229,7 +229,7 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
     let branches = parsed.normal_fut_handlers.into_iter().zip(variant_names.iter()).map(
         |((pat, expr), variant_name)| {
             quote! {
-                #enum_ident::#variant_name(#pat) => { #expr },
+                #enum_ident::#variant_name(#pat) => #expr,
             }
         },
     );

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -58,6 +58,18 @@ fn select() {
 }
 
 #[test]
+fn select_grammar() {
+    // Parsing after `=>` using Expr::parse would parse `{}() = future::ready(())`
+    // as one expression.
+    block_on(async {
+        select! {
+            () = future::pending::<()>() => {}
+            () = future::ready(()) => {}
+        }
+    });
+}
+
+#[test]
 fn select_biased() {
     let (tx1, rx1) = oneshot::channel::<i32>();
     let (_tx2, rx2) = oneshot::channel::<i32>();


### PR DESCRIPTION
Fixes #2824.

This is a breaking change because, for example, the following program would break.

```rust
use futures::{future, select};

fn main() {
    let _ = async {
        select! {
            () = future::ready(()) => {}()
        }
    };
}
```