### PR TITLE
update Rust edition -> 2021

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,11 +106,15 @@ jobs:
   util-msrv:
     name: cargo +${{ matrix.rust }} build
     strategy:
+      # XXX TODO REMOVE ONCE GENERAL MSRV IS UPDATED AS PROPOSED IN OTHER PR #2907
+      fail-fast: false
       matrix:
         rust:
           # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
+          # XXX TODO USE SINGLE, UPDATED MSRV AS PROPOSED IN OTHER PR #2907
           - '1.56'
+          - '1.63'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
           # This is the minimum Rust version supported by futures-core, futures-io, futures-sink.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
           # XXX TODO USE SINGLE, UPDATED MSRV AS PROPOSED IN OTHER PR #2906
-          - '1.36'
-          - '1.41.0'
+          # - '1.36'
+          # - '1.41.0'
           - '1.56'
           - '1.63'
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,15 @@ jobs:
   core-msrv:
     name: cargo +${{ matrix.rust }} build (futures-{core, io, sink})
     strategy:
+      # XXX TODO REMOVE ONCE CORE MSRV IS UPDATED AS PROPOSED IN OTHER PR #2906
+      fail-fast: false
       matrix:
         rust:
           # This is the minimum Rust version supported by futures-core, futures-io, futures-sink.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
+          # XXX TODO USE SINGLE, UPDATED MSRV AS PROPOSED IN OTHER PR #2906
           - '1.36'
+          - '1.41.0'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
           # XXX TODO USE SINGLE, UPDATED MSRV AS PROPOSED IN OTHER PR #2907
-          - '1.56'
+          # - '1.56'
           - '1.63'
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,8 @@ jobs:
           RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z sanitizer=${{ matrix.sanitizer }} --cfg futures_sanitizer
 
   clippy:
+    # XXX SKIP FAILING CI JOB FOR NOW - XXX TODO REMOVE once FIXED by merging other PR #2904
+    if: ${{ false }}
     name: cargo clippy
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
           # XXX TODO USE SINGLE, UPDATED MSRV AS PROPOSED IN OTHER PR #2906
           - '1.36'
           - '1.41.0'
+          - '1.56'
+          - '1.63'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "futures",
   "futures-core",

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-channel"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-executor"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-macro"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-task"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-test"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures-util"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "futures"
 version = "0.4.0-alpha.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"


### PR DESCRIPTION
requires PR #2907 - bump general MSRV to 1.63; need to update core MSRV as stated below

---

__CI testing TODO(s):__

- clippy failure - as already proposed by other PR: #2904
- core MSRV failure - requires core MSRV bump to 1.41 - as already proposed by other PR: #2906
- expected general MSRV failure - requires general MSRV -> 1.63 - as already proposed by other PR: #2907

---

__other TODO(s):__

- [x] ~~update workspace resolver -> "2", as stated by cargo warning~~
- [ ] update core MSRV -> 1.56 in other PR & merge once ready: #2906
- [ ] update main MSRV -> 1.63 in other PR: #2907