### PR TITLE
futures-util: make `Mutex::new()` const

### DIFF
--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -37,7 +37,7 @@ futures-channel = { path = "../futures-channel", version = "=0.4.0-alpha.0", def
 futures-io = { path = "../futures-io", version = "0.3.31", default-features = false, features = ["std"], optional = true }
 futures-sink = { path = "../futures-sink", version = "=0.4.0-alpha.0", default-features = false, optional = true }
 futures-macro = { path = "../futures-macro", version = "=0.4.0-alpha.0", default-features = false, optional = true }
-slab = { version = "0.4.2", default-features = false, optional = true }
+slab = { version = "0.4.7", default-features = false, optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }

--- a/futures-util/src/lock/mutex.rs
+++ b/futures-util/src/lock/mutex.rs
@@ -73,7 +73,7 @@ const HAS_WAITERS: usize = 1 << 1;
 
 impl<T> Mutex<T> {
     /// Creates a new futures-aware mutex.
-    pub fn new(t: T) -> Self {
+    pub const fn new(t: T) -> Self {
         Self {
             state: AtomicUsize::new(0),
             waiters: StdMutex::new(Slab::new()),


### PR DESCRIPTION
This builds with the MSRV (1.68) and is convenient for creating `static` mutexes.

This does bind the implementation to never allocate in `new` in the future, but that seems like a desirable property anyway.

Note that this also requires updating slab to 0.4.7, which is the first version that supports const `Slab::new()`.