### PR TITLE
Add `BoxTryFuture` and `BoxTryStream` aliases

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -16,6 +16,16 @@ pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send 
 #[cfg(feature = "alloc")]
 pub type LocalBoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
 
+/// [`BoxFuture`] with [`TryFuture`] instead.
+#[cfg(feature = "alloc")]
+pub type BoxTryFuture<'a, T, E> =
+    Pin<alloc::boxed::Box<dyn TryFuture<Ok = T, Error = E, Output = Result<T, E>> + Send + 'a>>;
+
+/// [`BoxTryFuture`], but without the `Send` requirement.
+#[cfg(feature = "alloc")]
+pub type LocalBoxTryFuture<'a, T, E> =
+    Pin<alloc::boxed::Box<dyn TryFuture<Ok = T, Error = E, Output = Result<T, E>> + 'a>>;
+
 /// A future which tracks whether or not the underlying future
 /// should no longer be polled.
 ///

--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -13,6 +13,16 @@ pub type BoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + Send + 
 #[cfg(feature = "alloc")]
 pub type LocalBoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + 'a>>;
 
+/// [`BoxStream`] with [`TryStream`].
+#[cfg(feature = "alloc")]
+pub type BoxTryStream<'a, T, E> =
+    Pin<alloc::boxed::Box<dyn TryStream<Item = Result<T, E>, Ok = T, Error = E> + Send + 'a>>;
+
+/// [`BoxTryStream`], but without the `Send` requirement.
+#[cfg(feature = "alloc")]
+pub type LocalBoxTryStream<'a, T, E> =
+    Pin<alloc::boxed::Box<dyn TryStream<Item = Result<T, E>, Ok = T, Error = E> + 'a>>;
+
 /// A stream of values produced asynchronously.
 ///
 /// If `Future<Output = T>` is an asynchronous version of `T`, then `Stream<Item


### PR DESCRIPTION
Including ones without `Send` bound like `LocalBoxTryFuture` and `LocalBoxTryStream`.

Closes #2869 