### PR TITLE
try_unfold: Fix function docs wording

### DIFF
--- a/futures-util/src/stream/try_stream/try_unfold.rs
+++ b/futures-util/src/stream/try_stream/try_unfold.rs
@@ -17,7 +17,7 @@ use pin_project_lite::pin_project;
 /// wait for the returned `TryFuture` to complete with `(a, b)`. It will then
 /// yield the value `a`, and use `b` as the next internal state.
 ///
-/// If the closure returns `None` instead of `Some(TryFuture)`, then the
+/// If the `TryFuture` returns `None` instead of `Some((Item, T))`, then the
 /// `try_unfold()` will stop producing items and return `Poll::Ready(None)` in
 /// future calls to `poll()`.
 ///


### PR DESCRIPTION
The wording of the documentation of the `try_unfold()` function was a bit misleading.

The function signature clearly states that the closure that must be provided to the function must return a `TryFuture` that yields an `Option<(Item, T)>`.
The wording of the related documentation indicated that the closure may return `None` or `Some(TryFuture)`, which is wrong.

This patch fixes that wording.