### PR TITLE
Document how `BoxFuture`s / `BoxStream`s are often made

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -9,6 +9,11 @@ pub use core::future::Future;
 
 /// An owned dynamically typed [`Future`] for use in cases where you can't
 /// statically type your result or need to add some indirection.
+///
+/// This type is often created by the [`boxed`] method on [`FutureExt`]. See its documentation for more.
+///
+/// [`boxed`]: https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.boxed
+/// [`FutureExt`]: https://docs.rs/futures/latest/futures/future/trait.FutureExt.html
 #[cfg(feature = "alloc")]
 pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
 

--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -18,6 +18,11 @@ pub use core::future::Future;
 pub type BoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// `BoxFuture`, but without the `Send` requirement.
+///
+/// This type is often created by the [`boxed_local`] method on [`FutureExt`]. See its documentation for more.
+///
+/// [`boxed_local`]: https://docs.rs/futures/latest/futures/future/trait.FutureExt.html#method.boxed_local
+/// [`FutureExt`]: https://docs.rs/futures/latest/futures/future/trait.FutureExt.html
 #[cfg(feature = "alloc")]
 pub type LocalBoxFuture<'a, T> = Pin<alloc::boxed::Box<dyn Future<Output = T> + 'a>>;
 

--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -6,10 +6,20 @@ use core::task::{Context, Poll};
 
 /// An owned dynamically typed [`Stream`] for use in cases where you can't
 /// statically type your result or need to add some indirection.
+///
+/// This type is often created by the [`boxed`] method on [`StreamExt`]. See its documentation for more.
+///
+/// [`boxed`]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.boxed
+/// [`StreamExt`]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html
 #[cfg(feature = "alloc")]
 pub type BoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + Send + 'a>>;
 
 /// `BoxStream`, but without the `Send` requirement.
+///
+/// This type is often created by the [`boxed_local`] method on [`StreamExt`]. See its documentation for more.
+///
+/// [`boxed_local`]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.boxed_local
+/// [`StreamExt`]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html
 #[cfg(feature = "alloc")]
 pub type LocalBoxStream<'a, T> = Pin<alloc::boxed::Box<dyn Stream<Item = T> + 'a>>;
 


### PR DESCRIPTION
# Rationale

Unless you are already familiar with the Rust futures ecosystem and `FuturesExt::boxed` it is not always obvious how to create a `BoxFuture`

Specifically, we have [APIs for reading parquet files](https://docs.rs/parquet/latest/parquet/arrow/async_reader/trait.MetadataFetch.html), which involve `BoxFuture`s that when a user clicks on the return type, 

<img width="1106" alt="Screenshot 2024-10-03 at 9 22 37 AM" src="https://github.com/user-attachments/assets/16182d14-1829-4d9a-a956-27915f51309a">

The documentation doesn't lead them to `FutureExt::boxed`:

<img width="1153" alt="Screenshot 2024-10-03 at 9 21 43 AM" src="https://github.com/user-attachments/assets/5b7d08fd-b8c5-42cc-b639-d52d39d36c65">

# Proposal

While a better improvement for our users is a full featured example (added in https://github.com/apache/arrow-rs/pull/6505), I think this to propose improvements in this crate too to help the broader community

If the maintainers like this pattern, I am happy to add it for other similar types in Futures and Streams but I won't bother if you are not interested in this type of change


