### PR TITLE
util: no-std error::Error info

### DIFF
--- a/futures-util/src/abortable.rs
+++ b/futures-util/src/abortable.rs
@@ -126,8 +126,7 @@ impl fmt::Display for Aborted {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Aborted {}
+impl core::error::Error for Aborted {}
 
 impl<T> Abortable<T> {
     fn try_poll<I>(

--- a/futures-util/src/io/split.rs
+++ b/futures-util/src/io/split.rs
@@ -125,5 +125,4 @@ impl<T> fmt::Display for ReuniteError<T> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: core::any::Any> std::error::Error for ReuniteError<T> {}
+impl<T: core::any::Any> core::error::Error for ReuniteError<T> {}

--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -220,8 +220,7 @@ impl<T> fmt::Display for ReuniteError<T> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: core::any::Any> std::error::Error for ReuniteError<T> {}
+impl<T: core::any::Any> core::error::Error for ReuniteError<T> {}
 
 /// Returned RAII guard from the `poll_lock` method.
 ///

--- a/futures-util/src/stream/stream/split.rs
+++ b/futures-util/src/stream/stream/split.rs
@@ -154,8 +154,7 @@ impl<T, Item> fmt::Display for ReuniteError<T, Item> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T: core::any::Any, Item> std::error::Error for ReuniteError<T, Item> {}
+impl<T: core::any::Any, Item> core::error::Error for ReuniteError<T, Item> {}
 
 #[cfg(test)]
 mod tests {

--- a/futures-util/src/stream/try_stream/try_chunks.rs
+++ b/futures-util/src/stream/try_stream/try_chunks.rs
@@ -128,5 +128,4 @@ impl<T, E: fmt::Display> fmt::Display for TryChunksError<T, E> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T, E: fmt::Debug + fmt::Display> std::error::Error for TryChunksError<T, E> {}
+impl<T, E: fmt::Debug + fmt::Display> core::error::Error for TryChunksError<T, E> {}

--- a/futures-util/src/stream/try_stream/try_ready_chunks.rs
+++ b/futures-util/src/stream/try_stream/try_ready_chunks.rs
@@ -122,5 +122,4 @@ impl<T, E: fmt::Display> fmt::Display for TryReadyChunksError<T, E> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<T, E: fmt::Debug + fmt::Display> std::error::Error for TryReadyChunksError<T, E> {}
+impl<T, E: fmt::Debug + fmt::Display> core::error::Error for TryReadyChunksError<T, E> {}


### PR DESCRIPTION
__STATUS:__ need the following updates to resolve expected CI issues:

- [ ] PR #2904 - resolve known clippy issue
- [ ] ~~PR #2907 - bump MSRV -> 1.63~~ - UPDATED with apologies: this would need MSRV ➡️ 1.81