### PR TITLE
chore: reduce dependency to pin-utils

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -41,7 +41,6 @@ slab = { version = "0.4.2", default-features = false, optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
-pin-utils = "0.1.0"
 pin-project-lite = "0.2.6"
 spin = { version = "0.9.8", optional = true }
 

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -10,6 +10,7 @@ use core::pin::Pin;
 
 use crate::fns::{inspect_fn, into_fn, ok_fn, InspectFn, IntoFn, OkFn};
 use crate::future::{assert_future, Either};
+use crate::pin_mut;
 use crate::stream::assert_stream;
 #[cfg(feature = "alloc")]
 use futures_core::future::{BoxFuture, LocalBoxFuture};
@@ -110,36 +111,6 @@ pub use self::remote_handle::{Remote, RemoteHandle};
 mod shared;
 #[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 pub use self::shared::{Shared, WeakShared};
-
-/// Pins a value on the stack.
-///
-/// **Note:** Since Rust 1.68, this macro is soft-deprecated in favor of
-/// [`pin!`](https://doc.rust-lang.org/std/pin/macro.pin.html) macro
-/// in the standard library.
-///
-/// # Example
-///
-/// ```rust
-/// # use futures_util::pin_mut;
-/// # use core::pin::Pin;
-/// # struct Foo {}
-/// let foo = Foo { /* ... */ };
-/// pin_mut!(foo);
-/// let _: Pin<&mut Foo> = foo;
-/// ```
-#[macro_export]
-macro_rules! pin_mut {
-    ($($x:ident),* $(,)?) => { $(
-        // Move the value to ensure that it is owned
-        let mut $x = $x;
-        // Shadow the original binding so that it can't be directly accessed
-        // ever again.
-        #[allow(unused_mut)]
-        let mut $x = unsafe {
-            ::core::pin::Pin::new_unchecked(&mut $x)
-        };
-    )* }
-}
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
 

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -18,7 +18,6 @@ use futures_core::{
     stream::Stream,
     task::{Context, Poll},
 };
-use pin_utils::pin_mut;
 
 // Combinators
 
@@ -111,6 +110,36 @@ pub use self::remote_handle::{Remote, RemoteHandle};
 mod shared;
 #[cfg(any(feature = "std", all(feature = "alloc", feature = "spin")))]
 pub use self::shared::{Shared, WeakShared};
+
+/// Pins a value on the stack.
+///
+/// **Note:** Since Rust 1.68, this macro is soft-deprecated in favor of
+/// [`pin!`](https://doc.rust-lang.org/std/pin/macro.pin.html) macro
+/// in the standard library.
+///
+/// # Example
+///
+/// ```rust
+/// # use futures_util::pin_mut;
+/// # use core::pin::Pin;
+/// # struct Foo {}
+/// let foo = Foo { /* ... */ };
+/// pin_mut!(foo);
+/// let _: Pin<&mut Foo> = foo;
+/// ```
+#[macro_export]
+macro_rules! pin_mut {
+    ($($x:ident),* $(,)?) => { $(
+        // Move the value to ensure that it is owned
+        let mut $x = $x;
+        // Shadow the original binding so that it can't be directly accessed
+        // ever again.
+        #[allow(unused_mut)]
+        let mut $x = unsafe {
+            ::core::pin::Pin::new_unchecked(&mut $x)
+        };
+    )* }
+}
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
 

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -23,7 +23,6 @@ extern crate std;
 
 // Macro re-exports
 pub use futures_core::ready;
-pub use pin_utils::pin_mut;
 
 #[cfg(feature = "async-await")]
 #[macro_use]

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -327,5 +327,5 @@ pub mod lock;
 mod abortable;
 
 mod fns;
-mod unfold_state;
 mod macros;
+mod unfold_state;

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -32,7 +32,6 @@ mod async_await;
 pub use self::async_await::*;
 
 // Not public API.
-#[cfg(feature = "async-await")]
 #[doc(hidden)]
 pub mod __private {
     pub use crate::*;
@@ -42,6 +41,7 @@ pub mod __private {
         result::Result::{Err, Ok},
     };
 
+    #[cfg(feature = "async-await")]
     pub mod async_await {
         pub use crate::async_await::*;
     }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -328,3 +328,4 @@ mod abortable;
 
 mod fns;
 mod unfold_state;
+mod macros;

--- a/futures-util/src/macros.rs
+++ b/futures-util/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! pin_mut {
         // ever again.
         #[allow(unused_mut)]
         let mut $x = unsafe {
-            ::core::pin::Pin::new_unchecked(&mut $x)
+            $crate::__private::Pin::new_unchecked(&mut $x)
         };
     )* }
 }

--- a/futures-util/src/macros.rs
+++ b/futures-util/src/macros.rs
@@ -1,0 +1,31 @@
+/// Pins a value on the stack.
+///
+/// Can safely pin values that are not `Unpin` by taking ownership.
+///
+/// **Note:** Since Rust 1.68, this macro is soft-deprecated in favor of
+/// [`pin!`](https://doc.rust-lang.org/std/pin/macro.pin.html) macro
+/// in the standard library.
+///
+/// # Example
+///
+/// ```rust
+/// # use futures_util::pin_mut;
+/// # use core::pin::Pin;
+/// # struct Foo {}
+/// let foo = Foo { /* ... */ };
+/// pin_mut!(foo);
+/// let _: Pin<&mut Foo> = foo;
+/// ```
+#[macro_export]
+macro_rules! pin_mut {
+    ($($x:ident),* $(,)?) => { $(
+        // Move the value to ensure that it is owned
+        let mut $x = $x;
+        // Shadow the original binding so that it can't be directly accessed
+        // ever again.
+        #[allow(unused_mut)]
+        let mut $x = unsafe {
+            ::core::pin::Pin::new_unchecked(&mut $x)
+        };
+    )* }
+}


### PR DESCRIPTION
This refers to https://github.com/rust-lang/futures-rs/issues/2924.

cc @taiki-e as for "it is reasonable to remove it in v0.4", IIUC I can open a follow-up PR to remove this macro and update the corresponding related usage, only we don't mark that PR as 0.3-backport?

BTW, if there is anything I can help in backporting, please let me know. In my experience, it means opening a PR against branch `0.3` and do the same change.