### PR TITLE
refactor: remove leftover from `read_initializer` feature

### DIFF
--- a/futures-util/src/io/mod.rs
+++ b/futures-util/src/io/mod.rs
@@ -21,7 +21,7 @@
 use crate::compat::Compat;
 use crate::future::assert_future;
 use crate::stream::assert_stream;
-use std::{pin::Pin, ptr, string::String, vec::Vec};
+use std::{pin::Pin, string::String, vec::Vec};
 
 // Re-export some types from `std::io` so that users don't have to deal
 // with conflicts when `use`ing `futures::io` and `std::io`.
@@ -33,14 +33,6 @@ pub use futures_io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 // used by `BufReader` and `BufWriter`
 // https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/io.rs#L1
 const DEFAULT_BUF_SIZE: usize = 8 * 1024;
-
-/// Initializes a buffer if necessary.
-///
-/// A buffer is currently always initialized.
-#[inline]
-unsafe fn initialize<R: AsyncRead>(_reader: &R, buf: &mut [u8]) {
-    unsafe { ptr::write_bytes(buf.as_mut_ptr(), 0, buf.len()) }
-}
 
 mod allow_std;
 pub use self::allow_std::AllowStdIo;


### PR DESCRIPTION
While auditing the use of unsafe, I've discovered a strange way of growing and initialising the extended part of a `Vec`, which resulted in a `Vec::set_len` call that technically violates the safety invariants - the new length isn't fully init yet, and also uses unsafe operations and a `read_initializer` style API for something so simple.

This replaces it with a much simpler implementation.