### PR TITLE
Support shared futures on no_std

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -43,6 +43,7 @@ futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
 pin-project-lite = "0.2.6"
+spin = "0.9.8"
 
 [dev-dependencies]
 futures = { path = "../futures", features = ["async-await", "thread-pool"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -22,7 +22,6 @@ sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
 portable-atomic = ["futures-core/portable-atomic"]
-spin = ["dep:spin"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -12,8 +12,8 @@ Common utilities and extension traits for the futures-rs library.
 
 [features]
 default = ["std", "async-await", "async-await-macro"]
-std = ["alloc", "futures-core/std", "futures-task/std", "slab"]
-alloc = ["futures-core/alloc", "futures-task/alloc"]
+std = ["alloc", "futures-core/std", "futures-task/std", "slab/std"]
+alloc = ["futures-core/alloc", "futures-task/alloc", "slab"]
 async-await = []
 async-await-macro = ["async-await", "futures-macro"]
 compat = ["std", "futures_01"]
@@ -37,12 +37,14 @@ futures-channel = { path = "../futures-channel", version = "=0.4.0-alpha.0", def
 futures-io = { path = "../futures-io", version = "0.3.30", default-features = false, features = ["std"], optional = true }
 futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 futures-macro = { path = "../futures-macro", version = "=0.4.0-alpha.0", default-features = false, optional = true }
-slab = { version = "0.4.2", optional = true }
+slab = { version = "0.4.2", default-features = false, optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
 pin-project-lite = "0.2.6"
+
+[target.'cfg(target_has_atomic = "8")'.dependencies]
 spin = "0.9.8"
 
 [dev-dependencies]

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -22,6 +22,7 @@ sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
 portable-atomic = ["futures-core/portable-atomic"]
+spin = ["dep:spin"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the
@@ -43,9 +44,7 @@ futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-utils = "0.1.0"
 pin-project-lite = "0.2.6"
-
-[target.'cfg(target_has_atomic = "8")'.dependencies]
-spin = "0.9.8"
+spin = { version = "0.9.8", optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", features = ["async-await", "thread-pool"] }

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -107,9 +107,9 @@ mod remote_handle;
 #[cfg(feature = "std")]
 pub use self::remote_handle::{Remote, RemoteHandle};
 
-#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
+#[cfg(any(feature = "std", feature = "spin"))]
 mod shared;
-#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
+#[cfg(any(feature = "std", feature = "spin"))]
 pub use self::shared::{Shared, WeakShared};
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
@@ -440,7 +440,7 @@ pub trait FutureExt: Future {
     /// into a cloneable future. It enables a future to be polled by multiple
     /// threads.
     ///
-    /// This method is only available when the `std` feature of this
+    /// This method is only available when the `std` or 'spin' feature of this
     /// library is activated, and it is activated by default.
     ///
     /// # Examples
@@ -474,7 +474,7 @@ pub trait FutureExt: Future {
     /// join_handle.join().unwrap();
     /// # });
     /// ```
-    #[cfg(all(feature = "alloc", target_has_atomic = "8"))]
+    #[cfg(any(feature = "std", feature = "spin"))]
     fn shared(self) -> Shared<Self>
     where
         Self: Sized,

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -107,9 +107,9 @@ mod remote_handle;
 #[cfg(feature = "std")]
 pub use self::remote_handle::{Remote, RemoteHandle};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
 mod shared;
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
 pub use self::shared::{Shared, WeakShared};
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
@@ -474,7 +474,7 @@ pub trait FutureExt: Future {
     /// join_handle.join().unwrap();
     /// # });
     /// ```
-    #[cfg(feature = "alloc")]
+    #[cfg(all(feature = "alloc", target_has_atomic = "8"))]
     fn shared(self) -> Shared<Self>
     where
         Self: Sized,

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -107,9 +107,9 @@ mod remote_handle;
 #[cfg(feature = "std")]
 pub use self::remote_handle::{Remote, RemoteHandle};
 
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 mod shared;
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 pub use self::shared::{Shared, WeakShared};
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
@@ -474,7 +474,7 @@ pub trait FutureExt: Future {
     /// join_handle.join().unwrap();
     /// # });
     /// ```
-    #[cfg(any(feature = "std", feature = "spin"))]
+    #[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
     fn shared(self) -> Shared<Self>
     where
         Self: Sized,

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -107,9 +107,9 @@ mod remote_handle;
 #[cfg(feature = "std")]
 pub use self::remote_handle::{Remote, RemoteHandle};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 mod shared;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::shared::{Shared, WeakShared};
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
@@ -474,7 +474,7 @@ pub trait FutureExt: Future {
     /// join_handle.join().unwrap();
     /// # });
     /// ```
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     fn shared(self) -> Shared<Self>
     where
         Self: Sized,

--- a/futures-util/src/future/future/shared.rs
+++ b/futures-util/src/future/future/shared.rs
@@ -1,15 +1,20 @@
 use crate::task::{waker_ref, ArcWake};
+use alloc::sync::{Arc, Weak};
+use core::cell::UnsafeCell;
+use core::fmt;
+use core::hash::Hasher;
+use core::pin::Pin;
+use core::ptr;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::{Acquire, SeqCst};
 use futures_core::future::{FusedFuture, Future};
 use futures_core::task::{Context, Poll, Waker};
 use slab::Slab;
-use std::cell::UnsafeCell;
-use std::fmt;
-use std::hash::Hasher;
-use std::pin::Pin;
-use std::ptr;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Acquire, SeqCst};
-use std::sync::{Arc, Mutex, Weak};
+
+#[cfg(feature = "std")]
+type Mutex<T> = std::sync::Mutex<T>;
+#[cfg(not(feature = "std"))]
+type Mutex<T> = spin::Mutex<T>;
 
 /// Future for the [`shared`](super::FutureExt::shared) method.
 #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -35,7 +35,7 @@ pub use self::future::CatchUnwind;
 #[cfg(feature = "std")]
 pub use self::future::{Remote, RemoteHandle};
 
-#[cfg(any(feature = "std", feature = "spin"))]
+#[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 pub use self::future::{Shared, WeakShared};
 
 mod try_future;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -35,7 +35,7 @@ pub use self::future::CatchUnwind;
 #[cfg(feature = "std")]
 pub use self::future::{Remote, RemoteHandle};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub use self::future::{Shared, WeakShared};
 
 mod try_future;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -35,7 +35,7 @@ pub use self::future::CatchUnwind;
 #[cfg(feature = "std")]
 pub use self::future::{Remote, RemoteHandle};
 
-#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
+#[cfg(any(feature = "std", feature = "spin"))]
 pub use self::future::{Shared, WeakShared};
 
 mod try_future;

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -35,7 +35,7 @@ pub use self::future::CatchUnwind;
 #[cfg(feature = "std")]
 pub use self::future::{Remote, RemoteHandle};
 
-#[cfg(feature = "alloc")]
+#[cfg(all(feature = "alloc", target_has_atomic = "8"))]
 pub use self::future::{Shared, WeakShared};
 
 mod try_future;

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -40,6 +40,7 @@ compat = ["std", "futures-util/compat"]
 io-compat = ["compat", "futures-util/io-compat"]
 executor = ["std", "futures-executor/std"]
 thread-pool = ["executor", "futures-executor/thread-pool"]
+spin = ["futures-util/spin"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the


### PR DESCRIPTION
Currently, `Shared` futures are only available when the `std` feature is enabled because they use `std::sync::Mutex` internally. This PR changes this so that `Shared` futures will fall back to using a spinlock when `std` is not enabled.

Alternatively, `Shared` could be changed to be generic over a mutex trait (e.g. `lock_api::RawMutex`, though it isn't implemented for `std::sync::Mutex`) to allow arbitrary user implementations.