### PR TITLE
Fix unsound `Send` impl for `IterPinRef` and `Iter`

### DIFF
--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -160,11 +160,14 @@ impl<'a, Fut: Unpin> Iterator for Iter<'a, Fut> {
 
 impl<Fut: Unpin> ExactSizeIterator for Iter<'_, Fut> {}
 
-// SAFETY: we do nothing thread-local and there is no interior mutability,
-// so the usual structural `Send`/`Sync` apply.
-unsafe impl<Fut: Send> Send for IterPinRef<'_, Fut> {}
+// SAFETY: `IterPinRef` yields `Pin<&Fut>` shared references. Sending these
+// to another thread requires `Fut: Sync` since both the sender and receiver
+// can concurrently access the same `Fut` through their shared references.
+unsafe impl<Fut: Sync> Send for IterPinRef<'_, Fut> {}
 unsafe impl<Fut: Sync> Sync for IterPinRef<'_, Fut> {}
 
+// SAFETY: we do nothing thread-local and there is no interior mutability,
+// so the usual structural `Send`/`Sync` apply.
 unsafe impl<Fut: Send> Send for IterPinMut<'_, Fut> {}
 unsafe impl<Fut: Sync> Sync for IterPinMut<'_, Fut> {}
 

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -10,6 +10,7 @@ use futures::{
     task::{Context, Poll},
 };
 use static_assertions::{assert_impl_all as assert_impl, assert_not_impl_all as assert_not_impl};
+use std::cell::Cell;
 use std::marker::PhantomPinned;
 use std::{marker::PhantomData, pin::Pin};
 
@@ -1850,6 +1851,7 @@ mod stream {
 
     assert_impl!(futures_unordered::Iter<'_, ()>: Send);
     assert_not_impl!(futures_unordered::Iter<'_, *const ()>: Send);
+    assert_not_impl!(futures_unordered::Iter<'_, Cell<()>>: Send);
     assert_impl!(futures_unordered::Iter<'_, ()>: Sync);
     assert_not_impl!(futures_unordered::Iter<'_, *const ()>: Sync);
     assert_impl!(futures_unordered::Iter<'_, ()>: Unpin);
@@ -1872,6 +1874,7 @@ mod stream {
 
     assert_impl!(futures_unordered::IterPinRef<'_, ()>: Send);
     assert_not_impl!(futures_unordered::IterPinRef<'_, *const ()>: Send);
+    assert_not_impl!(futures_unordered::IterPinRef<'_, Cell<()>>: Send);
     assert_impl!(futures_unordered::IterPinRef<'_, ()>: Sync);
     assert_not_impl!(futures_unordered::IterPinRef<'_, *const ()>: Sync);
     assert_impl!(futures_unordered::IterPinRef<'_, PhantomPinned>: Unpin);


### PR DESCRIPTION
Fixes #3002