### PR TITLE
Add variant of LocalPool with bound lifetime

### DIFF
--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -54,7 +54,10 @@ extern crate std;
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
-pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
+pub use crate::local_pool::{
+    block_on, block_on_stream, BlockingStream, BoundLocalPool, BoundLocalSpawner, LocalPool,
+    LocalSpawner,
+};
 
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -2,7 +2,7 @@ use crate::enter;
 use futures_core::future::Future;
 use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
-use futures_task::{waker_ref, ArcWake};
+use futures_task::{waker_ref, ArcWake, BoundLocalSpawn};
 use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
 use futures_util::pin_mut;
 use futures_util::stream::FuturesUnordered;
@@ -17,6 +17,36 @@ use std::sync::{
 use std::thread::{self, Thread};
 use std::vec::Vec;
 
+/// A single-threaded task pool with bound lifetime for polling futures to
+/// completion.
+///
+/// This executor allows you to multiplex any number of tasks onto a single
+/// thread. It's appropriate to poll strictly I/O-bound futures that do very
+/// little work in between I/O actions. The lifetime of the executor is bound by
+/// a generic parameter. Futures associated with the executor need only outlive
+/// this lifetime. That uncompleted futures are dropped when the lifetime of the
+/// executor expires.
+///
+/// To get a handle to the pool that implements [`Spawn`](futures_task::Spawn),
+/// use the [`spawner()`](BoundLocalPool::spawner) method. Because the executor
+/// is single-threaded, it supports a special form of task spawning for
+/// non-`Send` futures, via
+/// [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
+/// Additionally, tasks with a limited lifetime can be spawned via
+/// [`spawn_bound_local_obj`](futures_task::BoundLocalSpawn::spawn_bound_local_obj).
+#[derive(Debug)]
+pub struct BoundLocalPool<'a> {
+    pool: FuturesUnordered<LocalFutureObj<'a, ()>>,
+    incoming: Rc<Incoming<'a>>,
+}
+
+/// A handle to a [`BoundLocalPool`] that implements
+/// [`BoundLocalSpawn`](futures_task::BoundLocalSpawn).
+#[derive(Clone, Debug)]
+pub struct BoundLocalSpawner<'a> {
+    incoming: Weak<Incoming<'a>>,
+}
+
 /// A single-threaded task pool for polling futures to completion.
 ///
 /// This executor allows you to multiplex any number of tasks onto a single
@@ -28,19 +58,13 @@ use std::vec::Vec;
 /// [`spawner()`](LocalPool::spawner) method. Because the executor is
 /// single-threaded, it supports a special form of task spawning for non-`Send`
 /// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
-#[derive(Debug)]
-pub struct LocalPool {
-    pool: FuturesUnordered<LocalFutureObj<'static, ()>>,
-    incoming: Rc<Incoming>,
-}
+pub type LocalPool = BoundLocalPool<'static>;
 
-/// A handle to a [`LocalPool`] that implements [`Spawn`](futures_task::Spawn).
-#[derive(Clone, Debug)]
-pub struct LocalSpawner {
-    incoming: Weak<Incoming>,
-}
+/// A handle to a [`LocalPool`] that implements [`Spawn`](futures_task::Spawn)
+/// and [`LocalSpawn`](futures_task::LocalSpawn).
+pub type LocalSpawner = BoundLocalSpawner<'static>;
 
-type Incoming = RefCell<Vec<LocalFutureObj<'static, ()>>>;
+type Incoming<'a> = RefCell<Vec<LocalFutureObj<'a, ()>>>;
 
 pub(crate) struct ThreadNotify {
     /// The (single) executor thread.
@@ -107,15 +131,15 @@ fn woken() -> bool {
     CURRENT_THREAD_NOTIFY.with(|thread_notify| thread_notify.unparked.load(Ordering::Acquire))
 }
 
-impl LocalPool {
+impl<'a> BoundLocalPool<'a> {
     /// Create a new, empty pool of tasks.
     pub fn new() -> Self {
         Self { pool: FuturesUnordered::new(), incoming: Default::default() }
     }
 
     /// Get a clonable handle to the pool as a [`Spawn`].
-    pub fn spawner(&self) -> LocalSpawner {
-        LocalSpawner { incoming: Rc::downgrade(&self.incoming) }
+    pub fn spawner(&self) -> BoundLocalSpawner<'a> {
+        BoundLocalSpawner { incoming: Rc::downgrade(&self.incoming) }
     }
 
     /// Run all tasks in the pool to completion.
@@ -362,7 +386,7 @@ impl<S: Stream + Unpin> Iterator for BlockingStream<S> {
     }
 }
 
-impl Spawn for LocalSpawner {
+impl Spawn for BoundLocalSpawner<'_> {
     fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
         if let Some(incoming) = self.incoming.upgrade() {
             incoming.borrow_mut().push(future.into());
@@ -381,7 +405,7 @@ impl Spawn for LocalSpawner {
     }
 }
 
-impl LocalSpawn for LocalSpawner {
+impl LocalSpawn for BoundLocalSpawner<'_> {
     fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
         if let Some(incoming) = self.incoming.upgrade() {
             incoming.borrow_mut().push(future);
@@ -393,6 +417,17 @@ impl LocalSpawn for LocalSpawner {
 
     fn status_local(&self) -> Result<(), SpawnError> {
         if self.incoming.upgrade().is_some() {
+            Ok(())
+        } else {
+            Err(SpawnError::shutdown())
+        }
+    }
+}
+
+impl<'a> BoundLocalSpawn<'a> for BoundLocalSpawner<'a> {
+    fn spawn_bound_local_obj(&self, future: LocalFutureObj<'a, ()>) -> Result<(), SpawnError> {
+        if let Some(incoming) = self.incoming.upgrade() {
+            incoming.borrow_mut().push(future);
             Ok(())
         } else {
             Err(SpawnError::shutdown())

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 extern crate std;
 
 mod spawn;
-pub use crate::spawn::{LocalSpawn, Spawn, SpawnError};
+pub use crate::spawn::{BoundLocalSpawn, LocalSpawn, Spawn, SpawnError};
 
 #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -17,7 +17,7 @@ use core::sync::atomic::{AtomicBool, AtomicPtr};
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
-use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
+use futures_task::{BoundLocalSpawn, FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
 
 mod abort;
 
@@ -73,6 +73,13 @@ impl Spawn for FuturesUnordered<FutureObj<'_, ()>> {
 
 impl LocalSpawn for FuturesUnordered<LocalFutureObj<'_, ()>> {
     fn spawn_local_obj(&self, future_obj: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
+        self.push(future_obj);
+        Ok(())
+    }
+}
+
+impl<'a> BoundLocalSpawn<'a> for FuturesUnordered<LocalFutureObj<'a, ()>> {
+    fn spawn_bound_local_obj(&self, future_obj: LocalFutureObj<'a, ()>) -> Result<(), SpawnError> {
         self.push(future_obj);
         Ok(())
     }

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -13,7 +13,9 @@
 #[doc(no_inline)]
 pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
-pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj};
+pub use futures_task::{
+    BoundLocalSpawn, FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj,
+};
 
 pub use futures_task::noop_waker;
 pub use futures_task::noop_waker_ref;
@@ -37,4 +39,4 @@ pub use futures_task::{waker_ref, WakerRef};
 pub use futures_core::task::__internal::AtomicWaker;
 
 mod spawn;
-pub use self::spawn::{LocalSpawnExt, SpawnExt};
+pub use self::spawn::{BoundLocalSpawnExt, LocalSpawnExt, SpawnExt};

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -189,8 +189,8 @@ pub mod executor {
     //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
     pub use futures_executor::{
-        block_on, block_on_stream, enter, BlockingStream, Enter, EnterError, LocalPool,
-        LocalSpawner,
+        block_on, block_on_stream, enter, BlockingStream, BoundLocalPool, BoundLocalSpawner, Enter,
+        EnterError, LocalPool, LocalSpawner,
     };
 
     #[cfg(feature = "thread-pool")]


### PR DESCRIPTION
This modifies `LocalPool` to accept a generic lifetime parameter, and renames it to `BoundLocalPool` parameter, with `LocalPool` now being an alias for `BoundLocalPool<'static>`. Associated types (`Incoming` and `LocalSpawner`) get the same treatment where applicable. Add additional `BoundLocalSpawn` and `BoundLocalSpawnExt` traits that extend the unbound variants with functions spawning bound-lifetime tasks.

The purpose of this is to enable the use of an executor that does not require the futures assigned to it to exist any longer than it does. Existing code should of course still just work as it is.

Somewhat tangentially related, the implementations for the various spawner traits have been consolidated to just require `Deref`, but that need not be part of the same change and does break compatibility. I left it in as a suggestion, but I suspect that should be reverted :).