### PR TITLE
Make access inner of futures::io::{BufReader,BufWriter} not require inner trait bound

### DIFF
--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -52,7 +52,9 @@ impl<R: AsyncRead> BufReader<R> {
         let buffer = vec![0; capacity];
         Self { inner, buffer: buffer.into_boxed_slice(), pos: 0, cap: 0 }
     }
+}
 
+impl<R> BufReader<R> {
     delegate_access_inner!(inner, R, ());
 
     /// Returns a reference to the internally buffered data.

--- a/futures-util/src/io/buf_writer.rs
+++ b/futures-util/src/io/buf_writer.rs
@@ -79,6 +79,26 @@ impl<W: AsyncWrite> BufWriter<W> {
         Poll::Ready(ret)
     }
 
+    /// Write directly using `inner`, bypassing buffering
+    pub(super) fn inner_poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    /// Write directly using `inner`, bypassing buffering
+    pub(super) fn inner_poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+}
+
+impl<W> BufWriter<W> {
     delegate_access_inner!(inner, W, ());
 
     /// Returns a reference to the internally buffered data.
@@ -130,24 +150,6 @@ impl<W: AsyncWrite> BufWriter<W> {
             ptr::copy_nonoverlapping(src, dst, buf_len);
             this.buf.set_len(old_len + buf_len);
         }
-    }
-
-    /// Write directly using `inner`, bypassing buffering
-    pub(super) fn inner_poll_write(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<io::Result<usize>> {
-        self.project().inner.poll_write(cx, buf)
-    }
-
-    /// Write directly using `inner`, bypassing buffering
-    pub(super) fn inner_poll_write_vectored(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        bufs: &[IoSlice<'_>],
-    ) -> Poll<io::Result<usize>> {
-        self.project().inner.poll_write_vectored(cx, bufs)
     }
 }
 


### PR DESCRIPTION
Currently, accessing the inner of `futures::io::{BufReader, BufWriter}` requires that the inner type implements `AsyncRead` or `AsyncWrite`. This constraint is much stricter than the semantics of inner access require. Removing the trait bound would be helpful in cases where pass-through functions simply obtain a reference to the inner I/O object for further use, without having to specify the inner trait bound explicitly.