### PR TITLE
Add MaybeImmediate future

### DIFF
--- a/futures-util/src/future/future/mod.rs
+++ b/futures-util/src/future/future/mod.rs
@@ -20,7 +20,7 @@ use futures_core::{
 
 use crate::{
     fns::{InspectFn, IntoFn, OkFn, inspect_fn, into_fn, ok_fn},
-    future::{Either, assert_future},
+    future::{Either, MaybeImmediate, assert_future},
     stream::assert_stream,
 };
 
@@ -602,5 +602,24 @@ pub trait FutureExt: Future {
             Poll::Ready(x) => Some(x),
             _ => None,
         }
+    }
+
+    /// Wraps a future into a `MaybeImmediate`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use futures::future::FutureExt;
+    ///
+    /// let future = async { "hello" }.maybe_immediate();
+    /// assert_eq!("hello", future.await);
+    /// # });
+    /// ```
+    fn maybe_immediate(self) -> MaybeImmediate<Self>
+    where
+        Self: Sized,
+    {
+        assert_future::<Self::Output, _>(MaybeImmediate::new(self))
     }
 }

--- a/futures-util/src/future/maybe_immediate.rs
+++ b/futures-util/src/future/maybe_immediate.rs
@@ -1,0 +1,94 @@
+use core::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_core::{FusedFuture, future::Future};
+use pin_project_lite::pin_project;
+
+use super::{MaybeDone, assert_future};
+
+pin_project! {
+    /// A future that may wrap another future or immediately return a value.
+    ///
+    /// This is created by the [`maybe_immediate()`] function and via
+    /// [`FutureExt::maybe_immediate`].
+    pub struct MaybeImmediate<Fut: Future> {
+        #[pin]
+        inner: MaybeDone<Fut>,
+    }
+}
+
+impl<Fut: Future> MaybeImmediate<Fut> {
+    pub(super) fn new(future: Fut) -> Self {
+        let inner = MaybeDone::Future(future);
+        Self { inner }
+    }
+
+    fn new_immediate(value: Fut::Output) -> Self {
+        let inner = MaybeDone::Done(value);
+        Self { inner }
+    }
+}
+
+/// Wraps a value into a `MaybeImmediate`
+///
+/// # Examples
+///
+/// ```
+/// # futures::executor::block_on(async {
+/// use futures::future;
+/// use futures::future::FutureExt;
+/// use futures::Future;
+///
+/// fn immediately_or_later(now: bool) -> impl Future<Output = &'static str> {
+///     if now {
+///         future::maybe_immediate("now")
+///     } else {
+///         async {
+///             "later"
+///         }.maybe_immediate()
+///     }
+/// }
+///
+/// let immediate_future = immediately_or_later(true);
+/// assert_eq!("now", immediate_future.await);
+/// let later_future = immediately_or_later(false);
+/// assert_eq!("later", later_future.await);
+/// # });
+/// ```
+pub fn maybe_immediate<Fut: Future>(value: Fut::Output) -> MaybeImmediate<Fut> {
+    assert_future::<Fut::Output, _>(MaybeImmediate::new_immediate(value))
+}
+
+// `#[derive(Debug)]` fails to compile with
+// "error[E0277]: `<Fut as Future>::Output` doesn't implement `Debug`"
+impl<Fut: Future> Debug for MaybeImmediate<Fut>
+where
+    MaybeDone<Fut>: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MaybeImmediate").field("inner", &self.inner).finish()
+    }
+}
+
+impl<Fut: Future> FusedFuture for MaybeImmediate<Fut> {
+    fn is_terminated(&self) -> bool {
+        self.inner.is_terminated()
+    }
+}
+
+impl<Fut: Future> Future for MaybeImmediate<Fut> {
+    type Output = Fut::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.project().inner;
+        match inner.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                Poll::Ready(inner.take_output().expect("MaybeImmediate polled after termination"))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -54,6 +54,9 @@ pub use self::pending::{Pending, pending};
 mod maybe_done;
 pub use self::maybe_done::{MaybeDone, maybe_done};
 
+mod maybe_immediate;
+pub use self::maybe_immediate::{MaybeImmediate, maybe_immediate};
+
 mod try_maybe_done;
 pub use self::try_maybe_done::{TryMaybeDone, try_maybe_done};
 


### PR DESCRIPTION
`MaybeImmediate<Fut>` wraps a future via `FutureExt::maybe_immediate` but it can also be constructed directly from a `Fut::Output` value which is then returned on the first poll without ever creating a `Fut`. It behaves almost like `MaybeDone<Fut>` but the first poll after completion will take the output and return it.

This is particularly useful in situations where a function validates inputs and calls another function that returns a future when the input is valid. In case the input is not valid `MaybeImmediate` can be used to bail out with an error early without having to return a trait object via `Box::pin`.

For example we'd be able to write this (pseudo-code):

```rust
fn validate_then_do_something(inputs: Inputs) -> impl Future<Result<(), ()>> {
  if is_valid(&inputs) {
    do_something(inputs).maybe_immediate()
  } else {
    future::maybe_immediate(Err(()))
  }
}

fn do_something(inputs: Inputs) -> impl Future<Result<(), ()>> {
  // ...
}
```

instead of 

```rust
fn validate_then_do_something(inputs: Inputs) -> Pin<Box<dyn Future<Output = Result<(), ()>>> {
  if is_valid(&inputs) {
    Box::pin(do_something(inputs))
  } else {
    Box::pin(std::future::ready(Err(())))
  }
}

fn do_something(inputs: Inputs) -> impl Future<Result<(), ()>> {
  // ...
}
```