### PR TITLE
Bump MSRV of core crates to 1.41.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         rust:
           # This is the minimum Rust version supported by futures-core, futures-io, futures-sink.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
-          - '1.36'
+          - '1.41.0'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-core"
 version = "1.0.0-alpha.0"
 edition = "2018"
-rust-version = "1.36"
+rust-version = "1.41.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-core/README.md
+++ b/futures-core/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-core = "0.3"
 ```
 
-The current `futures-core` requires Rust 1.36 or later.
+The current `futures-core` requires Rust 1.41.0 or later.
 
 ## License
 

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-io"
 version = "0.3.31"
 edition = "2018"
-rust-version = "1.36"
+rust-version = "1.41.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-io/README.md
+++ b/futures-io/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-io = "0.3"
 ```
 
-The current `futures-io` requires Rust 1.36 or later.
+The current `futures-io` requires Rust 1.41.0 or later.
 
 ## License
 

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-sink"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.36"
+rust-version = "1.41.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-sink/README.md
+++ b/futures-sink/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-sink = "0.3"
 ```
 
-The current `futures-sink` requires Rust 1.36 or later.
+The current `futures-sink` requires Rust 1.41.0 or later.
 
 ## License
 


### PR DESCRIPTION
This should allow us to use `core::panic::AssertUnwindSafe` rather than depending on `std` for this.