### PR TITLE
docs: remove repeated word in AllowStdIo summary

### DIFF
--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -6,8 +6,8 @@ use std::vec::Vec;
 use std::{fmt, io};
 
 /// A simple wrapper type which allows types which implement only
-/// implement `std::io::Read` or `std::io::Write`
-/// to be used in contexts which expect an `AsyncRead` or `AsyncWrite`.
+/// `std::io::Read` or `std::io::Write` to be used
+/// in contexts which expect an `AsyncRead` or `AsyncWrite`.
 ///
 /// If these types issue an error with the kind `io::ErrorKind::WouldBlock`,
 /// it is expected that they will notify the current task on readiness.


### PR DESCRIPTION
The `implement` is repeated twice so removed one.