### PR TITLE
`#[inline(always)]` on `clone_arc_raw`

### DIFF
--- a/futures-task/src/waker.rs
+++ b/futures-task/src/waker.rs
@@ -36,6 +36,7 @@ unsafe fn increase_refcount<T: ArcWake + 'static>(data: *const ()) {
 }
 
 // used by `waker_ref`
+#[inline(always)]
 unsafe fn clone_arc_raw<T: ArcWake + 'static>(data: *const ()) -> RawWaker {
     unsafe { increase_refcount::<T>(data) }
     RawWaker::new(data, waker_vtable::<T>())


### PR DESCRIPTION
Similar patch (by, if I understand correctly, forcing these to be in the same CGUs) to https://github.com/rust-lang/rust/pull/121622
