### PR TITLE
chore: recommend to use core lib's ready macro

### DIFF
--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -4,10 +4,6 @@
 ///
 /// **Note:** Since Rust 1.64, this macro is soft-deprecated in favor of
 /// [`ready!`](core::task::ready) macro in the standard library.
-#[deprecated(
-    since = "0.4.0",
-    note = "use core::task::ready macro in the standard library instead"
-)]
 #[macro_export]
 macro_rules! ready {
     ($e:expr $(,)?) => {

--- a/futures-core/src/task/poll.rs
+++ b/futures-core/src/task/poll.rs
@@ -1,6 +1,13 @@
-/// Extracts the successful type of a `Poll<T>`.
+/// Extracts the successful type of `Poll<T>`.
 ///
 /// This macro bakes in propagation of `Pending` signals by returning early.
+///
+/// **Note:** Since Rust 1.64, this macro is soft-deprecated in favor of
+/// [`ready!`](core::task::ready) macro in the standard library.
+#[deprecated(
+    since = "0.4.0",
+    note = "use core::task::ready macro in the standard library instead"
+)]
 #[macro_export]
 macro_rules! ready {
     ($e:expr $(,)?) => {


### PR DESCRIPTION
Ref - https://rust-lang.zulipchat.com/#narrow/channel/187312-wg-async/topic/Move.20the.20.60ready!.60.20macro.20to.20libcore.3F/near/497123105

Weak Ref - https://github.com/rust-lang/futures-rs/issues/2924