### PR TITLE
chore: replace all doctest usage of pin_mut with pin 

### DIFF
--- a/futures-test/src/assert.rs
+++ b/futures-test/src/assert.rs
@@ -9,15 +9,16 @@ pub fn assert_is_unpin_stream<S: Stream + Unpin>(_: &mut S) {}
 /// # Examples
 ///
 /// ```
+/// use core::pin::pin;
+///
 /// use futures::stream;
 /// use futures_test::future::FutureTestExt;
-/// use futures_test::{
-///     assert_stream_pending, assert_stream_next, assert_stream_done,
-/// };
-/// use futures::pin_mut;
+/// use futures_test::assert_stream_pending;
+/// use futures_test::assert_stream_next;
+/// use futures_test::assert_stream_done;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
-/// pin_mut!(stream);
+/// let mut stream = pin!(stream);
 ///
 /// assert_stream_pending!(stream);
 /// assert_stream_next!(stream, 5);
@@ -46,15 +47,16 @@ macro_rules! assert_stream_pending {
 /// # Examples
 ///
 /// ```
+/// use core::pin::pin;
+///
 /// use futures::stream;
 /// use futures_test::future::FutureTestExt;
-/// use futures_test::{
-///     assert_stream_pending, assert_stream_next, assert_stream_done,
-/// };
-/// use futures::pin_mut;
+/// use futures_test::assert_stream_pending;
+/// use futures_test::assert_stream_next;
+/// use futures_test::assert_stream_done;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
-/// pin_mut!(stream);
+/// let mut stream = pin!(stream);
 ///
 /// assert_stream_pending!(stream);
 /// assert_stream_next!(stream, 5);
@@ -90,15 +92,16 @@ macro_rules! assert_stream_next {
 /// # Examples
 ///
 /// ```
+/// use core::pin::pin;
+///
 /// use futures::stream;
 /// use futures_test::future::FutureTestExt;
-/// use futures_test::{
-///     assert_stream_pending, assert_stream_next, assert_stream_done,
-/// };
-/// use futures::pin_mut;
+/// use futures_test::assert_stream_pending;
+/// use futures_test::assert_stream_next;
+/// use futures_test::assert_stream_done;
 ///
 /// let stream = stream::once((async { 5 }).pending_once());
-/// pin_mut!(stream);
+/// let mut stream = pin!(stream);
 ///
 /// assert_stream_pending!(stream);
 /// assert_stream_next!(stream, 5);

--- a/futures-test/src/future/mod.rs
+++ b/futures-test/src/future/mod.rs
@@ -32,14 +32,15 @@ pub trait FutureTestExt: Future {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::future::FutureExt;
     /// use futures_test::task::noop_context;
     /// use futures_test::future::FutureTestExt;
-    /// use futures::pin_mut;
     ///
     /// let future = (async { 5 }).pending_once();
-    /// pin_mut!(future);
+    /// let mut future = pin!(future);
     ///
     /// let mut cx = noop_context();
     ///
@@ -84,14 +85,15 @@ pub trait FutureTestExt: Future {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::future::{self, Future};
     /// use futures_test::task::noop_context;
     /// use futures_test::future::FutureTestExt;
-    /// use futures::pin_mut;
     ///
     /// let future = future::ready(1).interleave_pending();
-    /// pin_mut!(future);
+    /// let mut future = pin!(future);
     ///
     /// let mut cx = noop_context();
     ///

--- a/futures-test/src/io/read/mod.rs
+++ b/futures-test/src/io/read/mod.rs
@@ -29,14 +29,15 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::io::{AsyncRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use futures::pin_mut;
     ///
     /// let reader = Cursor::new(&[1, 2, 3]).interleave_pending();
-    /// pin_mut!(reader);
+    /// let mut reader = pin!(reader);
     ///
     /// let mut cx = noop_context();
     ///
@@ -59,14 +60,15 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// The returned reader will also implement `AsyncBufRead` if the underlying reader does.
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::io::{AsyncBufRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use futures::pin_mut;
     ///
     /// let reader = Cursor::new(&[1, 2, 3]).interleave_pending();
-    /// pin_mut!(reader);
+    /// let mut reader = pin!(reader);
     ///
     /// let mut cx = noop_context();
     ///
@@ -93,14 +95,15 @@ pub trait AsyncReadTestExt: AsyncRead {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::io::{AsyncRead, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncReadTestExt;
-    /// use futures::pin_mut;
     ///
     /// let reader = Cursor::new(&[1, 2, 3, 4, 5]).limited(2);
-    /// pin_mut!(reader);
+    /// let mut reader = pin!(reader);
     ///
     /// let mut cx = noop_context();
     ///

--- a/futures-test/src/io/write/mod.rs
+++ b/futures-test/src/io/write/mod.rs
@@ -30,14 +30,15 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::io::{AsyncWrite, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
-    /// use futures::pin_mut;
     ///
     /// let writer = Cursor::new(vec![0u8; 4].into_boxed_slice()).interleave_pending_write();
-    /// pin_mut!(writer);
+    /// let mut writer = pin!(writer);
     ///
     /// let mut cx = noop_context();
     ///
@@ -70,14 +71,15 @@ pub trait AsyncWriteTestExt: AsyncWrite {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::io::{AsyncWrite, Cursor};
     /// use futures_test::task::noop_context;
     /// use futures_test::io::AsyncWriteTestExt;
-    /// use futures::pin_mut;
     ///
     /// let writer = Cursor::new(vec![0u8; 4].into_boxed_slice()).limited_write(2);
-    /// pin_mut!(writer);
+    /// let mut writer = pin!(writer);
     ///
     /// let mut cx = noop_context();
     ///

--- a/futures-test/src/stream/mod.rs
+++ b/futures-test/src/stream/mod.rs
@@ -28,14 +28,15 @@ pub trait StreamTestExt: Stream {
     /// # Examples
     ///
     /// ```
+    /// use core::pin::pin;
+    ///
     /// use futures::task::Poll;
     /// use futures::stream::{self, Stream};
     /// use futures_test::task::noop_context;
     /// use futures_test::stream::StreamTestExt;
-    /// use futures::pin_mut;
     ///
     /// let stream = stream::iter(vec![1, 2]).interleave_pending();
-    /// pin_mut!(stream);
+    /// let mut stream = pin!(stream);
     ///
     /// let mut cx = noop_context();
     ///

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -29,7 +29,7 @@ pub fn panic_context() -> Context<'static> {
 /// use futures_test::task::noop_context;
 ///
 /// let future = async { 5 };
-/// let mut future = pin!(future);
+/// let future = pin!(future);
 ///
 /// assert_eq!(future.poll(&mut noop_context()), Poll::Ready(5));
 /// ```

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -22,13 +22,14 @@ pub fn panic_context() -> Context<'static> {
 /// # Examples
 ///
 /// ```
+/// use core::pin::pin;
+///
 /// use futures::future::Future;
 /// use futures::task::Poll;
 /// use futures_test::task::noop_context;
-/// use futures::pin_mut;
 ///
 /// let future = async { 5 };
-/// pin_mut!(future);
+/// let mut future = pin!(future);
 ///
 /// assert_eq!(future.poll(&mut noop_context()), Poll::Ready(5));
 /// ```

--- a/futures-util/src/async_await/select_mod.rs
+++ b/futures-util/src/async_await/select_mod.rs
@@ -58,7 +58,7 @@ macro_rules! document_select_macro {
         /// select! {
         ///     x = st.next() => assert_eq!(Some(2), x),
         ///     _ = fut => panic!(),
-        /// };
+        /// }
         /// # });
         /// ```
         ///
@@ -87,14 +87,15 @@ macro_rules! document_select_macro {
         /// If a similar async function is called outside of `select` to produce
         /// a `Future`, the `Future` must be pinned in order to be able to pass
         /// it to `select`. This can be achieved via `Box::pin` for pinning a
-        /// `Future` on the heap or the `pin_mut!` macro for pinning a `Future`
+        /// `Future` on the heap or the `pin!` macro for pinning a `Future`
         /// on the stack.
         ///
         /// ```
         /// # futures::executor::block_on(async {
+        /// use core::pin::pin;
+        ///
         /// use futures::future::FutureExt;
         /// use futures::select;
-        /// use futures::pin_mut;
         ///
         /// // Calling the following async fn returns a Future which does not
         /// // implement Unpin
@@ -105,7 +106,7 @@ macro_rules! document_select_macro {
         /// let fut_1 = async_identity_fn(1).fuse();
         /// let fut_2 = async_identity_fn(2).fuse();
         /// let mut fut_1 = Box::pin(fut_1); // Pins the Future on the heap
-        /// pin_mut!(fut_2); // Pins the Future on the stack
+        /// let mut fut_2 = pin!(fut_2); // Pins the Future on the stack
         ///
         /// let res = select! {
         ///     a_res = fut_1 => a_res,
@@ -138,7 +139,7 @@ macro_rules! document_select_macro {
         ///         b = b_fut => total += b,
         ///         complete => break,
         ///         default => panic!(), // never runs (futures run first, then complete)
-        ///     };
+        ///     }
         /// }
         /// assert_eq!(total, 10);
         /// # });
@@ -209,7 +210,7 @@ macro_rules! document_select_macro {
         /// select_biased! {
         ///     x = st.next() => assert_eq!(Some(2), x),
         ///     _ = fut => panic!(),
-        /// };
+        /// }
         /// # });
         /// ```
         ///
@@ -238,14 +239,15 @@ macro_rules! document_select_macro {
         /// If a similar async function is called outside of `select_biased` to produce
         /// a `Future`, the `Future` must be pinned in order to be able to pass
         /// it to `select_biased`. This can be achieved via `Box::pin` for pinning a
-        /// `Future` on the heap or the `pin_mut!` macro for pinning a `Future`
+        /// `Future` on the heap or the `pin!` macro for pinning a `Future`
         /// on the stack.
         ///
         /// ```
         /// # futures::executor::block_on(async {
+        /// use core::pin::pin;
+        ///
         /// use futures::future::FutureExt;
         /// use futures::select_biased;
-        /// use futures::pin_mut;
         ///
         /// // Calling the following async fn returns a Future which does not
         /// // implement Unpin
@@ -256,7 +258,7 @@ macro_rules! document_select_macro {
         /// let fut_1 = async_identity_fn(1).fuse();
         /// let fut_2 = async_identity_fn(2).fuse();
         /// let mut fut_1 = Box::pin(fut_1); // Pins the Future on the heap
-        /// pin_mut!(fut_2); // Pins the Future on the stack
+        /// let mut fut_2 = pin!(fut_2); // Pins the Future on the stack
         ///
         /// let res = select_biased! {
         ///     a_res = fut_1 => a_res,
@@ -289,7 +291,7 @@ macro_rules! document_select_macro {
         ///         b = b_fut => total += b,
         ///         complete => break,
         ///         default => panic!(), // never runs (futures run first, then complete)
-        ///     };
+        ///     }
         /// }
         /// assert_eq!(total, 10);
         /// # });

--- a/futures-util/src/future/future/fuse.rs
+++ b/futures-util/src/future/future/fuse.rs
@@ -29,11 +29,12 @@ impl<Fut: Future> Fuse<Fut> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
+    /// use core::pin::pin;
+    ///
     /// use futures::channel::mpsc;
     /// use futures::future::{Fuse, FusedFuture, FutureExt};
     /// use futures::select;
     /// use futures::stream::StreamExt;
-    /// use futures::pin_mut;
     ///
     /// let (sender, mut stream) = mpsc::unbounded();
     ///
@@ -45,7 +46,7 @@ impl<Fut: Future> Fuse<Fut> {
     /// // Use `Fuse::terminated()` to create an already-terminated future
     /// // which may be instantiated later.
     /// let foo_printer = Fuse::terminated();
-    /// pin_mut!(foo_printer);
+    /// let mut foo_printer = pin!(foo_printer);
     ///
     /// loop {
     ///     select! {

--- a/futures-util/src/future/maybe_done.rs
+++ b/futures-util/src/future/maybe_done.rs
@@ -29,11 +29,12 @@ impl<Fut: Future + Unpin> Unpin for MaybeDone<Fut> {}
 ///
 /// ```
 /// # futures::executor::block_on(async {
+/// use core::pin::pin;
+///
 /// use futures::future;
-/// use futures::pin_mut;
 ///
 /// let future = future::maybe_done(async { 5 });
-/// pin_mut!(future);
+/// let mut future = pin!(future);
 /// assert_eq!(future.as_mut().take_output(), None);
 /// let () = future.as_mut().await;
 /// assert_eq!(future.as_mut().take_output(), Some(5));

--- a/futures-util/src/future/poll_immediate.rs
+++ b/futures-util/src/future/poll_immediate.rs
@@ -55,12 +55,12 @@ impl<T: Future> FusedFuture for PollImmediate<T> {
 /// use future::FusedFuture;
 ///
 /// let f = async { 1_u32 };
-/// let mut f = pin!(f);
+/// let f = pin!(f);
 /// let mut r = future::poll_immediate(f);
 /// assert_eq!(r.next().await, Some(Poll::Ready(1)));
 ///
 /// let f = async {futures::pending!(); 42_u8};
-/// let mut f = pin!(f);
+/// let f = pin!(f);
 /// let mut p = future::poll_immediate(f);
 /// assert_eq!(p.next().await, Some(Poll::Pending));
 /// assert!(!p.is_terminated());

--- a/futures-util/src/future/poll_immediate.rs
+++ b/futures-util/src/future/poll_immediate.rs
@@ -48,17 +48,19 @@ impl<T: Future> FusedFuture for PollImmediate<T> {
 /// so polling it in a tight loop is worse than using a blocking synchronous function.
 /// ```
 /// # futures::executor::block_on(async {
+/// use core::pin::pin;
+///
 /// use futures::task::Poll;
-/// use futures::{StreamExt, future, pin_mut};
+/// use futures::{StreamExt, future};
 /// use future::FusedFuture;
 ///
 /// let f = async { 1_u32 };
-/// pin_mut!(f);
+/// let mut f = pin!(f);
 /// let mut r = future::poll_immediate(f);
 /// assert_eq!(r.next().await, Some(Poll::Ready(1)));
 ///
 /// let f = async {futures::pending!(); 42_u8};
-/// pin_mut!(f);
+/// let mut f = pin!(f);
 /// let mut p = future::poll_immediate(f);
 /// assert_eq!(p.next().await, Some(Poll::Pending));
 /// assert!(!p.is_terminated());
@@ -114,9 +116,12 @@ where
 ///
 /// ```
 /// # futures::executor::block_on(async {
-/// use futures::{future, pin_mut};
+/// use core::pin::pin;
+///
+/// use futures::future;
+///
 /// let f = async {futures::pending!(); 42_u8};
-/// pin_mut!(f);
+/// let mut f = pin!(f);
 /// assert_eq!(None, future::poll_immediate(&mut f).await);
 /// assert_eq!(42, f.await);
 /// # });

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -47,8 +47,8 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 /// };
 ///
 /// // 'select' requires Future + Unpin bounds
-/// let mut future1 = pin!(future1);
-/// let mut future2 = pin!(future2);
+/// let future1 = pin!(future1);
+/// let future2 = pin!(future2);
 ///
 /// let value = match future::select(future1, future2).await {
 ///     Either::Left((value1, _)) => value1,  // `value1` is resolved from `future1`

--- a/futures-util/src/future/select.rs
+++ b/futures-util/src/future/select.rs
@@ -32,11 +32,10 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 ///
 /// ```
 /// # futures::executor::block_on(async {
-/// use futures::{
-///     pin_mut,
-///     future::Either,
-///     future::self,
-/// };
+/// use core::pin::pin;
+///
+/// use futures::future;
+/// use futures::future::Either;
 ///
 /// // These two futures have different types even though their outputs have the same type.
 /// let future1 = async {
@@ -48,8 +47,8 @@ impl<A: Unpin, B: Unpin> Unpin for Select<A, B> {}
 /// };
 ///
 /// // 'select' requires Future + Unpin bounds
-/// pin_mut!(future1);
-/// pin_mut!(future2);
+/// let mut future1 = pin!(future1);
+/// let mut future2 = pin!(future2);
 ///
 /// let value = match future::select(future1, future2).await {
 ///     Either::Left((value1, _)) => value1,  // `value1` is resolved from `future1`

--- a/futures-util/src/macros.rs
+++ b/futures-util/src/macros.rs
@@ -9,11 +9,11 @@
 /// # Example
 ///
 /// ```rust
-/// # use futures_util::pin_mut;
+/// # use core::pin::pin;
 /// # use core::pin::Pin;
 /// # struct Foo {}
 /// let foo = Foo { /* ... */ };
-/// pin_mut!(foo);
+/// let foo = pin!(foo);
 /// let _: Pin<&mut Foo> = foo;
 /// ```
 #[macro_export]

--- a/futures-util/src/macros.rs
+++ b/futures-util/src/macros.rs
@@ -9,11 +9,11 @@
 /// # Example
 ///
 /// ```rust
-/// # use core::pin::pin;
+/// # use futures_util::pin_mut;
 /// # use core::pin::Pin;
 /// # struct Foo {}
 /// let foo = Foo { /* ... */ };
-/// let foo = pin!(foo);
+/// pin_mut!(foo);
 /// let _: Pin<&mut Foo> = foo;
 /// ```
 #[macro_export]

--- a/futures-util/src/sink/unfold.rs
+++ b/futures-util/src/sink/unfold.rs
@@ -23,7 +23,10 @@ pin_project! {
 ///
 /// ```
 /// # futures::executor::block_on(async {
-/// use futures::sink::{self, SinkExt};
+/// use core::pin::pin;
+///
+/// use futures::sink;
+/// use futures::sink::SinkExt;
 ///
 /// let unfold = sink::unfold(0, |mut sum, i: i32| {
 ///     async move {
@@ -32,7 +35,7 @@ pin_project! {
 ///         Ok::<_, std::convert::Infallible>(sum)
 ///     }
 /// });
-/// futures::pin_mut!(unfold);
+/// let mut unfold = pin!(unfold);
 /// unfold.send(5).await?;
 /// # Ok::<(), std::convert::Infallible>(()) }).unwrap();
 /// ```

--- a/futures-util/src/stream/stream/peek.rs
+++ b/futures-util/src/stream/stream/peek.rs
@@ -64,11 +64,13 @@ impl<St: Stream> Peekable<St> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::stream::{self, StreamExt};
-    /// use futures::pin_mut;
+    /// use core::pin::pin;
+    ///
+    /// use futures::stream;
+    /// use futures::stream::StreamExt;
     ///
     /// let stream = stream::iter(vec![1, 2, 3]).peekable();
-    /// pin_mut!(stream);
+    /// let mut stream = pin!(stream);
     ///
     /// assert_eq!(stream.as_mut().peek_mut().await, Some(&mut 1));
     /// assert_eq!(stream.as_mut().next().await, Some(1));
@@ -117,11 +119,13 @@ impl<St: Stream> Peekable<St> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::stream::{self, StreamExt};
-    /// use futures::pin_mut;
+    /// use core::pin::pin;
+    ///
+    /// use futures::stream;
+    /// use futures::stream::StreamExt;
     ///
     /// let stream = stream::iter(0..5).peekable();
-    /// pin_mut!(stream);
+    /// let mut stream = pin!(stream);
     /// // The first item of the stream is 0; consume it.
     /// assert_eq!(stream.as_mut().next_if(|&x| x == 0).await, Some(0));
     /// // The next item returned is now 1, so `consume` will return `false`.
@@ -135,11 +139,13 @@ impl<St: Stream> Peekable<St> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::stream::{self, StreamExt};
-    /// use futures::pin_mut;
+    /// use core::pin::pin;
+    ///
+    /// use futures::stream;
+    /// use futures::stream::StreamExt;
     ///
     /// let stream = stream::iter(1..20).peekable();
-    /// pin_mut!(stream);
+    /// let mut stream = pin!(stream);
     /// // Consume all numbers less than 10
     /// while stream.as_mut().next_if(|&x| x < 10).await.is_some() {}
     /// // The next value returned will be 10
@@ -162,11 +168,13 @@ impl<St: Stream> Peekable<St> {
     ///
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::stream::{self, StreamExt};
-    /// use futures::pin_mut;
+    /// use core::pin::pin;
+    ///
+    /// use futures::stream;
+    /// use futures::stream::StreamExt;
     ///
     /// let stream = stream::iter(0..5).peekable();
-    /// pin_mut!(stream);
+    /// let mut stream = pin!(stream);
     /// // The first item of the stream is 0; consume it.
     /// assert_eq!(stream.as_mut().next_if_eq(&0).await, Some(0));
     /// // The next item returned is now 1, so `consume` will return `false`.

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -657,8 +657,11 @@ pub trait TryStreamExt: TryStream {
     /// # Examples
     /// ```
     /// # futures::executor::block_on(async {
-    /// use futures::stream::{self, StreamExt, TryStreamExt};
-    /// use futures::pin_mut;
+    /// use core::pin::pin;
+    ///
+    /// use futures::stream;
+    /// use futures::stream::StreamExt;
+    /// use futures::stream::TryStreamExt;
     ///
     /// let stream = stream::iter(vec![Ok(1i32), Ok(6i32), Err("error")]);
     /// let halves = stream.try_filter_map(|x| async move {
@@ -666,7 +669,7 @@ pub trait TryStreamExt: TryStream {
     ///     Ok(ret)
     /// });
     ///
-    /// pin_mut!(halves);
+    /// let mut halves = pin!(halves);
     /// assert_eq!(halves.next().await, Some(Ok(3)));
     /// assert_eq!(halves.next().await, Some(Err("error")));
     /// # })


### PR DESCRIPTION
This follows up https://github.com/rust-lang/futures-rs/pull/2929#issuecomment-2746232982 step 1.

cc @taiki-e 