### PR TITLE
chore: replace all test usage of pin_mut

### DIFF
--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -1,11 +1,11 @@
 use futures::channel::{mpsc, oneshot};
 use futures::executor::{block_on, block_on_stream};
 use futures::future::{poll_fn, FutureExt};
-use futures::pin_mut;
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use futures::task::{Context, Poll};
 use futures_test::task::{new_count_waker, noop_context};
+use std::pin::pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -30,7 +30,8 @@ fn send_recv_no_buffer() {
     // Run on a task context
     block_on(poll_fn(move |cx| {
         let (tx, rx) = mpsc::channel::<i32>(0);
-        pin_mut!(tx, rx);
+        let mut tx = pin!(tx);
+        let mut rx = pin!(rx);
 
         assert!(tx.as_mut().poll_flush(cx).is_ready());
         assert!(tx.as_mut().poll_ready(cx).is_ready());

--- a/futures/tests/async_await_macros.rs
+++ b/futures/tests/async_await_macros.rs
@@ -4,16 +4,15 @@ use futures::future::{self, poll_fn, FutureExt};
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
 use futures::task::{Context, Poll};
-use futures::{
-    join, pending, pin_mut, poll, select, select_biased, stream, stream_select, try_join,
-};
+use futures::{join, pending, poll, select, select_biased, stream, stream_select, try_join};
 use std::mem;
+use std::pin::pin;
 
 #[test]
 fn poll_and_pending() {
     let pending_once = async { pending!() };
     block_on(async {
-        pin_mut!(pending_once);
+        let mut pending_once = pin!(pending_once);
         assert_eq!(Poll::Pending, poll!(&mut pending_once));
         assert_eq!(Poll::Ready(()), poll!(&mut pending_once));
     });
@@ -30,7 +29,7 @@ fn join() {
     };
 
     block_on(async {
-        pin_mut!(fut);
+        let mut fut = pin!(fut);
         assert_eq!(Poll::Pending, poll!(&mut fut));
         tx1.send(1).unwrap();
         assert_eq!(Poll::Pending, poll!(&mut fut));

--- a/futures/tests/future_join_all.rs
+++ b/futures/tests/future_join_all.rs
@@ -1,15 +1,14 @@
 use futures::executor::block_on;
 use futures::future::{join_all, ready, Future, JoinAll};
-use futures::pin_mut;
 use std::fmt::Debug;
+use std::pin::pin;
 
 #[track_caller]
 fn assert_done<T>(actual_fut: impl Future<Output = T>, expected: T)
 where
     T: PartialEq + Debug,
 {
-    pin_mut!(actual_fut);
-    let output = block_on(actual_fut);
+    let output = block_on(pin!(actual_fut));
     assert_eq!(output, expected);
 }
 

--- a/futures/tests/future_try_join_all.rs
+++ b/futures/tests/future_try_join_all.rs
@@ -1,15 +1,14 @@
 use futures::executor::block_on;
 use futures::future::{err, ok, try_join_all, Future, TryJoinAll};
-use futures::pin_mut;
 use std::fmt::Debug;
+use std::pin::pin;
 
 #[track_caller]
 fn assert_done<T>(actual_fut: impl Future<Output = T>, expected: T)
 where
     T: PartialEq + Debug,
 {
-    pin_mut!(actual_fut);
-    let output = block_on(actual_fut);
+    let output = block_on(pin!(actual_fut));
     assert_eq!(output, expected);
 }
 

--- a/futures/tests/io_buf_reader.rs
+++ b/futures/tests/io_buf_reader.rs
@@ -4,13 +4,12 @@ use futures::io::{
     AllowStdIo, AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt,
     BufReader, SeekFrom,
 };
-use futures::pin_mut;
 use futures::task::{Context, Poll};
 use futures_test::task::noop_context;
 use pin_project::pin_project;
 use std::cmp;
 use std::io;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 
 // helper for maybe_pending_* tests
 fn run<F: Future + Unpin>(mut f: F) -> F::Output {
@@ -157,7 +156,7 @@ fn test_buffered_reader_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.seek(SeekFrom::Start(3)).await.unwrap(), 3);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -175,7 +174,7 @@ fn test_buffered_reader_seek_relative() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(2, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader = pin!(reader);
 
         assert!(reader.as_mut().seek_relative(3).await.is_ok());
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1][..]);
@@ -195,7 +194,7 @@ fn test_buffered_reader_invalidated_after_read() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -216,7 +215,7 @@ fn test_buffered_reader_invalidated_after_seek() {
     block_on(async {
         let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
         let reader = BufReader::with_capacity(3, Cursor::new(inner));
-        pin_mut!(reader);
+        let mut reader = pin!(reader);
 
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[5, 6, 7][..]);
         reader.as_mut().consume(3);
@@ -265,7 +264,7 @@ fn test_buffered_reader_seek_underflow() {
 
     block_on(async {
         let reader = BufReader::with_capacity(5, AllowStdIo::new(PositionReader { pos: 0 }));
-        pin_mut!(reader);
+        let mut reader = pin!(reader);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap(), &[0, 1, 2, 3, 4][..]);
         assert_eq!(reader.seek(SeekFrom::End(-5)).await.unwrap(), u64::MAX - 5);
         assert_eq!(reader.as_mut().fill_buf().await.unwrap().len(), 5);
@@ -419,7 +418,7 @@ fn maybe_pending_seek() {
 
     let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
     let reader = BufReader::with_capacity(2, MaybePendingSeek::new(inner));
-    pin_mut!(reader);
+    let mut reader = pin!(reader);
 
     assert_eq!(run(reader.seek(SeekFrom::Current(3))).ok(), Some(3));
     assert_eq!(run(reader.as_mut().fill_buf()).ok(), Some(&[0, 1][..]));

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -11,7 +11,7 @@ use std::collections::VecDeque;
 use std::convert::Infallible;
 use std::fmt;
 use std::mem;
-use std::pin::Pin;
+use std::pin::{pin, Pin};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -509,7 +509,7 @@ fn sink_unfold() {
                 Ok::<_, String>(())
             }
         });
-        futures::pin_mut!(unfold);
+        let mut unfold = pin!(unfold);
         assert_eq!(unfold.as_mut().start_send(1), Ok(()));
         assert_eq!(unfold.as_mut().poll_flush(cx), Poll::Ready(Ok(())));
         assert_eq!(rx.try_next().unwrap(), Some(1));

--- a/futures/tests/stream_peekable.rs
+++ b/futures/tests/stream_peekable.rs
@@ -1,17 +1,17 @@
 use futures::executor::block_on;
-use futures::pin_mut;
 use futures::stream::{self, Peekable, StreamExt};
+use std::pin::pin;
 
 #[test]
 fn peekable() {
     block_on(async {
         let peekable: Peekable<_> = stream::iter(vec![1u8, 2, 3]).peekable();
-        pin_mut!(peekable);
+        let mut peekable = pin!(peekable);
         assert_eq!(peekable.as_mut().peek().await, Some(&1u8));
         assert_eq!(peekable.collect::<Vec<u8>>().await, vec![1, 2, 3]);
 
         let s = stream::once(async { 1 }).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         assert_eq!(s.as_mut().peek().await, Some(&1u8));
         assert_eq!(s.collect::<Vec<u8>>().await, vec![1]);
     });
@@ -21,7 +21,7 @@ fn peekable() {
 fn peekable_mut() {
     block_on(async {
         let s = stream::iter(vec![1u8, 2, 3]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         if let Some(p) = s.as_mut().peek_mut().await {
             if *p == 1 {
                 *p = 5;
@@ -36,7 +36,7 @@ fn peekable_next_if_eq() {
     block_on(async {
         // first, try on references
         let s = stream::iter(vec!["Heart", "of", "Gold"]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         // try before `peek()`
         assert_eq!(s.as_mut().next_if_eq(&"trillian").await, None);
         assert_eq!(s.as_mut().next_if_eq(&"Heart").await, Some("Heart"));
@@ -49,7 +49,7 @@ fn peekable_next_if_eq() {
 
         // make sure comparison works for owned values
         let s = stream::iter(vec![String::from("Ludicrous"), "speed".into()]).peekable();
-        pin_mut!(s);
+        let mut s = pin!(s);
         // make sure basic functionality works
         assert_eq!(s.as_mut().next_if_eq("Ludicrous").await, Some("Ludicrous".into()));
         assert_eq!(s.as_mut().next_if_eq("speed").await, Some("speed".into()));


### PR DESCRIPTION
cc @taiki-e 

This splits from https://github.com/rust-lang/futures-rs/pull/2941