### PR TITLE
Revert "Temporarily disable ref_wake_same test"

### DIFF
--- a/futures-task/src/waker.rs
+++ b/futures-task/src/waker.rs
@@ -36,6 +36,7 @@ unsafe fn increase_refcount<T: ArcWake + 'static>(data: *const ()) {
 }
 
 // used by `waker_ref`
+#[inline(always)]
 unsafe fn clone_arc_raw<T: ArcWake + 'static>(data: *const ()) -> RawWaker {
     unsafe { increase_refcount::<T>(data) }
     RawWaker::new(data, waker_vtable::<T>())

--- a/futures/tests/task_arc_wake.rs
+++ b/futures/tests/task_arc_wake.rs
@@ -44,18 +44,17 @@ fn create_from_arc() {
     assert_eq!(1, Arc::strong_count(&some_w));
 }
 
-// TODO: rustc regression: https://github.com/rust-lang/rust/issues/121600
-// #[test]
-// fn ref_wake_same() {
-//     let some_w = Arc::new(CountingWaker::new());
-//
-//     let w1: Waker = task::waker(some_w.clone());
-//     let w2 = task::waker_ref(&some_w);
-//     let w3 = w2.clone();
-//
-//     assert!(w1.will_wake(&w2));
-//     assert!(w2.will_wake(&w3));
-// }
+#[test]
+fn ref_wake_same() {
+    let some_w = Arc::new(CountingWaker::new());
+
+    let w1: Waker = task::waker(some_w.clone());
+    let w2 = task::waker_ref(&some_w);
+    let w3 = w2.clone();
+
+    assert!(w1.will_wake(&w2));
+    assert!(w2.will_wake(&w3));
+}
 
 #[test]
 fn proper_refcount_on_wake_panic() {


### PR DESCRIPTION
This reverts commit 42c2ab0e731892e9ff6c6e7fc28ab11d6eaee804.

~~Potentially fixed by https://github.com/rust-lang/rust/pull/121622.~~ Fixed by #2865