### PR TITLE
Add accessors for the inner of stream::Iter

### DIFF
--- a/futures-util/src/stream/iter.rs
+++ b/futures-util/src/stream/iter.rs
@@ -10,6 +10,23 @@ pub struct Iter<I> {
     iter: I,
 }
 
+impl<I> Iter<I> {
+    /// Acquires a reference to the underlying iterator that this stream is pulling from.
+    pub fn get_ref(&self) -> &I {
+        &self.iter
+    }
+
+    /// Acquires a mutable reference to the underlying iterator that this stream is pulling from.
+    pub fn get_mut(&mut self) -> &mut I {
+        &mut self.iter
+    }
+
+    /// Consumes this stream, returning the underlying iterator.
+    pub fn into_inner(self) -> I {
+        self.iter
+    }
+}
+
 impl<I> Unpin for Iter<I> {}
 
 /// Converts an `Iterator` into a `Stream` which is always ready


### PR DESCRIPTION
This PR adds analogues to the methods of all the stream/sink combinators which allow accessing the thing being wrapped. Here it lets you access the iterator, which is currently not possible.

I'm intentionally not using the `delegate_access_inner` macro, because the doc comments describe the inner member as being a stream or sink, which it is not for `Iter` (it also requires using `pin_project`, which `Iter` does not do or need).