### PR TITLE
select: add missing space in panic message

### DIFF
--- a/futures-macro/src/select.rs
+++ b/futures-macro/src/select.rs
@@ -221,7 +221,7 @@ fn select_inner(input: TokenStream, random: bool) -> TokenStream {
         }
     } else {
         quote! {
-            panic!("all futures in select! were completed,\
+            panic!("all futures in select! were completed, \
                     but no `complete =>` handler was provided")
         }
     };


### PR DESCRIPTION
Trivial one-character change in a panic message.