### PR TITLE
Allow deprecated Atomic::fetch_update, fixes CI (nightly failures)

### DIFF
--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -63,6 +63,7 @@ impl SharedPollState {
     /// Attempts to start polling, returning stored state in case of success.
     /// Returns `None` if either waker is waking at the moment.
     fn start_polling(&self) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&Self) -> u8>)> {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
@@ -86,6 +87,7 @@ impl SharedPollState {
         &self,
         to_poll: u8,
     ) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&Self) -> u8>)> {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
@@ -121,6 +123,7 @@ impl SharedPollState {
     ///   * `POLLING` phase can't start if some of the wakers are active
     ///     So no wrapped waker can touch the inner waker's cell, it's safe to poll again.
     fn stop_polling(&self, to_poll: u8, will_be_woken: bool) -> u8 {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         self.state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |mut value| {
                 let mut next_value = to_poll;
@@ -138,6 +141,7 @@ impl SharedPollState {
 
     /// Toggles state to non-waking, allowing to start polling.
     fn stop_waking(&self) -> u8 {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {

--- a/futures/tests/io_read_to_end.rs
+++ b/futures/tests/io_read_to_end.rs
@@ -48,7 +48,7 @@ fn issue2310() {
     impl Drop for VecWrapper {
         fn drop(&mut self) {
             // Observe uninitialized bytes
-            println!("{:?}", &self.inner);
+            println!("{:?}", self.inner);
             // Overwrite heap contents
             for b in &mut self.inner {
                 *b = 0x90;

--- a/futures/tests/io_read_until.rs
+++ b/futures/tests/io_read_until.rs
@@ -26,10 +26,10 @@ fn read_until() {
     let mut v = Vec::new();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 3);
     assert_eq!(v, b"123");
-    v.truncate(0);
+    v.clear();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 1);
     assert_eq!(v, b"3");
-    v.truncate(0);
+    v.clear();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 0);
     assert_eq!(v, []);
 }


### PR DESCRIPTION
`fetch_update` was renamed to `try_update` in rust 1.95.0, and the old name (probably) gets deprecated in 1.99.0; MSRV is 1.71.