### PR TITLE
Fix memory leak in `FuturesUnordered::IntoIter`

### DIFF
--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -1,5 +1,6 @@
 use super::task::Task;
 use super::FuturesUnordered;
+use alloc::sync::Arc;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use core::ptr;
@@ -50,19 +51,27 @@ impl<Fut: Unpin> Iterator for IntoIter<Fut> {
         }
 
         unsafe {
+            let head = *task;
+
             // Moving out of the future is safe because it is `Unpin`
-            let future = (*(**task).future.get()).take().unwrap();
+            let future = (*(*head).future.get()).take().unwrap();
 
             // Mutable access to a previously shared `FuturesUnordered` implies
             // that the other threads already released the object before the
             // current thread acquired it, so relaxed ordering can be used and
             // valid `next_all` checks can be skipped.
-            let next = (**task).next_all.load(Relaxed);
+            let next = (*head).next_all.load(Relaxed);
             *task = next;
-            if !task.is_null() {
-                *(**task).prev_all.get() = ptr::null_mut();
+            if !next.is_null() {
+                *(*next).prev_all.get() = ptr::null_mut();
             }
             self.len -= 1;
+
+            let arc = Arc::from_raw(head);
+            arc.next_all.store(self.inner.pending_next_all(), Relaxed);
+            *arc.prev_all.get() = ptr::null_mut();
+            self.inner.release_task(arc);
+
             Some(future)
         }
     }

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -8,7 +8,7 @@ use futures_test::task::noop_context;
 use futures_test::{assert_stream_done, assert_stream_next, assert_stream_pending};
 use std::iter::FromIterator;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 #[test]
 fn is_terminated() {
@@ -428,4 +428,83 @@ fn panic_on_drop_fut() {
     }
 
     FuturesUnordered::default().push(BadFuture);
+}
+
+#[test]
+fn into_iter_after_poll_doesnt_leak() {
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+
+    struct DetectDrop;
+    impl Drop for DetectDrop {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct PendingFuture {
+        _guard: DetectDrop,
+        ready: bool,
+    }
+
+    impl Unpin for PendingFuture {}
+
+    impl Future for PendingFuture {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.ready {
+                Poll::Ready(())
+            } else {
+                self.ready = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    DROPPED.store(false, Ordering::SeqCst);
+
+    let mut fu = FuturesUnordered::new();
+    fu.push(PendingFuture { _guard: DetectDrop, ready: false });
+
+    let mut cx = noop_context();
+    let _ = fu.poll_next_unpin(&mut cx);
+    assert!(!DROPPED.load(Ordering::SeqCst));
+
+    let collected: Vec<_> = fu.into_iter().collect();
+    assert_eq!(collected.len(), 1);
+    drop(collected);
+
+    assert!(DROPPED.load(Ordering::SeqCst));
+}
+
+#[test]
+fn into_iter_partial_doesnt_leak() {
+    static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct Counted;
+    impl Drop for Counted {
+        fn drop(&mut self) {
+            DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct CountedFuture(Counted);
+    impl Unpin for CountedFuture {}
+    impl Future for CountedFuture {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Pending
+        }
+    }
+
+    DROP_COUNT.store(0, Ordering::SeqCst);
+
+    let fu: FuturesUnordered<_> = (0..4).map(|_| CountedFuture(Counted)).collect();
+
+    let mut into_iter = fu.into_iter();
+    let _ = into_iter.next();
+    let _ = into_iter.next();
+    drop(into_iter);
+
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 4);
 }


### PR DESCRIPTION
Fixes #3004