### PR TITLE
ci: Remove workaround for fixed AArch64 Linux runner bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      # https://github.com/orgs/community/discussions/148648#discussioncomment-11867019
-      - name: Workaround for AArch64 Linux runner bug
-        run: for var in PATH XDG_CONFIG_HOME; do sed -Ee "s/^/${var}=/" -e 's/(runner)admin/\1/g' <<< "${!var}"; done | tee -a -- "${GITHUB_ENV}"
-        if: endsWith(matrix.os, '-arm')
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         uses: taiki-e/github-actions/install-rust@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - master
       - '[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 2 * * *'
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Follow-up to #2915.