### PR TITLE
ci: Test armv7hf Linux on ubuntu-24.04-arm runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - os: macos-latest
           - os: windows-latest
           - os: ubuntu-24.04-arm
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             target: armv7-unknown-linux-gnueabihf
           - os: ubuntu-latest
             target: armv5te-unknown-linux-gnueabi


### PR DESCRIPTION
setup-cross-toolchain-action now supports this: https://github.com/taiki-e/setup-cross-toolchain-action/releases/tag/v1.27.0

Related: https://github.com/rust-lang/futures-rs/pull/2915