### PR TITLE
feat: add `_timeout` variants to blocking executions

### DIFF
--- a/futures-executor/src/lib.rs
+++ b/futures-executor/src/lib.rs
@@ -53,7 +53,10 @@ extern crate std;
 #[cfg(feature = "std")]
 mod local_pool;
 #[cfg(feature = "std")]
-pub use crate::local_pool::{block_on, block_on_stream, BlockingStream, LocalPool, LocalSpawner};
+pub use crate::local_pool::{
+    block_on, block_on_stream, block_on_timeout, BlockingStream, LocalPool, LocalSpawner,
+    TimeoutError,
+};
 
 #[cfg(feature = "thread-pool")]
 #[cfg_attr(docsrs, doc(cfg(feature = "thread-pool")))]

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -76,22 +76,9 @@ impl ArcWake for ThreadNotify {
 }
 
 /// An error returned when a blocking execution times out.
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct TimeoutError {
-    _private: (),
-}
-
-impl TimeoutError {
-    fn new() -> Self {
-        Self { _private: () }
-    }
-}
-
-impl fmt::Debug for TimeoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TimeoutError").finish()
-    }
-}
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TimeoutError;
 
 impl fmt::Display for TimeoutError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -152,7 +139,7 @@ fn run_executor_timeout<T, F: FnMut(&mut Context<'_>) -> Poll<T>>(
         thread::park_timeout(timeout);
         let elapsed = start.elapsed();
         if elapsed >= timeout {
-            return Err(TimeoutError::new());
+            return Err(TimeoutError);
         }
         timeout -= elapsed;
         Ok(())

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -82,7 +82,7 @@ pub struct TimeoutError {
 }
 
 impl TimeoutError {
-    pub(crate) fn new() -> Self {
+    fn new() -> Self {
         Self { _private: () }
     }
 }

--- a/futures-executor/tests/local_pool.rs
+++ b/futures-executor/tests/local_pool.rs
@@ -65,6 +65,19 @@ fn run_until_executes_spawned() {
 }
 
 #[test]
+fn run_until_timeout() {
+    let mut pool = LocalPool::new();
+    assert!(pool.run_until_timeout(pending(), Duration::from_millis(1)).is_err())
+}
+
+#[test]
+fn run_timeout() {
+    let mut pool = LocalPool::new();
+    pool.spawner().spawn_local(pending()).unwrap();
+    assert!(pool.run_timeout(Duration::from_millis(1)).is_err())
+}
+
+#[test]
 fn run_returns_if_empty() {
     let mut pool = LocalPool::new();
     pool.run();

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -189,8 +189,8 @@ pub mod executor {
     //! [`spawn_local_obj`]: https://docs.rs/futures/0.3/futures/task/trait.LocalSpawn.html#tymethod.spawn_local_obj
 
     pub use futures_executor::{
-        block_on, block_on_stream, enter, BlockingStream, Enter, EnterError, LocalPool,
-        LocalSpawner,
+        block_on, block_on_stream, block_on_timeout, enter, BlockingStream, Enter, EnterError,
+        LocalPool, LocalSpawner, TimeoutError,
     };
 
     #[cfg(feature = "thread-pool")]


### PR DESCRIPTION
This commit introduce `block_on_timeout`, as well as `LocalPool::run_timeout` and `LocalPool::run_until_timeout`. The internal `run_executor` has been modified to use either `std::thread::park` or `std::thread::park_timeout`. In case of timeout, a `TimeoutError` instance is returned.

The new generic `run_executor_impl` returns a `Result`, which is always `Ok` in `run_executor` case (using `park`). It has been checked with `cargo asm` that the compiler is able to elide the `unwrap` call in this case. Also, the assembly showed that the parking closure was inlined, so no regression is expected compared to the previous implementation.