### PR TITLE
Can we haz const new Mutex?

### DIFF
--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -73,7 +73,7 @@ const HAS_WAITERS: usize = 1 << 1;
 
 impl<T> Mutex<T> {
     /// Creates a new futures-aware mutex.
-    pub fn new(t: T) -> Self {
+    pub const fn new(t: T) -> Self {
         Self {
             state: AtomicUsize::new(0),
             waiters: StdMutex::new(Slab::new()),


### PR DESCRIPTION
All code in `futures_util::lock::Mutex::new` is `const` compatible, and I don't see a reason why it shouldn't be marked as a `const` fn. Can we haz?