### PR TITLE
Re-export alloc::task::Wake

### DIFF
--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -48,3 +48,7 @@ pub use crate::noop_waker::noop_waker_ref;
 
 #[doc(no_inline)]
 pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(no_inline)]
+pub use alloc::task::Wake;

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -13,6 +13,10 @@
 #[doc(no_inline)]
 pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(no_inline)]
+pub use alloc::task::Wake;
+
 pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj};
 
 pub use futures_task::noop_waker;


### PR DESCRIPTION
I added alloc::task::Wake to fix it pointing in the correct direction.