### PR TITLE
Add FutureExt::also_poll

### DIFF
--- a/futures-util/src/future/future/also_poll.rs
+++ b/futures-util/src/future/future/also_poll.rs
@@ -1,0 +1,46 @@
+use core::pin::Pin;
+use futures_core::future::{FusedFuture, Future};
+use futures_core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+use super::Fuse;
+
+pin_project! {
+    /// Future for the [`also_poll`](super::FutureExt::also_poll) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct AlsoPoll<Fut, Also> {
+        #[pin] fut: Fut,
+        #[pin] also: Fuse<Also>,
+    }
+}
+
+impl<Fut, Also> AlsoPoll<Fut, Also> {
+    pub(super) fn new(fut: Fut, also: Also) -> Self {
+        AlsoPoll { fut, also: Fuse::new(also) }
+    }
+}
+
+impl<Fut, Also> Future for AlsoPoll<Fut, Also>
+where
+    Fut: Future,
+    Also: Future<Output = ()>,
+{
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _ = this.also.poll(cx);
+        this.fut.poll(cx)
+    }
+}
+
+impl<Fut, Also> FusedFuture for AlsoPoll<Fut, Also>
+where
+    Fut: FusedFuture,
+    Also: Future<Output = ()>,
+{
+    fn is_terminated(&self) -> bool {
+        self.fut.is_terminated()
+    }
+}

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -21,7 +21,8 @@ pub use futures_task::{FutureObj, LocalFutureObj, UnsafeFutureObj};
 #[allow(clippy::module_inception)]
 mod future;
 pub use self::future::{
-    Flatten, Fuse, FutureExt, Inspect, IntoStream, Map, MapInto, NeverError, Then, UnitError,
+    AlsoPoll, Flatten, Fuse, FutureExt, Inspect, IntoStream, Map, MapInto, NeverError, Then,
+    UnitError,
 };
 
 #[deprecated(note = "This is now an alias for [Flatten](Flatten)")]


### PR DESCRIPTION
```rust
trait FutureExt {
    fn also_poll<Also>(self, also: Also) -> AlsoPoll<Self, Also> // Output = Self::Output
    where
        Self: Sized,
        Also: Future<Output = ()>,
    { // AlsoPoll pseudocode:
        let mut also = also.fuse();
        poll_fn(|cx| {
            let _ = also.poll(cx);
            self.poll(cx)
        })
    }
}
```

I've found this sort of function helpful when trying to avoid a Barbara Battles Buffered Streams type situation; specifically in my case, when you have a select-loop and one of the branches needs to await, but you don't want to starve something from another branch (pseudocode):

```rust
let mut fut = foo();
let mut stream = bar();
loop {
    select! {
        x = &mut fut => {
            do_thing_with(x);
            fut = foo();
        }
        y = stream.next() => {
            handle_stream_item(y).also_poll(&mut fut).await;
        }
    }
}
```

Without that `.also_poll(&mut fut)`, `fut` would be starved of polls for the duration of `handle_stream_item`, potentially causing deadlocks or very long delays through the rest of the system if `fut` was queued to receive a semaphore permit (e.g. a mutex, a mpsc send() permit) because now it can't release it until `handle_stream_item` is done. That was my specific use case, at least, but I feel that this is a valuable primitive to have in general as folks start to look at stuff like `Stream::poll_progress` for combating BBBS (`.also_poll(poll_fn(|cx| foo.poll_progress(cx)))` is I feel a quintessential potential use case for this function).

Definitely open to naming suggestions, I feel like as it is it might not be super intuitive, but I do like how  `foo.also_poll(bar).await` reads.