### PR TITLE
core: no-std panic::AssertUnwindSafe (etc.)

### DIFF
--- a/futures-core/src/future.rs
+++ b/futures-core/src/future.rs
@@ -104,8 +104,7 @@ mod if_alloc {
         }
     }
 
-    #[cfg(feature = "std")]
-    impl<F: FusedFuture> FusedFuture for std::panic::AssertUnwindSafe<F> {
+    impl<F: FusedFuture> FusedFuture for core::panic::AssertUnwindSafe<F> {
         fn is_terminated(&self) -> bool {
             <F as FusedFuture>::is_terminated(&**self)
         }

--- a/futures-core/src/lib.rs
+++ b/futures-core/src/lib.rs
@@ -12,8 +12,6 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 pub mod future;
 #[doc(no_inline)]

--- a/futures-core/src/stream.rs
+++ b/futures-core/src/stream.rs
@@ -224,8 +224,7 @@ mod if_alloc {
         }
     }
 
-    #[cfg(feature = "std")]
-    impl<S: Stream> Stream for std::panic::AssertUnwindSafe<S> {
+    impl<S: Stream> Stream for core::panic::AssertUnwindSafe<S> {
         type Item = S::Item;
 
         fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<S::Item>> {

--- a/futures-sink/src/lib.rs
+++ b/futures-sink/src/lib.rs
@@ -15,8 +15,6 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 use core::ops::DerefMut;
 use core::pin::Pin;


### PR DESCRIPTION
__STATUS:__

I think the following PRs should be merged first to resolve the CI build issues:

- [ ] #2904 - resolve clippy failure
- [ ] #2907 - bump main / general MSRV to resolve MSRV failure
- [ ] #2906 - bump core MSRV as needed for this PR

---

__WHAT:__

- use panic::AssertUnwindSafe from Rust core lib in `futures-core`
- remove `extern crate std` not needed from `futures-core` & `futures-sink`

I would be happy to split these updates into separate PRs, if needed. I figured we may as well do these updates together.

---

__CI testing TODO(s):__

- core MSRV failure (expected) - requires core MSRV bump to 1.41 - already resolved by PR: #2906
- clippy failure - already resolved by PR: #2904
- general msrv failure - as resolved by PR: #2907

---

__other TODO(s):__

- [ ] remove `std` option from `futures-core` & `futures-sink` - this would be another breaking change - I would be happy to do this here or in a separate PR