### PR TITLE
feat: `select!` macro for no-std environments 

### DIFF
--- a/futures-util/src/async_await/mod.rs
+++ b/futures-util/src/async_await/mod.rs
@@ -34,10 +34,8 @@ mod stream_select_mod;
 #[cfg(feature = "async-await-macro")]
 pub use self::stream_select_mod::*;
 
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 mod random;
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await-macro")]
 pub use self::random::*;
 

--- a/futures-util/src/async_await/random.rs
+++ b/futures-util/src/async_await/random.rs
@@ -88,6 +88,7 @@ fn xorshift64star(mut x: Wrapping<u64>) -> (Wrapping<u64>, u64) {
 #[cfg(not(feature = "std"))]
 #[inline]
 fn xorshift32(mut x: u32) -> u32 {
+    debug_assert_ne!(x, 0);
     x ^= x << 13;
     x ^= x >> 17;
     x ^= x << 5;

--- a/futures-util/src/async_await/random.rs
+++ b/futures-util/src/async_await/random.rs
@@ -73,7 +73,7 @@ fn random() -> u64 {
     }
 
     let result = x.wrapping_mul(0x2545_f491_4f6c_dd1d) as u64;
-    RNG.store(result, Ordering::Relaxed);
+    RNG.store(result as usize, Ordering::Relaxed);
 
     result
 }

--- a/futures-util/src/async_await/random.rs
+++ b/futures-util/src/async_await/random.rs
@@ -53,7 +53,7 @@ fn random() -> u64 {
 }
 
 #[cfg(not(feature = "std"))]
-fn random_nostd() -> u64 {
+fn random() -> u64 {
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     static RNG: AtomicUsize = AtomicUsize::new(1);

--- a/futures-util/src/async_await/random.rs
+++ b/futures-util/src/async_await/random.rs
@@ -56,15 +56,22 @@ fn random() -> u64 {
 
 #[cfg(not(feature = "std"))]
 fn random() -> u64 {
-    use core::sync::atomic::{AtomicU64, Ordering};
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
-    static RNG: AtomicU64 = AtomicU64::new(1);
+    static RNG: AtomicUsize = AtomicUsize::new(1);
 
     let mut x = RNG.load(Ordering::Relaxed);
 
-    x ^= x >> 12;
-    x ^= x << 25;
-    x ^= x >> 27;
+    if core::mem::size_of::<usize>() == 4 {
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+    } else if core::mem::size_of::<usize>() == 8 {
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+    }
+
     let result = x.wrapping_mul(0x2545_f491_4f6c_dd1d) as u64;
     RNG.store(result, Ordering::Relaxed);
 

--- a/futures-util/src/async_await/random.rs
+++ b/futures-util/src/async_await/random.rs
@@ -70,10 +70,9 @@ fn random() -> u64 {
         x ^= x >> 12;
         x ^= x << 25;
         x ^= x >> 27;
+        x = x.wrapping_mul(0x2545_f491_4f6c_dd1d);
     }
 
-    let result = x.wrapping_mul(0x2545_f491_4f6c_dd1d) as u64;
-    RNG.store(result as usize, Ordering::Relaxed);
-
-    result
+    RNG.store(x, Ordering::Relaxed);
+    x as u64
 }

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -305,7 +305,6 @@ macro_rules! document_select_macro {
     };
 }
 
-#[cfg(feature = "std")]
 #[doc(hidden)]
 pub use futures_macro::select_internal;
 
@@ -313,7 +312,6 @@ pub use futures_macro::select_internal;
 pub use futures_macro::select_biased_internal;
 
 document_select_macro! {
-    #[cfg(feature = "std")]
     #[macro_export]
     macro_rules! select {
         ($($tokens:tt)*) => {{

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -120,7 +120,6 @@ pub use futures_util::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteEx
 // Macro reexports
 pub use futures_core::ready; // Readiness propagation
 pub use futures_util::pin_mut;
-#[cfg(feature = "std")]
 #[cfg(feature = "async-await")]
 pub use futures_util::select;
 #[cfg(feature = "async-await")]


### PR DESCRIPTION
Currently, the `select!` macro works only in the std environment.
This PR fixes the implementation so that the `select!` macro also works in no-std environments for 32- and 64-bit CPUs.

The behavior in the std environment remains unchanged.