### PR TITLE
ci: Run clippy on stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,10 +297,10 @@ jobs:
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
+        uses: taiki-e/github-actions/install-rust@stable
         with:
           component: clippy
-      - run: cargo clippy --workspace --all-features --all-targets
+      - run: cargo clippy --workspace --all-features --lib --bins --tests --examples
 
   fmt:
     name: cargo fmt
@@ -310,6 +310,8 @@ jobs:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         uses: taiki-e/github-actions/install-rust@stable
+        with:
+          component: rustfmt
       - run: cargo fmt --all -- --check
 
   docs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ members = [
 missing_debug_implementations = "warn"
 rust_2018_idioms = "warn"
 single_use_lifetimes = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(futures_sanitizer)',
+] }
 unreachable_pub = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(futures_sanitizer)'] }
 # unsafe_op_in_unsafe_fn = "warn" # Set at crate-level instead since https://github.com/rust-lang/rust/pull/100081 is not available on MSRV
 [workspace.lints.clippy]
 incompatible_msrv = { level = "allow", priority = 1 } # https://github.com/rust-lang/rust-clippy/issues/12273, https://github.com/rust-lang/rust-clippy/issues/12257

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -20,7 +20,6 @@
     )
 ))]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
-#![allow(clippy::arc_with_non_send_sync)] // false positive https://github.com/rust-lang/rust-clippy/issues/11076
 
 #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
 #[cfg(feature = "alloc")]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -12,7 +12,6 @@
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::needless_borrow)] // https://github.com/rust-lang/futures-rs/pull/2558#issuecomment-1030745203
-#![allow(clippy::arc_with_non_send_sync)] // false positive https://github.com/rust-lang/rust-clippy/issues/11076
 
 #[cfg(all(feature = "bilock", not(feature = "unstable")))]
 compile_error!("The `bilock` feature requires the `unstable` feature as an explicit opt-in to unstable features");

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -145,7 +145,6 @@ pub use futures_util::lock;
 #[doc(inline)]
 pub use futures_util::io;
 
-#[allow(clippy::mixed_attributes_style)] // https://github.com/rust-lang/rust-clippy/issues/12435
 #[cfg(feature = "executor")]
 #[cfg_attr(docsrs, doc(cfg(feature = "executor")))]
 pub mod executor {
@@ -198,7 +197,6 @@ pub mod executor {
     pub use futures_executor::{ThreadPool, ThreadPoolBuilder};
 }
 
-#[allow(clippy::mixed_attributes_style)] // https://github.com/rust-lang/rust-clippy/issues/12435
 #[cfg(feature = "compat")]
 #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
 pub mod compat {


### PR DESCRIPTION
This was previously proposed but was not possible at the time due to one of our unstable features using the rustc's unstable feature. Since https://github.com/rust-lang/futures-rs/pull/2885, we there is no feature enables rustc's unstable features.

This should alleviate our CI failure issues that sometimes occur.