### PR TITLE
Fix documentation of `BiLock::lock`

### DIFF
--- a/futures-util/src/lock/bilock.rs
+++ b/futures-util/src/lock/bilock.rs
@@ -139,7 +139,6 @@ impl<T> BiLock<T> {
     ///
     /// This function consumes the `BiLock<T>` and returns a sentinel future,
     /// `BiLockAcquire<T>`. The returned future will resolve to
-    /// `BiLockAcquired<T>` which represents a locked lock similarly to
     /// `BiLockGuard<T>`.
     ///
     /// Note that the returned future will never resolve to an error.


### PR DESCRIPTION
This simply removes a reference to the `BiLockAcquired` type which was removed in 2018. `BiLockAcquire` actually resolves to `BiLockGuard`.