### PR TITLE
Change condition for is_terminated in Zip

### DIFF
--- a/futures-util/src/stream/stream/zip.rs
+++ b/futures-util/src/stream/stream/zip.rs
@@ -64,7 +64,7 @@ where
     St2: Stream,
 {
     fn is_terminated(&self) -> bool {
-        self.stream1.is_terminated() && self.stream2.is_terminated()
+        self.stream1.is_terminated() || self.stream2.is_terminated()
     }
 }
 


### PR DESCRIPTION
The condition for `is_terminated` in the `FusedStream` impl for `Zip` should check if either child stream has terminated. Otherwise, one stream may be polled even after it has been terminated if the other has not.

This following example triggers the current bug:

```rust
use futures::stream::{self, StreamExt};

#[tokio::main]
pub async fn main() {
    let stream1 = stream::iter(vec![17, 19]);
    let stream2 = stream::iter(vec![17]);
    let mut zipped = stream1.zip(stream2);
    loop {
        futures::select!{
            res = zipped.select_next_some() => {
                println!("Zip result {res:?}");
            }
            complete => break,
        }
        
    }
}
```