### PR TITLE
chore: replace all internal usage of pin_mut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
         rust:
           # This is the minimum Rust version supported by futures, futures-util, futures-task, futures-macro, futures-executor, futures-channel, futures-test.
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
-          - '1.63'
+          - '1.68'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to your `Cargo.toml`:
 futures = "0.3"
 ```
 
-The current `futures` requires Rust 1.63 or later.
+The current `futures` requires Rust 1.68 or later.
 
 ### Feature `std`
 

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-channel"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-channel/README.md
+++ b/futures-channel/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-channel = "0.3"
 ```
 
-The current `futures-channel` requires Rust 1.63 or later.
+The current `futures-channel` requires Rust 1.68 or later.
 
 ## License
 

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,7 +1,7 @@
+use std::pin::pin;
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
 use futures::future::{poll_fn, FutureExt};
-use futures::pin_mut;
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use futures::task::{Context, Poll};
@@ -30,7 +30,8 @@ fn send_recv_no_buffer() {
     // Run on a task context
     block_on(poll_fn(move |cx| {
         let (tx, rx) = mpsc::channel::<i32>(0);
-        pin_mut!(tx, rx);
+        let mut tx = pin!(tx);
+        let mut rx = pin!(rx);
 
         assert!(tx.as_mut().poll_flush(cx).is_ready());
         assert!(tx.as_mut().poll_ready(cx).is_ready());

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,4 +1,3 @@
-use std::pin::pin;
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
 use futures::future::{poll_fn, FutureExt};
@@ -6,6 +5,7 @@ use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use futures::task::{Context, Poll};
 use futures_test::task::{new_count_waker, noop_context};
+use std::pin::pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-executor"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-executor/README.md
+++ b/futures-executor/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-executor = "0.3"
 ```
 
-The current `futures-executor` requires Rust 1.63 or later.
+The current `futures-executor` requires Rust 1.68 or later.
 
 ## License
 

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -4,11 +4,11 @@ use futures_core::stream::Stream;
 use futures_core::task::{Context, Poll};
 use futures_task::{waker_ref, ArcWake};
 use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError};
-use futures_util::pin_mut;
 use futures_util::stream::FuturesUnordered;
 use futures_util::stream::StreamExt;
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
+use std::pin::pin;
 use std::rc::{Rc, Weak};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -155,7 +155,7 @@ impl LocalPool {
     /// one of the pool's run or poll methods. While the function is running,
     /// however, all tasks in the pool will try to make progress.
     pub fn run_until<F: Future>(&mut self, future: F) -> F::Output {
-        pin_mut!(future);
+        let mut future = pin!(future);
 
         run_executor(|cx| {
             {
@@ -312,7 +312,7 @@ impl Default for LocalPool {
 ///
 /// Use a [`LocalPool`] if you need finer-grained control over spawned tasks.
 pub fn block_on<F: Future>(f: F) -> F::Output {
-    pin_mut!(f);
+    let mut f = pin!(f);
     run_executor(|cx| f.as_mut().poll(cx))
 }
 

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-macro"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-task"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-task/README.md
+++ b/futures-task/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-task = "0.3"
 ```
 
-The current `futures-task` requires Rust 1.63 or later.
+The current `futures-task` requires Rust 1.68 or later.
 
 ## License
 

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-test"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-test/README.md
+++ b/futures-test/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-test = "0.3"
 ```
 
-The current `futures-test` requires Rust 1.63 or later.
+The current `futures-test` requires Rust 1.68 or later.
 
 ## License
 

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures-util"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/futures-rs"
 homepage = "https://rust-lang.github.io/futures-rs"

--- a/futures-util/README.md
+++ b/futures-util/README.md
@@ -11,7 +11,7 @@ Add this to your `Cargo.toml`:
 futures-util = "0.3"
 ```
 
-The current `futures-util` requires Rust 1.63 or later.
+The current `futures-util` requires Rust 1.68 or later.
 
 ## License
 

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -3,14 +3,14 @@
 //! This module contains a number of functions for working with `Future`s,
 //! including the `FutureExt` trait which adds methods to `Future` types.
 
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
-use core::convert::Infallible;
-use core::pin::Pin;
-use std::pin::pin;
 use crate::fns::{inspect_fn, into_fn, ok_fn, InspectFn, IntoFn, OkFn};
 use crate::future::{assert_future, Either};
 use crate::stream::assert_stream;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+use core::convert::Infallible;
+use core::pin::pin;
+use core::pin::Pin;
 #[cfg(feature = "alloc")]
 use futures_core::future::{BoxFuture, LocalBoxFuture};
 use futures_core::{
@@ -26,7 +26,7 @@ mod fuse;
 mod map;
 
 delegate_all!(
-    /// Future for the [`flatten`](super::FutureExt::flatten) method.
+    /// Future for the [`flatten`](FutureExt::flatten) method.
     Flatten<F>(
         flatten::Flatten<F, <F as Future>::Output>
     ): Debug + Future + FusedFuture + New[|x: F| flatten::Flatten::new(x)]
@@ -44,7 +44,7 @@ delegate_all!(
 pub use fuse::Fuse;
 
 delegate_all!(
-    /// Future for the [`map`](super::FutureExt::map) method.
+    /// Future for the [`map`](FutureExt::map) method.
     Map<Fut, F>(
         map::Map<Fut, F>
     ): Debug + Future + FusedFuture + New[|x: Fut, f: F| map::Map::new(x, f)]
@@ -79,14 +79,14 @@ delegate_all!(
 );
 
 delegate_all!(
-    /// Future for the [`never_error`](super::FutureExt::never_error) combinator.
+    /// Future for the [`never_error`](FutureExt::never_error) combinator.
     NeverError<Fut>(
         Map<Fut, OkFn<Infallible>>
     ): Debug + Future + FusedFuture + New[|x: Fut| Map::new(x, ok_fn())]
 );
 
 delegate_all!(
-    /// Future for the [`unit_error`](super::FutureExt::unit_error) combinator.
+    /// Future for the [`unit_error`](FutureExt::unit_error) combinator.
     UnitError<Fut>(
         Map<Fut, OkFn<()>>
     ): Debug + Future + FusedFuture + New[|x: Fut| Map::new(x, ok_fn())]

--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -7,10 +7,9 @@
 use alloc::boxed::Box;
 use core::convert::Infallible;
 use core::pin::Pin;
-
+use std::pin::pin;
 use crate::fns::{inspect_fn, into_fn, ok_fn, InspectFn, IntoFn, OkFn};
 use crate::future::{assert_future, Either};
-use crate::pin_mut;
 use crate::stream::assert_stream;
 #[cfg(feature = "alloc")]
 use futures_core::future::{BoxFuture, LocalBoxFuture};
@@ -592,8 +591,7 @@ pub trait FutureExt: Future {
         let noop_waker = crate::task::noop_waker();
         let mut cx = Context::from_waker(&noop_waker);
 
-        let this = self;
-        pin_mut!(this);
+        let this = pin!(self);
         match this.poll(&mut cx) {
             Poll::Ready(x) => Some(x),
             _ => None,

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -2,7 +2,7 @@
 name = "futures"
 version = "0.4.0-alpha.0"
 edition = "2018"
-rust-version = "1.63"
+rust-version = "1.68"
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
 keywords = ["futures", "async", "future"]

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -4,9 +4,7 @@ use futures::future::{self, poll_fn, FutureExt};
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
 use futures::task::{Context, Poll};
-use futures::{
-    join, pending, poll, select, select_biased, stream, stream_select, try_join,
-};
+use futures::{join, pending, poll, select, select_biased, stream, stream_select, try_join};
 use std::pin::pin;
 
 #[test]

--- a/futures/tests/future_join_all.rs
+++ b/futures/tests/future_join_all.rs
@@ -1,14 +1,14 @@
 use futures::executor::block_on;
 use futures::future::{join_all, ready, Future, JoinAll};
-use futures::pin_mut;
 use std::fmt::Debug;
+use std::pin::pin;
 
 #[track_caller]
 fn assert_done<T>(actual_fut: impl Future<Output = T>, expected: T)
 where
     T: PartialEq + Debug,
 {
-    pin_mut!(actual_fut);
+    let actual_fut = pin!(actual_fut);
     let output = block_on(actual_fut);
     assert_eq!(output, expected);
 }

--- a/futures/tests/future_try_join_all.rs
+++ b/futures/tests/future_try_join_all.rs
@@ -1,14 +1,14 @@
 use futures::executor::block_on;
 use futures::future::{err, ok, try_join_all, Future, TryJoinAll};
-use futures::pin_mut;
 use std::fmt::Debug;
+use std::pin::pin;
 
 #[track_caller]
 fn assert_done<T>(actual_fut: impl Future<Output = T>, expected: T)
 where
     T: PartialEq + Debug,
 {
-    pin_mut!(actual_fut);
+    let actual_fut = pin!(actual_fut);
     let output = block_on(actual_fut);
     assert_eq!(output, expected);
 }

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -156,7 +156,7 @@ fn test_buffered_reader_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        let mut reader =  pin!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.seek(SeekFrom::Start(3)).await.unwrap(), 3);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -174,7 +174,7 @@ fn test_buffered_reader_seek_relative() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        let mut reader =  pin!(reader);
+        let mut reader = pin!(reader);
 
         assert!(reader.as_mut().seek_relative(3).await.is_ok());
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -194,7 +194,7 @@ fn test_buffered_reader_invalidated_after_read() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        let mut reader =  pin!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -215,7 +215,7 @@ fn test_buffered_reader_invalidated_after_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        let mut reader =  pin!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -264,7 +264,7 @@ fn test_buffered_reader_seek_underflow() {
 
     block_on(async {
         let reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
-        let mut reader =  pin!(reader);
+        let mut reader = pin!(reader);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1, 2, 3, 4][..]);
         assert_eq!(reader.seek(SeekFrom::End(-5)).await.unwrap(), u64::MAX - 5);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap().len(), 5);
@@ -418,7 +418,7 @@ fn maybe_pending_seek() {
 
     let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
     let reader = BufReader::with_capacity(2, MaybePendingSeek::new(inner));
-    let mut reader =  pin!(reader);
+    let mut reader = pin!(reader);
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run(reader.as_mut().fill_buf()).ok(), Some(&[0, 1][..]));

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -4,13 +4,12 @@ use futures::io::{
     AllowStdIo, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt,
     BufReader, SeekFrom,
 };
-use futures::pin_mut;
 use futures::task::{Context, Poll};
 use futures_test::task::noop_context;
 use pin_project::pin_project;
 use std::cmp;
 use std::io;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 
 // helper for maybe_pending_* tests
 fn run<F: Future + Unpin>(mut f: F) -> F::Output {
@@ -157,7 +156,7 @@ fn test_buffered_reader_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader =  pin!(reader);
 
         assert_eq!(reader.seek(SeekFrom::Start(3)).await.unwrap(), 3);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -175,7 +174,7 @@ fn test_buffered_reader_seek_relative() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader =  pin!(reader);
 
         assert!(reader.as_mut().seek_relative(3).await.is_ok());
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -195,7 +194,7 @@ fn test_buffered_reader_invalidated_after_read() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader =  pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -216,7 +215,7 @@ fn test_buffered_reader_invalidated_after_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader =  pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -265,7 +264,7 @@ fn test_buffered_reader_seek_underflow() {
 
     block_on(async {
         let reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
-        pin_mut!(reader);
+        let mut reader =  pin!(reader);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1, 2, 3, 4][..]);
         assert_eq!(reader.seek(SeekFrom::End(-5)).await.unwrap(), u64::MAX - 5);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap().len(), 5);
@@ -419,7 +418,7 @@ fn maybe_pending_seek() {
 
     let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
     let reader = BufReader::with_capacity(2, MaybePendingSeek::new(inner));
-    pin_mut!(reader);
+    let mut reader =  pin!(reader);
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run(reader.as_mut().fill_buf()).ok(), Some(&[0, 1][..]));

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::fmt;
 use std::mem;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -509,7 +509,7 @@ fn sink_unfold() {
                 Ok::<_, String>(())
             }
         });
-        futures::pin_mut!(unfold);
+        let mut unfold = pin!(unfold);
         assert_eq!(unfold.as_mut().start_send(1), Ok(()));
         assert_eq!(unfold.as_mut().poll_flush(cx), Poll::Ready(Ok(())));
         assert_eq!(rx.try_next().unwrap(), Some(1));

--- a/futures/tests/stream_peekable.rs
+++ b/futures/tests/stream_peekable.rs
@@ -1,17 +1,17 @@
+use std::pin::pin;
 use futures::executor::block_on;
-use futures::pin_mut;
 use futures::stream::{self, Peekable, StreamExt};
 
 #[test]
 fn peekable() {
     block_on(async {
         let peekable: Peekable<_> = stream::iter(vec![1u8, 2, 3]).peekable();
-        pin_mut!(peekable);
+        let mut peekable = pin!(peekable);
         assert_eq!(peekable.as_mut().peek().await, Some(&1u8));
         assert_eq!(peekable.collect::<Vec<u8>>().await, vec![1, 2, 3]);
 
         let s = stream::once(async { 1 }).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         assert_eq!(s.as_mut().peek().await, Some(&1u8));
         assert_eq!(s.collect::<Vec<u8>>().await, vec![1]);
     });
@@ -21,7 +21,7 @@ fn peekable() {
 fn peekable_mut() {
     block_on(async {
         let s = stream::iter(vec![1u8, 2, 3]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         if let Some(p) = s.as_mut().peek_mut().await {
             if *p == 1 {
                 *p = 5;
@@ -36,7 +36,7 @@ fn peekable_next_if_eq() {
     block_on(async {
         // first, try on references
         let s = stream::iter(vec!["Heart", "of", "Gold"]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         // try before `peek()`
         assert_eq!(s.as_mut().next_if_eq(&"trillian").await, None);
         assert_eq!(s.as_mut().next_if_eq(&"Heart").await, Some("Heart"));
@@ -49,7 +49,7 @@ fn peekable_next_if_eq() {
 
         // make sure comparison works for owned values
         let s = stream::iter(vec![String::from("Ludicrous"), "speed".into()]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         // make sure basic functionality works
         assert_eq!(s.as_mut().next_if_eq("Ludicrous").await, Some("Ludicrous".into()));
         assert_eq!(s.as_mut().next_if_eq("speed").await, Some("speed".into()));

--- a/futures/tests/stream_peekable.rs
+++ b/futures/tests/stream_peekable.rs
@@ -1,6 +1,6 @@
-use std::pin::pin;
 use futures::executor::block_on;
 use futures::stream::{self, Peekable, StreamExt};
+use std::pin::pin;
 
 #[test]
 fn peekable() {


### PR DESCRIPTION
This follows up https://github.com/rust-lang/futures-rs/pull/2929#issuecomment-2746232982 step 2.

cc @taiki-e 

We don't use a unified MSRV. So I'm understanding which versions should be updated.