### PR TITLE
channel: Add try_recv and deprecate try_next

### DIFF
--- a/futures-channel/tests/mpsc-size_hint.rs
+++ b/futures-channel/tests/mpsc-size_hint.rs
@@ -7,16 +7,16 @@ fn unbounded_size_hint() {
     assert_eq!((0, None), rx.size_hint());
     tx.unbounded_send(1).unwrap();
     assert_eq!((1, None), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((0, None), rx.size_hint());
     tx.unbounded_send(2).unwrap();
     tx.unbounded_send(3).unwrap();
     assert_eq!((2, None), rx.size_hint());
     drop(tx);
     assert_eq!((2, Some(2)), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((1, Some(1)), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((0, Some(0)), rx.size_hint());
 }
 
@@ -26,15 +26,15 @@ fn channel_size_hint() {
     assert_eq!((0, None), rx.size_hint());
     tx.try_send(1).unwrap();
     assert_eq!((1, None), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((0, None), rx.size_hint());
     tx.try_send(2).unwrap();
     tx.try_send(3).unwrap();
     assert_eq!((2, None), rx.size_hint());
     drop(tx);
     assert_eq!((2, Some(2)), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((1, Some(1)), rx.size_hint());
-    rx.try_next().unwrap().unwrap();
+    rx.try_recv().unwrap();
     assert_eq!((0, Some(0)), rx.size_hint());
 }

--- a/futures-channel/tests/mpsc.rs
+++ b/futures-channel/tests/mpsc.rs
@@ -4,6 +4,7 @@ use futures::future::{poll_fn, FutureExt};
 use futures::sink::{Sink, SinkExt};
 use futures::stream::{Stream, StreamExt};
 use futures::task::{Context, Poll};
+use futures_channel::mpsc::TryRecvError;
 use futures_test::task::{new_count_waker, noop_context};
 use std::pin::pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -503,12 +504,12 @@ fn try_send_recv() {
     tx.try_send("hello").unwrap();
     tx.try_send("hello").unwrap();
     tx.try_send("hello").unwrap_err(); // should be full
-    rx.try_next().unwrap();
-    rx.try_next().unwrap();
-    rx.try_next().unwrap_err(); // should be empty
+    rx.try_recv().unwrap();
+    rx.try_recv().unwrap();
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
     tx.try_send("hello").unwrap();
-    rx.try_next().unwrap();
-    rx.try_next().unwrap_err(); // should be empty
+    rx.try_recv().unwrap();
+    assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
 }
 
 #[test]

--- a/futures/tests/sink.rs
+++ b/futures/tests/sink.rs
@@ -512,19 +512,19 @@ fn sink_unfold() {
         let mut unfold = pin!(unfold);
         assert_eq!(unfold.as_mut().start_send(1), Ok(()));
         assert_eq!(unfold.as_mut().poll_flush(cx), Poll::Ready(Ok(())));
-        assert_eq!(rx.try_next().unwrap(), Some(1));
+        assert_eq!(rx.try_recv().unwrap(), 1);
 
         assert_eq!(unfold.as_mut().poll_ready(cx), Poll::Ready(Ok(())));
         assert_eq!(unfold.as_mut().start_send(2), Ok(()));
         assert_eq!(unfold.as_mut().poll_ready(cx), Poll::Ready(Ok(())));
         assert_eq!(unfold.as_mut().start_send(3), Ok(()));
-        assert_eq!(rx.try_next().unwrap(), Some(2));
-        assert!(rx.try_next().is_err());
+        assert_eq!(rx.try_recv().unwrap(), 2);
+        assert!(rx.try_recv().is_err());
         assert_eq!(unfold.as_mut().poll_ready(cx), Poll::Ready(Ok(())));
         assert_eq!(unfold.as_mut().start_send(4), Ok(()));
         assert_eq!(unfold.as_mut().poll_flush(cx), Poll::Pending); // Channel full
-        assert_eq!(rx.try_next().unwrap(), Some(3));
-        assert_eq!(rx.try_next().unwrap(), Some(4));
+        assert_eq!(rx.try_recv().unwrap(), 3);
+        assert_eq!(rx.try_recv().unwrap(), 4);
 
         Poll::Ready(())
     }))


### PR DESCRIPTION
Adds `try_recv` and deprecates `try_next` as discussed in #2936.
  
  It does so by changing the previously private `TryRecvError` internals from a struct to an an enum.
  
  Note that this is *technically* not semver compatible with 0.3 as the following is legal (albeit nonsensical) Rust:
  
  ```Rust
  let TryRecvError {..} = my_err;
  ```
  This would no longer compile after this change.
  I'm happy to introduce some slightly hacky `TryReceiveError` or similar instead if that is preferred.

---

 I've also moved most most tests over to `try_recv` but kept around [these two](https://github.com/rust-lang/futures-rs/compare/master...cmrschwarz:try_recv?expand=1#diff-dd03b534a872e5823ae44f0ff4de693c8eab5e87b94cf82ebcfde65121b643b0L280) using `try_next` just to make sure it isn't somehow broken.

--- 

Adding `recv` aswell proved harder than expected because I can't add a dependency on 
  `futures-util`, which would be cyclic. I see two options:
  1. Take out the `futures-channel` specific code from `futures-util` and move it into `futures-channel`.   
  2. Essentially reimplement [`Next`](https://docs.rs/futures-util/latest/src/futures_util/stream/stream/next.rs.html#10-12) as `Recv`. Might be reasonable as `Next` is pretty small.

Which would you prefer? I'm happy do do either as a follow up if that still seems good, or of course do a third option if there's a better Idea.

---

Closes #2936
Closes #2197