### PR TITLE
 Release 0.3.33

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 14
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14 # Note: Unless dependencies are pinned/locked, the effect is limited.
+    commit-message:
+      prefix: ''
+    labels: []
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 14
+    commit-message:
+      prefix: ''
+    labels: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,7 @@ jobs:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         uses: taiki-e/github-actions/install-rust@nightly
-      - run: cargo bench --workspace
-      - run: cargo bench --manifest-path futures-util/Cargo.toml --features=bilock,unstable
+      - run: cargo bench --workspace --all-features
 
   features:
     name: cargo hack check --feature-powerset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,8 +281,6 @@ jobs:
         uses: taiki-e/github-actions/install-rust@nightly
         with:
           component: rust-src
-      # https://github.com/google/sanitizers/issues/1716 / https://github.com/actions/runner-images/issues/9491
-      - run: sudo sysctl vm.mmap_rnd_bits=28
       - run: cargo -Z build-std test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests -- --skip panic_on_drop_fut
         env:
           # TODO: Once `cfg(sanitize = "..")` is stable, replace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,16 +277,25 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
+      - run: |
+          printf 'TARGET=x86_64-unknown-linux-gnuasan\n' >>"${GITHUB_ENV}"
+          printf 'ASAN_OPTIONS=detect_stack_use_after_return=1\n' >>"${GITHUB_ENV}"
+        if: matrix.sanitizer == 'address'
+      - run: |
+          printf 'TARGET=x86_64-unknown-linux-gnumsan\n' >>"${GITHUB_ENV}"
+        if: matrix.sanitizer == 'memory'
+      - run: |
+          printf 'TARGET=x86_64-unknown-linux-gnutsan\n' >>"${GITHUB_ENV}"
+        if: matrix.sanitizer == 'thread'
+      - uses: taiki-e/github-actions/install-rust@nightly
         with:
-          component: rust-src
-      - run: cargo -Z build-std test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests -- --skip panic_on_drop_fut
+          target: ${{ env.TARGET }}
+      - run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests -- --skip panic_on_drop_fut
         env:
           # TODO: Once `cfg(sanitize = "..")` is stable, replace
           # `cfg(futures_sanitizer)` with `cfg(sanitize = "..")` and remove
           # `--cfg futures_sanitizer`.
-          RUSTFLAGS: -D warnings -Z sanitizer=${{ matrix.sanitizer }} --cfg futures_sanitizer
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg futures_sanitizer
 
   # This branch no longer actively developed. Most commits to this
   # branch are backporting and should not be blocked by clippy.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,15 +302,22 @@ jobs:
   #         component: clippy
   #     - run: cargo clippy --workspace --all-features --all-targets
 
-  fmt:
-    name: cargo fmt
+  tidy:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: taiki-e/checkout-action@v1
       - name: Install Rust
         uses: taiki-e/github-actions/install-rust@stable
+        with:
+          component: rustfmt
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: zizmor
       - run: cargo fmt --all -- --check
+      - run: zizmor .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docs:
     name: cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,7 @@ jobs:
           component: rust-src
       # https://github.com/google/sanitizers/issues/1716 / https://github.com/actions/runner-images/issues/9491
       - run: sudo sysctl vm.mmap_rnd_bits=28
-      # Exclude futures-macro to work around upstream bug since nightly-2024-10-06.
-      - run: cargo -Z build-std test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests --exclude futures-macro -- --skip panic_on_drop_fut
+      - run: cargo -Z build-std test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests -- --skip panic_on_drop_fut
         env:
           # TODO: Once `cfg(sanitize = "..")` is stable, replace
           # `cfg(futures_sanitizer)` with `cfg(sanitize = "..")` and remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   pull_request:
@@ -29,6 +28,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This branch no longer actively developed. Most commits to this
+  # branch are backporting and should not be blocked by clippy.
+  # clippy:
+  #   uses: taiki-e/github-actions/.github/workflows/rust-clippy.yml@e6a1170cbd07eb898017958967912976fce18f2d # 2026.7.3
+  #   with:
+  #     implicit_provenance_casts: false # TODO
+  docs:
+    uses: taiki-e/github-actions/.github/workflows/rust-docs.yml@e6a1170cbd07eb898017958967912976fce18f2d # 2026.7.3
+
   test:
     name: cargo test
     strategy:
@@ -50,10 +58,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
-      - uses: taiki-e/setup-cross-toolchain-action@v1
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: rust@nightly
+          fallback: none
+      - uses: taiki-e/setup-cross-toolchain-action@3d9770ce98eb7dbcf378563182a5e8031165f75b # v1.41.0
         with:
           target: ${{ matrix.target }}
         if: matrix.target != ''
@@ -71,15 +82,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@main
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and cargo-hack
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          toolchain: ${{ matrix.rust }}
-      # cargo does not support for --features/--no-default-features with workspace, so use cargo-hack instead.
-      # Refs: cargo#3620, cargo#4106, cargo#4463, cargo#4753, cargo#5015, cargo#5364, cargo#6195
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+          # cargo does not support for --features/--no-default-features with workspace, so use cargo-hack instead.
+          # Refs: cargo#3620, cargo#4106, cargo#4463, cargo#4753, cargo#5015, cargo#5364, cargo#6195
+          tool: rust@${{ matrix.rust }},cargo-hack
+          fallback: none
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
       # Check no-default-features
@@ -108,13 +118,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@main
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and cargo-hack
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          toolchain: ${{ matrix.rust }}
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+          tool: rust@${{ matrix.rust }},cargo-hack
+          fallback: none
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
       # Check default features
@@ -143,13 +152,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@main
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and cargo-hack
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          toolchain: ${{ matrix.rust }}
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+          tool: rust@${{ matrix.rust }},cargo-hack
+          fallback: none
       - run: cargo hack build --workspace --no-dev-deps
       - run: cargo build --tests --features default,thread-pool,io-compat --manifest-path futures/Cargo.toml
 
@@ -158,13 +166,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - name: Install cargo-minimal-versions
-        uses: taiki-e/install-action@cargo-minimal-versions
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust, cargo-hack, and cargo-minimal-versions
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: rust@nightly,cargo-hack,cargo-minimal-versions
+          fallback: none
       - run: cargo minimal-versions build --workspace --ignore-private --all-features
 
   no-std:
@@ -180,13 +187,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and cargo-hack
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          target: ${{ matrix.target }}
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+          tool: rust@nightly+${{ matrix.target }},cargo-hack
+          fallback: none
       # remove dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
       - run: cargo hack --remove-dev-deps --workspace
       - run: |
@@ -214,9 +220,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: rust@nightly
+          fallback: none
       - run: cargo bench --workspace --all-features
 
   features:
@@ -224,11 +233,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
-      - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and cargo-hack
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: rust@nightly,cargo-hack
+          fallback: none
       # Check each specified feature works properly
       # * `--feature-powerset` - run for the feature powerset of the package
       # * `--depth 2` - limit the max number of simultaneous feature flags of `--feature-powerset`
@@ -247,11 +257,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          component: miri
+          tool: rust@nightly+miri
+          fallback: none
       - run: cargo miri test --workspace --all-features -- --skip panic_on_drop_fut
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation
@@ -275,7 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - run: |
           printf 'TARGET=x86_64-unknown-linux-gnuasan\n' >>"${GITHUB_ENV}"
           printf 'ASAN_OPTIONS=detect_stack_use_after_return=1\n' >>"${GITHUB_ENV}"
@@ -286,9 +297,11 @@ jobs:
       - run: |
           printf 'TARGET=x86_64-unknown-linux-gnutsan\n' >>"${GITHUB_ENV}"
         if: matrix.sanitizer == 'thread'
-      - uses: taiki-e/github-actions/install-rust@nightly
+      - name: Install Rust
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          target: ${{ env.TARGET }}
+          tool: rust@stable+${{ env.TARGET }}
+          fallback: none
       - run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --lib --tests -- --skip panic_on_drop_fut
         env:
           # TODO: Once `cfg(sanitize = "..")` is stable, replace
@@ -296,45 +309,17 @@ jobs:
           # `--cfg futures_sanitizer`.
           RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg futures_sanitizer
 
-  # This branch no longer actively developed. Most commits to this
-  # branch are backporting and should not be blocked by clippy.
-  # clippy:
-  #   name: cargo clippy
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   steps:
-  #     - uses: taiki-e/checkout-action@v1
-  #     - name: Install Rust
-  #       uses: taiki-e/github-actions/install-rust@nightly
-  #       with:
-  #         component: clippy
-  #     - run: cargo clippy --workspace --all-features --all-targets
-
   tidy:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@stable
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - name: Install Rust and zizmor
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
-          component: rustfmt
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: zizmor
+          tool: rust@stable+rustfmt,zizmor
+          fallback: none
       - run: cargo fmt --all -- --check
-      - run: zizmor .
+      - run: zizmor . -q --strict-collection
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docs:
-    name: cargo doc
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: taiki-e/checkout-action@v1
-      - name: Install Rust
-        uses: taiki-e/github-actions/install-rust@nightly
-      - run: cargo doc --workspace --no-deps --all-features
-        env:
-          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} --cfg docsrs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: Release
 
+permissions: {}
+
 on:
   push:
     tags:
@@ -9,9 +11,11 @@ jobs:
   create-release:
     if: github.repository_owner == 'rust-lang'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for taiki-e/create-gh-release-action
     steps:
-      - uses: taiki-e/checkout-action@v1
-      - uses: taiki-e/create-gh-release-action@v1
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: taiki-e/create-gh-release-action@eba8ea96c86cca8a37f1b56e94b4d13301fba651 # v1.11.0
         with:
           changelog: CHANGELOG.md
           branch: 'master|[0-9]+\.[0-9]+'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+# zizmor configuration
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  anonymous-definition: { disable: true }
+  dependabot-cooldown: { config: { days: 14 } }
+  unpinned-uses:
+    config:
+      policies:
+        taiki-e/*: any

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -4,7 +4,3 @@
 rules:
   anonymous-definition: { disable: true }
   dependabot-cooldown: { config: { days: 14 } }
-  unpinned-uses:
-    config:
-      policies:
-        taiki-e/*: any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Releases may yanked if there is a security bug, a soundness bug, or a regression
 Note: In this file, do not use the hard wrap in the middle of a sentence for compatibility with GitHub comment style markdown rendering.
 -->
 
+# 0.3.33 - 2026-07-18
+
+* Fix `ReadLine`'s soundness issue regarding to exception safety. (#3020)
+* Fix unsound `Send` impl for `IterPinRef` and `Iter`. (#3003)
+* Fix stacked borrows violation in `compat01as03` implementation. (#3012)
+* Fix memory leak in `FuturesUnordered::IntoIter`. (#3005)
+* Add `portable-atomic-alloc` feature and use it in `FuturesUnordered`. (#3007)
+* Re-export `alloc::task::Wake`. (#3010)
+* Update `spin` to 0.12. (#3014)
+
 # 0.3.32 - 2026-02-15
 
 * Bump MSRV of utility crates to 1.71. (#2989)

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -23,8 +23,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.32", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.32", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-channel/src/lib.rs
+++ b/futures-channel/src/lib.rs
@@ -21,18 +21,18 @@
 ))]
 #![warn(missing_docs, unsafe_op_in_unsafe_fn)]
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod lock;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "std")]
 pub mod mpsc;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub mod oneshot;

--- a/futures-channel/tests/mpsc-close.rs
+++ b/futures-channel/tests/mpsc-close.rs
@@ -148,10 +148,9 @@ fn single_receiver_drop_closes_channel_and_drains() {
 
 // Stress test that `try_send()`s occurring concurrently with receiver
 // close/drops don't appear as successful sends.
-#[cfg_attr(miri, ignore)] // Miri is too slow
 #[test]
 fn stress_try_send_as_receiver_closes() {
-    const AMT: usize = 10000;
+    const AMT: usize = if cfg!(miri) { 100 } else { 10000 };
     // To provide variable timing characteristics (in the hopes of
     // reproducing the collision that leads to a race), we busy-re-poll
     // the test MPSC receiver a variable number of times before actually

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.32", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.32", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.32", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.33", default-features = false }
 
 [dev-dependencies]
 futures = { path = "../futures", features = ["thread-pool"] }

--- a/futures-executor/src/enter.rs
+++ b/futures-executor/src/enter.rs
@@ -34,8 +34,8 @@ impl std::error::Error for EnterError {}
 /// executor.
 ///
 /// Executor implementations should call this function before beginning to
-/// execute a task, and drop the returned [`Enter`](Enter) value after
-/// completing task execution:
+/// execute a task, and drop the returned [`Enter`] value after completing
+/// task execution:
 ///
 /// ```
 /// use futures::executor::enter;

--- a/futures-executor/src/local_pool.rs
+++ b/futures-executor/src/local_pool.rs
@@ -23,8 +23,7 @@ use std::vec::Vec;
 /// thread. It's appropriate to poll strictly I/O-bound futures that do very
 /// little work in between I/O actions.
 ///
-/// To get a handle to the pool that implements
-/// [`Spawn`](futures_task::Spawn), use the
+/// To get a handle to the pool that implements [`Spawn`], use the
 /// [`spawner()`](LocalPool::spawner) method. Because the executor is
 /// single-threaded, it supports a special form of task spawning for non-`Send`
 /// futures, via [`spawn_local_obj`](futures_task::LocalSpawn::spawn_local_obj).
@@ -34,7 +33,7 @@ pub struct LocalPool {
     incoming: Rc<Incoming>,
 }
 
-/// A handle to a [`LocalPool`] that implements [`Spawn`](futures_task::Spawn).
+/// A handle to a [`LocalPool`] that implements [`Spawn`].
 #[derive(Clone, Debug)]
 pub struct LocalSpawner {
     incoming: Weak<Incoming>,

--- a/futures-executor/src/thread_pool.rs
+++ b/futures-executor/src/thread_pool.rs
@@ -79,8 +79,7 @@ impl ThreadPool {
     /// Creates a new thread pool with the default configuration.
     ///
     /// See documentation for the methods in
-    /// [`ThreadPoolBuilder`](ThreadPoolBuilder) for details on the default
-    /// configuration.
+    /// [`ThreadPoolBuilder`] for details on the default configuration.
     pub fn new() -> Result<Self, io::Error> {
         ThreadPoolBuilder::new().create()
     }
@@ -88,8 +87,7 @@ impl ThreadPool {
     /// Create a default thread pool configuration, which can then be customized.
     ///
     /// See documentation for the methods in
-    /// [`ThreadPoolBuilder`](ThreadPoolBuilder) for details on the default
-    /// configuration.
+    /// [`ThreadPoolBuilder`] for details on the default configuration.
     pub fn builder() -> ThreadPoolBuilder {
         ThreadPoolBuilder::new()
     }
@@ -259,7 +257,7 @@ impl ThreadPoolBuilder {
         self
     }
 
-    /// Create a [`ThreadPool`](ThreadPool) with the given configuration.
+    /// Create a [`ThreadPool`] with the given configuration.
     pub fn create(&mut self) -> Result<ThreadPool, io::Error> {
         let (tx, rx) = mpsc::channel();
         let pool = ThreadPool {

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -48,3 +48,7 @@ pub use crate::noop_waker::noop_waker_ref;
 
 #[doc(no_inline)]
 pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(no_inline)]
+pub use alloc::task::Wake;

--- a/futures-task/src/lib.rs
+++ b/futures-task/src/lib.rs
@@ -18,24 +18,24 @@ extern crate std;
 mod spawn;
 pub use crate::spawn::{LocalSpawn, Spawn, SpawnError};
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod arc_wake;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use crate::arc_wake::ArcWake;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod waker;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use crate::waker::waker;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod waker_ref;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use crate::waker_ref::{waker_ref, WakerRef};
 

--- a/futures-task/src/spawn.rs
+++ b/futures-task/src/spawn.rs
@@ -168,7 +168,7 @@ mod if_alloc {
         }
     }
 
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     impl<Sp: ?Sized + Spawn> Spawn for alloc::sync::Arc<Sp> {
         fn spawn_obj(&self, future: FutureObj<'static, ()>) -> Result<(), SpawnError> {
             (**self).spawn_obj(future)
@@ -179,7 +179,7 @@ mod if_alloc {
         }
     }
 
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     impl<Sp: ?Sized + LocalSpawn> LocalSpawn for alloc::sync::Arc<Sp> {
         fn spawn_local_obj(&self, future: LocalFutureObj<'static, ()>) -> Result<(), SpawnError> {
             (**self).spawn_local_obj(future)

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -12,13 +12,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.32", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.32", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.32", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.32", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.32", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.32", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.32", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.33", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.33", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.33", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.33", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.33", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.33", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.33", path = "../futures-macro", default-features = false }
 pin-project = "1.0.11"
 
 [dev-dependencies]

--- a/futures-test/src/task/context.rs
+++ b/futures-test/src/task/context.rs
@@ -1,8 +1,8 @@
 use crate::task::{noop_waker_ref, panic_waker_ref};
 use futures_core::task::Context;
 
-/// Create a new [`Context`](core::task::Context) where the
-/// [waker](core::task::Context::waker) will panic if used.
+/// Create a new [`Context`] where the [waker](core::task::Context::waker)
+/// will panic if used.
 ///
 /// # Examples
 ///
@@ -16,8 +16,8 @@ pub fn panic_context() -> Context<'static> {
     Context::from_waker(panic_waker_ref())
 }
 
-/// Create a new [`Context`](core::task::Context) where the
-/// [waker](core::task::Context::waker) will ignore any uses.
+/// Create a new [`Context`] where the [waker](core::task::Context::waker)
+/// will ignore any uses.
 ///
 /// # Examples
 ///

--- a/futures-test/src/task/noop_spawner.rs
+++ b/futures-test/src/task/noop_spawner.rs
@@ -1,7 +1,6 @@
 use futures_task::{FutureObj, Spawn, SpawnError};
 
-/// An implementation of [`Spawn`](futures_task::Spawn) that
-/// discards spawned futures when used.
+/// An implementation of [`Spawn`] that discards spawned futures when used.
 ///
 /// # Examples
 ///

--- a/futures-test/src/task/panic_spawner.rs
+++ b/futures-test/src/task/panic_spawner.rs
@@ -1,7 +1,6 @@
 use futures_task::{FutureObj, Spawn, SpawnError};
 
-/// An implementation of [`Spawn`](futures_task::Spawn) that panics
-/// when used.
+/// An implementation of [`Spawn`] that panics when used.
 ///
 /// # Examples
 ///

--- a/futures-test/src/task/panic_waker.rs
+++ b/futures-test/src/task/panic_waker.rs
@@ -20,9 +20,9 @@ const fn raw_panic_waker() -> RawWaker {
     RawWaker::new(null(), &PANIC_WAKER_VTABLE)
 }
 
-/// Create a new [`Waker`](futures_core::task::Waker) which will
-/// panic when `wake()` is called on it. The [`Waker`] can be converted
-/// into a [`Waker`] which will behave the same way.
+/// Create a new [`Waker`] which will panic when `wake()` is called on it.
+/// The [`Waker`] can be converted into a [`Waker`] which will behave the same
+/// way.
 ///
 /// # Examples
 ///
@@ -37,9 +37,8 @@ pub fn panic_waker() -> Waker {
     unsafe { Waker::from_raw(raw_panic_waker()) }
 }
 
-/// Get a global reference to a
-/// [`Waker`](futures_core::task::Waker) referencing a singleton
-/// instance of a [`Waker`] which panics when woken.
+/// Get a global reference to a [`Waker`] referencing a singleton instance of
+/// a [`Waker`] which panics when woken.
 ///
 /// # Examples
 ///

--- a/futures-test/src/task/record_spawner.rs
+++ b/futures-test/src/task/record_spawner.rs
@@ -1,8 +1,8 @@
 use futures_task::{FutureObj, Spawn, SpawnError};
 use std::cell::{Ref, RefCell};
 
-/// An implementation of [`Spawn`](futures_task::Spawn) that records
-/// any [`Future`](futures_core::future::Future)s spawned on it.
+/// An implementation of [`Spawn`] that records any
+/// [`Future`](futures_core::future::Future)s spawned on it.
 ///
 /// # Examples
 ///

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -22,7 +22,8 @@ io-compat = ["io", "compat", "tokio-io", "libc"]
 sink = ["futures-sink"]
 io = ["std", "futures-io", "memchr"]
 channel = ["std", "futures-channel"]
-portable-atomic = ["futures-core/portable-atomic"]
+portable-atomic = ["futures-core/portable-atomic", "portable_atomic_crate"]
+portable-atomic-alloc = ["portable-atomic-util/alloc", "portable-atomic"]
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the
@@ -48,9 +49,16 @@ futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-project-lite = "0.2.6"
 spin = { version = "0.12.0", optional = true }
+portable-atomic-util = { version = "0.2.7", default-features = false, optional = true }
 
 # INDIRECT DEPENDENCYS BUT ONLY FOR SPECIFIC MINIMAL VERSIONS
 libc = { version = "0.2.26", optional = true }
+
+[dependencies.portable_atomic_crate]
+package = "portable-atomic"
+version = "1.13.1"
+default-features = false
+optional = true
 
 [dev-dependencies]
 futures = { path = "../futures", features = ["async-await", "thread-pool"] }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -37,12 +37,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.32", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.32", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.32", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.32", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.32", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.32", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.33", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.33", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.33", default-features = false, optional = true }
 slab = { version = "0.4.7", default-features = false, optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -47,7 +47,7 @@ memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }
 tokio-io = { version = "0.1.9", optional = true }
 pin-project-lite = "0.2.6"
-spin = { version = "0.10.0", optional = true }
+spin = { version = "0.12.0", optional = true }
 
 # INDIRECT DEPENDENCYS BUT ONLY FOR SPECIFIC MINIMAL VERSIONS
 libc = { version = "0.2.26", optional = true }

--- a/futures-util/src/async_await/pending.rs
+++ b/futures-util/src/async_await/pending.rs
@@ -5,7 +5,7 @@ use futures_core::task::{Context, Poll};
 /// A macro which yields to the event loop once.
 ///
 /// This is equivalent to returning [`Poll::Pending`](futures_core::task::Poll)
-/// from a [`Future::poll`](futures_core::future::Future::poll) implementation.
+/// from a [`Future::poll`] implementation.
 /// Similarly, when using this macro, it must be ensured that [`wake`](std::task::Waker::wake)
 /// is called somewhere when further progress can be made.
 ///

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -9,6 +9,7 @@ use futures_core::{future::Future as Future03, stream::Stream as Stream03, task 
 #[cfg(feature = "sink")]
 use futures_sink::Sink as Sink03;
 use std::boxed::Box;
+use std::cell::UnsafeCell;
 use std::pin::Pin;
 use std::task::Context;
 
@@ -320,7 +321,8 @@ where
     }
 }
 
-struct NotifyWaker(task03::Waker);
+#[repr(transparent)]
+struct NotifyWaker(UnsafeCell<task03::Waker>);
 
 #[allow(missing_debug_implementations)] // false positive: this is private type
 #[derive(Clone)]
@@ -328,26 +330,37 @@ struct WakerToHandle<'a>(&'a task03::Waker);
 
 impl From<WakerToHandle<'_>> for NotifyHandle01 {
     fn from(handle: WakerToHandle<'_>) -> Self {
-        let ptr = Box::new(NotifyWaker(handle.0.clone()));
+        let waker_ptr: Box<task03::Waker> = Box::new(handle.0.clone());
+        // NotifyWaker is a transparent (pointer compatible) wrapper for
+        // task03::Waker (and wrapping in UnsafeCell is fine).
+        let ptr: *mut NotifyWaker = Box::into_raw(waker_ptr) as *mut NotifyWaker;
 
-        unsafe { Self::new(Box::into_raw(ptr)) }
+        unsafe { Self::new(ptr) }
     }
 }
 
 impl Notify01 for NotifyWaker {
     fn notify(&self, _: usize) {
-        self.0.wake_by_ref();
+        unsafe { &*self.0.get() }.wake_by_ref();
     }
 }
 
+unsafe impl Send for NotifyWaker {}
+unsafe impl Sync for NotifyWaker {}
+
 unsafe impl UnsafeNotify01 for NotifyWaker {
     unsafe fn clone_raw(&self) -> NotifyHandle01 {
-        WakerToHandle(&self.0).into()
+        WakerToHandle(unsafe { &*self.0.get() }).into()
     }
 
     unsafe fn drop_raw(&self) {
-        let ptr: *const dyn UnsafeNotify01 = self;
-        drop(unsafe { Box::from_raw(ptr as *mut dyn UnsafeNotify01) });
+        /* UnsafeNotify01::drop_raw says this should receive `*mut Self`,
+         * but that isn't dyn compatible.
+         * miri is unhappy when a `*mut` is created from a `&` reference,
+         * so need to go through `UnsafeCell`.
+         */
+        let waker: *mut task03::Waker = self.0.get();
+        drop(unsafe { Box::from_raw(waker) });
     }
 }
 

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -66,7 +66,6 @@ pub trait Future01CompatExt: Future01 {
     /// [`Future<Output = Result<T, E>>`](futures_core::future::Future).
     ///
     /// ```
-    /// # if cfg!(miri) { return; } // https://github.com/rust-lang/futures-rs/issues/2514
     /// # futures::executor::block_on(async {
     /// # // TODO: These should be all using `futures::compat`, but that runs up against Cargo
     /// # // feature issues
@@ -93,7 +92,6 @@ pub trait Stream01CompatExt: Stream01 {
     /// [`Stream<Item = Result<T, E>>`](futures_core::stream::Stream).
     ///
     /// ```
-    /// # if cfg!(miri) { return; } // https://github.com/rust-lang/futures-rs/issues/2514
     /// # futures::executor::block_on(async {
     /// use futures::stream::StreamExt;
     /// use futures_util::compat::Stream01CompatExt;
@@ -123,7 +121,6 @@ pub trait Sink01CompatExt: Sink01 {
     /// [`Sink<T, Error = E>`](futures_sink::Sink).
     ///
     /// ```
-    /// # if cfg!(miri) { return; } // https://github.com/rust-lang/futures-rs/issues/2514
     /// # futures::executor::block_on(async {
     /// use futures::{sink::SinkExt, stream::StreamExt};
     /// use futures_util::compat::{Stream01CompatExt, Sink01CompatExt};
@@ -379,7 +376,7 @@ mod io {
         /// [`AsyncRead`](futures_io::AsyncRead).
         ///
         /// ```
-        /// # if cfg!(miri) { return; } // https://github.com/rust-lang/futures-rs/issues/2514
+        /// # if cfg!(miri) { return; } // Miri does not support epoll_create
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncReadExt;
         /// use futures_util::compat::AsyncRead01CompatExt;
@@ -409,7 +406,7 @@ mod io {
         /// [`AsyncWrite`](futures_io::AsyncWrite).
         ///
         /// ```
-        /// # if cfg!(miri) { return; } // https://github.com/rust-lang/futures-rs/issues/2514
+        /// # if cfg!(miri) { return; } // Miri does not support epoll_create
         /// # futures::executor::block_on(async {
         /// use futures::io::AsyncWriteExt;
         /// use futures_util::compat::AsyncWrite01CompatExt;

--- a/futures-util/src/compat/executor.rs
+++ b/futures-util/src/compat/executor.rs
@@ -17,7 +17,7 @@ pub trait Executor01CompatExt: Executor01<Executor01Future> + Clone + Send + 'st
     /// futures 0.3 [`Spawn`](futures_task::Spawn).
     ///
     /// ```
-    /// # if cfg!(miri) { return; } // Miri does not support epoll
+    /// # if cfg!(miri) { return; } // Miri does not support epoll_create
     /// use futures::task::SpawnExt;
     /// use futures::future::{FutureExt, TryFutureExt};
     /// use futures_util::compat::Executor01CompatExt;

--- a/futures-util/src/future/join_all.rs
+++ b/futures-util/src/future/join_all.rs
@@ -12,7 +12,7 @@ use core::task::{Context, Poll};
 
 use super::{assert_future, MaybeDone};
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 use crate::stream::{Collect, FuturesOrdered, StreamExt};
 
 pub(crate) fn iter_pin_mut<T>(slice: Pin<&mut [T]>) -> impl Iterator<Item = Pin<&mut T>> {
@@ -31,7 +31,7 @@ where
     kind: JoinAllKind<F>,
 }
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 pub(crate) const SMALL: usize = 30;
 
 enum JoinAllKind<F>
@@ -41,7 +41,7 @@ where
     Small {
         elems: Pin<Box<[MaybeDone<F>]>>,
     },
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     Big {
         fut: Collect<FuturesOrdered<F>, Vec<F::Output>>,
     },
@@ -57,7 +57,7 @@ where
             JoinAllKind::Small { ref elems } => {
                 f.debug_struct("JoinAll").field("elems", elems).finish()
             }
-            #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+            #[cfg(target_has_atomic = "ptr")]
             JoinAllKind::Big { ref fut, .. } => fmt::Debug::fmt(fut, f),
         }
     }
@@ -106,8 +106,7 @@ where
 {
     let iter = iter.into_iter();
 
-    #[cfg(target_os = "none")]
-    #[cfg_attr(target_os = "none", cfg(not(target_has_atomic = "ptr")))]
+    #[cfg(not(target_has_atomic = "ptr"))]
     {
         let kind =
             JoinAllKind::Small { elems: iter.map(MaybeDone::Future).collect::<Box<[_]>>().into() };
@@ -115,7 +114,7 @@ where
         assert_future::<Vec<<I::Item as Future>::Output>, _>(JoinAll { kind })
     }
 
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     {
         let kind = match iter.size_hint().1 {
             Some(max) if max <= SMALL => JoinAllKind::Small {
@@ -154,7 +153,7 @@ where
                     Poll::Pending
                 }
             }
-            #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+            #[cfg(target_has_atomic = "ptr")]
             JoinAllKind::Big { fut } => Pin::new(fut).poll(cx),
         }
     }

--- a/futures-util/src/future/mod.rs
+++ b/futures-util/src/future/mod.rs
@@ -114,13 +114,13 @@ pub use self::select_ok::{select_ok, SelectOk};
 mod either;
 pub use self::either::Either;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod abortable;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use crate::abortable::{AbortHandle, AbortRegistration, Abortable, Aborted};
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use abortable::abortable;
 

--- a/futures-util/src/future/poll_immediate.rs
+++ b/futures-util/src/future/poll_immediate.rs
@@ -7,7 +7,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// Future for the [`poll_immediate`](poll_immediate()) function.
     ///
-    /// It will never return [Poll::Pending](core::task::Poll::Pending)
+    /// It will never return [Poll::Pending].
     #[derive(Debug, Clone)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct PollImmediate<T> {
@@ -43,8 +43,8 @@ impl<T: Future> FusedFuture for PollImmediate<T> {
     }
 }
 
-/// A [Stream](crate::stream::Stream) implementation that can be polled repeatedly until the future is done.
-/// The stream will never return [Poll::Pending](core::task::Poll::Pending)
+/// A [Stream] implementation that can be polled repeatedly until the future is done.
+/// The stream will never return [Poll::Pending]
 /// so polling it in a tight loop is worse than using a blocking synchronous function.
 /// ```
 /// # futures::executor::block_on(async {
@@ -89,7 +89,8 @@ where
 }
 
 /// Creates a future that is immediately ready with an Option of a value.
-/// Specifically this means that [poll](core::future::Future::poll()) always returns [Poll::Ready](core::task::Poll::Ready).
+/// Specifically this means that [poll](core::future::Future::poll()) always
+/// returns [Poll::Ready].
 ///
 /// # Caution
 ///

--- a/futures-util/src/future/try_future/mod.rs
+++ b/futures-util/src/future/try_future/mod.rs
@@ -314,7 +314,7 @@ pub trait TryFutureExt: TryFuture {
     }
 
     /// Maps this future's [`Error`](TryFuture::Error) to a new error type
-    /// using the [`Into`](std::convert::Into) trait.
+    /// using the [`Into`] trait.
     ///
     /// This method does for futures what the `?`-operator does for
     /// [`Result`]: It lets the compiler infer the type of the resulting
@@ -347,7 +347,7 @@ pub trait TryFutureExt: TryFuture {
     }
 
     /// Maps this future's [`Ok`](TryFuture::Ok) to a new type
-    /// using the [`Into`](std::convert::Into) trait.
+    /// using the [`Into`] trait.
     fn ok_into<U>(self) -> OkInto<Self, U>
     where
         Self: Sized,

--- a/futures-util/src/future/try_join_all.rs
+++ b/futures-util/src/future/try_join_all.rs
@@ -12,7 +12,7 @@ use core::task::{Context, Poll};
 
 use super::{assert_future, join_all, IntoFuture, TryFuture, TryMaybeDone};
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 use crate::stream::{FuturesOrdered, TryCollect, TryStreamExt};
 use crate::TryFutureExt;
 
@@ -38,7 +38,7 @@ where
     Small {
         elems: Pin<Box<[TryMaybeDone<IntoFuture<F>>]>>,
     },
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     Big {
         fut: TryCollect<FuturesOrdered<IntoFuture<F>>, Vec<F::Ok>>,
     },
@@ -56,7 +56,7 @@ where
             TryJoinAllKind::Small { ref elems } => {
                 f.debug_struct("TryJoinAll").field("elems", elems).finish()
             }
-            #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+            #[cfg(target_has_atomic = "ptr")]
             TryJoinAllKind::Big { ref fut, .. } => fmt::Debug::fmt(fut, f),
         }
     }
@@ -121,8 +121,7 @@ where
 {
     let iter = iter.into_iter().map(TryFutureExt::into_future);
 
-    #[cfg(target_os = "none")]
-    #[cfg_attr(target_os = "none", cfg(not(target_has_atomic = "ptr")))]
+    #[cfg(not(target_has_atomic = "ptr"))]
     {
         let kind = TryJoinAllKind::Small {
             elems: iter.map(TryMaybeDone::Future).collect::<Box<[_]>>().into(),
@@ -133,7 +132,7 @@ where
         )
     }
 
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     {
         let kind = match iter.size_hint().1 {
             Some(max) if max <= join_all::SMALL => TryJoinAllKind::Small {
@@ -185,7 +184,7 @@ where
                     }
                 }
             }
-            #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+            #[cfg(target_has_atomic = "ptr")]
             TryJoinAllKind::Big { fut } => Pin::new(fut).poll(cx),
         }
     }

--- a/futures-util/src/io/allow_std.rs
+++ b/futures-util/src/io/allow_std.rs
@@ -6,8 +6,8 @@ use std::vec::Vec;
 use std::{fmt, io};
 
 /// A simple wrapper type which allows types which implement only
-/// implement `std::io::Read` or `std::io::Write`
-/// to be used in contexts which expect an `AsyncRead` or `AsyncWrite`.
+/// `std::io::Read` or `std::io::Write` to be used
+/// in contexts which expect an `AsyncRead` or `AsyncWrite`.
 ///
 /// If these types issue an error with the kind `io::ErrorKind::WouldBlock`,
 /// it is expected that they will notify the current task on readiness.

--- a/futures-util/src/io/buf_reader.rs
+++ b/futures-util/src/io/buf_reader.rs
@@ -195,7 +195,7 @@ impl<R: AsyncRead + AsyncSeek> AsyncSeek for BufReader<R> {
     /// [`BufReader::seek_relative`](BufReader::seek_relative) or
     /// [`BufReader::poll_seek_relative`](BufReader::poll_seek_relative).
     ///
-    /// See [`AsyncSeek`](futures_io::AsyncSeek) for more details.
+    /// See [`AsyncSeek`] for more details.
     ///
     /// Note: In the edge case where you're seeking with `SeekFrom::Current(n)`
     /// where `n` minus the internal buffer length overflows an `i64`, two

--- a/futures-util/src/io/read_until.rs
+++ b/futures-util/src/io/read_until.rs
@@ -42,8 +42,8 @@ pub(super) fn read_until_internal<R: AsyncBufRead + ?Sized>(
                 (false, available.len())
             }
         };
-        reader.as_mut().consume(used);
         *read += used;
+        reader.as_mut().consume(used);
         if done || used == 0 {
             return Poll::Ready(Ok(*read));
         }

--- a/futures-util/src/lib.rs
+++ b/futures-util/src/lib.rs
@@ -323,7 +323,7 @@ pub use crate::io::{
 #[cfg(feature = "alloc")]
 pub mod lock;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod abortable;
 

--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -3,25 +3,25 @@
 //! This module is only available when the `std` or `alloc` feature of this
 //! library is activated, and it is activated by default.
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(any(feature = "sink", feature = "io"))]
 #[cfg(not(feature = "bilock"))]
 pub(crate) use self::bilock::BiLock;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "bilock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "std")]
 pub use self::mutex::{
     MappedMutexGuard, Mutex, MutexGuard, MutexLockFuture, OwnedMutexGuard, OwnedMutexLockFuture,
 };
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(any(feature = "bilock", feature = "sink", feature = "io"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "bilock")))]
 #[cfg_attr(not(feature = "bilock"), allow(unreachable_pub))]
 mod bilock;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "std")]
 mod mutex;

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -160,11 +160,14 @@ impl<'a, Fut: Unpin> Iterator for Iter<'a, Fut> {
 
 impl<Fut: Unpin> ExactSizeIterator for Iter<'_, Fut> {}
 
-// SAFETY: we do nothing thread-local and there is no interior mutability,
-// so the usual structural `Send`/`Sync` apply.
-unsafe impl<Fut: Send> Send for IterPinRef<'_, Fut> {}
+// SAFETY: `IterPinRef` yields `Pin<&Fut>` shared references. Sending these
+// to another thread requires `Fut: Sync` since both the sender and receiver
+// can concurrently access the same `Fut` through their shared references.
+unsafe impl<Fut: Sync> Send for IterPinRef<'_, Fut> {}
 unsafe impl<Fut: Sync> Sync for IterPinRef<'_, Fut> {}
 
+// SAFETY: we do nothing thread-local and there is no interior mutability,
+// so the usual structural `Send`/`Sync` apply.
 unsafe impl<Fut: Send> Send for IterPinMut<'_, Fut> {}
 unsafe impl<Fut: Sync> Sync for IterPinMut<'_, Fut> {}
 

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -1,5 +1,6 @@
 use super::task::Task;
 use super::FuturesUnordered;
+use alloc::sync::Arc;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use core::ptr;
@@ -50,19 +51,27 @@ impl<Fut: Unpin> Iterator for IntoIter<Fut> {
         }
 
         unsafe {
+            let head = *task;
+
             // Moving out of the future is safe because it is `Unpin`
-            let future = (*(**task).future.get()).take().unwrap();
+            let future = (*(*head).future.get()).take().unwrap();
 
             // Mutable access to a previously shared `FuturesUnordered` implies
             // that the other threads already released the object before the
             // current thread acquired it, so relaxed ordering can be used and
             // valid `next_all` checks can be skipped.
-            let next = (**task).next_all.load(Relaxed);
+            let next = (*head).next_all.load(Relaxed);
             *task = next;
-            if !task.is_null() {
-                *(**task).prev_all.get() = ptr::null_mut();
+            if !next.is_null() {
+                *(*next).prev_all.get() = ptr::null_mut();
             }
             self.len -= 1;
+
+            let arc = Arc::from_raw(head);
+            arc.next_all.store(self.inner.pending_next_all(), Relaxed);
+            *arc.prev_all.get() = ptr::null_mut();
+            self.inner.release_task(arc);
+
             Some(future)
         }
     }

--- a/futures-util/src/stream/futures_unordered/iter.rs
+++ b/futures-util/src/stream/futures_unordered/iter.rs
@@ -1,6 +1,6 @@
 use super::task::Task;
+use super::Arc;
 use super::FuturesUnordered;
-use alloc::sync::Arc;
 use core::marker::PhantomData;
 use core::pin::Pin;
 use core::ptr;

--- a/futures-util/src/stream/futures_unordered/mod.rs
+++ b/futures-util/src/stream/futures_unordered/mod.rs
@@ -3,8 +3,21 @@
 //! This module is only available when the `std` or `alloc` feature of this
 //! library is activated, and it is activated by default.
 
-use crate::task::AtomicWaker;
+#[cfg(not(feature = "portable-atomic"))]
+use core::sync::atomic;
+
+#[cfg(not(feature = "portable-atomic-alloc"))]
 use alloc::sync::{Arc, Weak};
+
+#[cfg(feature = "portable-atomic")]
+use portable_atomic_crate as atomic;
+
+#[cfg(feature = "portable-atomic-alloc")]
+use portable_atomic_util::{Arc, Weak};
+
+use crate::task::AtomicWaker;
+use atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+use atomic::{AtomicBool, AtomicPtr};
 use core::cell::UnsafeCell;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
@@ -12,8 +25,6 @@ use core::marker::PhantomData;
 use core::mem;
 use core::pin::Pin;
 use core::ptr;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
-use core::sync::atomic::{AtomicBool, AtomicPtr};
 use futures_core::future::Future;
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};

--- a/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
+++ b/futures-util/src/stream/futures_unordered/ready_to_run_queue.rs
@@ -1,9 +1,9 @@
+use super::atomic::AtomicPtr;
+use super::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
+use super::Arc;
 use crate::task::AtomicWaker;
-use alloc::sync::Arc;
 use core::cell::UnsafeCell;
 use core::ptr;
-use core::sync::atomic::AtomicPtr;
-use core::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 
 use super::abort::abort;
 use super::task::Task;

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -20,12 +20,12 @@ use super::ReadyToRunQueue;
 ///
 /// Currently, there are two ways to convert `ArcWake` into [`Waker`]:
 ///
-/// * [`waker`](super::waker()) converts `Arc<impl ArcWake>` into [`Waker`].
-/// * [`waker_ref`](super::waker_ref()) converts `&Arc<impl ArcWake>` into [`WakerRef`] that
+/// * [`waker`](crate::task::waker()) converts `Arc<impl ArcWake>` into [`Waker`].
+/// * [`waker_ref`](crate::task::waker_ref()) converts `&Arc<impl ArcWake>` into [`WakerRef`] that
 ///   provides access to a [`&Waker`][`Waker`].
 ///
 /// [`Waker`]: std::task::Waker
-/// [`WakerRef`]: super::WakerRef
+/// [`WakerRef`]: crate::task::WakerRef
 // Note: Send + Sync required because `Arc<T>` doesn't automatically imply
 // those bounds, but `Waker` implements them.
 pub(crate) trait ArcWake: Send + Sync {

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -1,11 +1,63 @@
-use alloc::sync::{Arc, Weak};
+use super::{atomic, Arc, Weak};
+
 use core::cell::UnsafeCell;
-use core::sync::atomic::Ordering::{self, Relaxed, SeqCst};
-use core::sync::atomic::{AtomicBool, AtomicPtr};
+
+use atomic::Ordering::{self, Relaxed, SeqCst};
+use atomic::{AtomicBool, AtomicPtr};
 
 use super::abort::abort;
 use super::ReadyToRunQueue;
-use crate::task::ArcWake;
+
+/// Local version of `crate::arc_wake::ArcWake` to allow portable-atomic-util's
+/// `Arc` to be used.
+///
+/// A way of waking up a specific task.
+///
+/// By implementing this trait, types that are expected to be wrapped in an `Arc`
+/// can be converted into [`Waker`] objects.
+/// Those Wakers can be used to signal executors that a task it owns
+/// is ready to be `poll`ed again.
+///
+/// Currently, there are two ways to convert `ArcWake` into [`Waker`]:
+///
+/// * [`waker`](super::waker()) converts `Arc<impl ArcWake>` into [`Waker`].
+/// * [`waker_ref`](super::waker_ref()) converts `&Arc<impl ArcWake>` into [`WakerRef`] that
+///   provides access to a [`&Waker`][`Waker`].
+///
+/// [`Waker`]: std::task::Waker
+/// [`WakerRef`]: super::WakerRef
+// Note: Send + Sync required because `Arc<T>` doesn't automatically imply
+// those bounds, but `Waker` implements them.
+pub(crate) trait ArcWake: Send + Sync {
+    /// Indicates that the associated task is ready to make progress and should
+    /// be `poll`ed.
+    ///
+    /// This function can be called from an arbitrary thread, including threads which
+    /// did not create the `ArcWake` based [`Waker`].
+    ///
+    /// Executors generally maintain a queue of "ready" tasks; `wake` should place
+    /// the associated task onto this queue.
+    ///
+    /// [`Waker`]: std::task::Waker
+    fn wake(this: Arc<Self>) {
+        Self::wake_by_ref(&this)
+    }
+
+    /// Indicates that the associated task is ready to make progress and should
+    /// be `poll`ed.
+    ///
+    /// This function can be called from an arbitrary thread, including threads which
+    /// did not create the `ArcWake` based [`Waker`].
+    ///
+    /// Executors generally maintain a queue of "ready" tasks; `wake_by_ref` should place
+    /// the associated task onto this queue.
+    ///
+    /// This function is similar to [`wake`](ArcWake::wake), but must not consume the provided data
+    /// pointer.
+    ///
+    /// [`Waker`]: std::task::Waker
+    fn wake_by_ref(arc_self: &Arc<Self>);
+}
 
 pub(super) struct Task<Fut> {
     // The future
@@ -125,13 +177,16 @@ impl<Fut> Drop for Task<Fut> {
 }
 
 mod waker_ref {
+    use super::ArcWake;
+    #[cfg(not(feature = "portable-atomic-alloc"))]
     use alloc::sync::Arc;
     use core::marker::PhantomData;
     use core::mem;
     use core::mem::ManuallyDrop;
     use core::ops::Deref;
     use core::task::{RawWaker, RawWakerVTable, Waker};
-    use futures_task::ArcWake;
+    #[cfg(feature = "portable-atomic-alloc")]
+    use portable_atomic_util::Arc;
 
     pub(crate) struct WakerRef<'a> {
         waker: ManuallyDrop<Waker>,

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -37,13 +37,13 @@ pub use self::stream::ReadyChunks;
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 pub use self::stream::Forward;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use self::stream::{
     BufferUnordered, Buffered, FlatMapUnordered, FlattenUnordered, ForEachConcurrent,
 };
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[cfg(feature = "alloc")]
@@ -61,7 +61,7 @@ pub use self::try_stream::{
 #[cfg(feature = "std")]
 pub use self::try_stream::IntoAsyncRead;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use self::try_stream::{
     TryBufferUnordered, TryBuffered, TryFlattenUnordered, TryForEachConcurrent,
@@ -105,42 +105,36 @@ pub use self::select_with_strategy::{select_with_strategy, PollNext, SelectWithS
 mod unfold;
 pub use self::unfold::{unfold, Unfold};
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod futures_ordered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use self::futures_ordered::FuturesOrdered;
 
-#[cfg_attr(
-    target_os = "none",
-    cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))
-)]
+#[cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))]
 #[cfg(feature = "alloc")]
 pub mod futures_unordered;
-#[cfg_attr(
-    target_os = "none",
-    cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))
-)]
+#[cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))]
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use self::futures_unordered::FuturesUnordered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub mod select_all;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use self::select_all::{select_all, SelectAll};
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod abortable;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use crate::abortable::{AbortHandle, AbortRegistration, Abortable, Aborted};
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use abortable::abortable;
 

--- a/futures-util/src/stream/mod.rs
+++ b/futures-util/src/stream/mod.rs
@@ -112,10 +112,16 @@ mod futures_ordered;
 #[cfg(feature = "alloc")]
 pub use self::futures_ordered::FuturesOrdered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg_attr(
+    target_os = "none",
+    cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))
+)]
 #[cfg(feature = "alloc")]
 pub mod futures_unordered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg_attr(
+    target_os = "none",
+    cfg(any(target_has_atomic = "ptr", feature = "portable-atomic-alloc"))
+)]
 #[cfg(feature = "alloc")]
 #[doc(inline)]
 pub use self::futures_unordered::FuturesUnordered;

--- a/futures-util/src/stream/poll_immediate.rs
+++ b/futures-util/src/stream/poll_immediate.rs
@@ -6,7 +6,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// Stream for the [poll_immediate](poll_immediate()) function.
     ///
-    /// It will never return [Poll::Pending](core::task::Poll::Pending)
+    /// It will never return [Poll::Pending].
     #[derive(Debug, Clone)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct PollImmediate<S> {
@@ -50,7 +50,8 @@ impl<S: Stream> super::FusedStream for PollImmediate<S> {
     }
 }
 
-/// Creates a new stream that always immediately returns [Poll::Ready](core::task::Poll::Ready) when awaiting it.
+/// Creates a new stream that always immediately returns [Poll::Ready] when
+/// awaiting it.
 ///
 /// This is useful when immediacy is more important than waiting for the next item to be ready.
 ///

--- a/futures-util/src/stream/repeat_with.rs
+++ b/futures-util/src/stream/repeat_with.rs
@@ -44,7 +44,7 @@ impl<A, F: FnMut() -> A> FusedStream for RepeatWith<F> {
 ///
 /// If the element type of the stream you need implements [`Clone`], and
 /// it is OK to keep the source element in memory, you should instead use
-/// the [`stream::repeat()`](crate::stream::repeat) function.
+/// the [`stream::repeat()`](crate::stream::repeat()) function.
 ///
 /// # Examples
 ///

--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -116,7 +116,7 @@ pin_project! {
 ///
 /// ### Round Robin
 /// This example shows how to select from both streams round robin.
-/// Note: this special case is provided by [`stream::select`](crate::stream::select).
+/// Note: this special case is provided by [`stream::select`](crate::stream::select()).
 ///
 /// ```rust
 /// # futures::executor::block_on(async {

--- a/futures-util/src/stream/stream/flatten_unordered.rs
+++ b/futures-util/src/stream/stream/flatten_unordered.rs
@@ -63,6 +63,7 @@ impl SharedPollState {
     /// Attempts to start polling, returning stored state in case of success.
     /// Returns `None` if either waker is waking at the moment.
     fn start_polling(&self) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&Self) -> u8>)> {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
@@ -86,6 +87,7 @@ impl SharedPollState {
         &self,
         to_poll: u8,
     ) -> Option<(u8, PollStateBomb<'_, impl FnOnce(&Self) -> u8>)> {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
@@ -121,6 +123,7 @@ impl SharedPollState {
     ///   * `POLLING` phase can't start if some of the wakers are active
     ///     So no wrapped waker can touch the inner waker's cell, it's safe to poll again.
     fn stop_polling(&self, to_poll: u8, will_be_woken: bool) -> u8 {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         self.state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |mut value| {
                 let mut next_value = to_poll;
@@ -138,6 +141,7 @@ impl SharedPollState {
 
     /// Toggles state to non-waking, allowing to start polling.
     fn stop_waking(&self) -> u8 {
+        #[allow(deprecated)] // fetch_update was renamed to try_update in rust 1.95.0
         let value = self
             .state
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -181,32 +181,32 @@ mod scan;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::scan::Scan;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod buffer_unordered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::buffer_unordered::BufferUnordered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod buffered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::buffered::Buffered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub(crate) mod flatten_unordered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)]
 pub use self::flatten_unordered::FlattenUnordered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 delegate_all!(
     /// Stream for the [`flat_map_unordered`](StreamExt::flat_map_unordered) method.
@@ -216,20 +216,20 @@ delegate_all!(
     where St: Stream, U: Stream, U: Unpin, F: FnMut(St::Item) -> U
 );
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod for_each_concurrent;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::for_each_concurrent::ForEachConcurrent;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[cfg(feature = "alloc")]
 mod split;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "sink")]
 #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
 #[cfg(feature = "alloc")]
@@ -820,7 +820,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(output, vec![1, 2, 3, 4]);
     /// # });
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn flatten_unordered(self, limit: impl Into<Option<usize>>) -> FlattenUnordered<Self>
     where
@@ -902,7 +902,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(vec![1usize, 2, 2, 3, 3, 3, 4, 4, 4, 4], values);
     /// # });
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn flat_map_unordered<U, F>(
         self,
@@ -1142,7 +1142,7 @@ pub trait StreamExt: Stream {
     /// fut.await;
     /// # })
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn for_each_concurrent<Fut, F>(
         self,
@@ -1365,7 +1365,7 @@ pub trait StreamExt: Stream {
     ///
     /// This method is only available when the `std` or `alloc` feature of this
     /// library is activated, and it is activated by default.
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn buffered(self, n: usize) -> Buffered<Self>
     where
@@ -1410,7 +1410,7 @@ pub trait StreamExt: Stream {
     /// assert_eq!(buffered.next().await, None);
     /// # Ok::<(), i32>(()) }).unwrap();
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn buffer_unordered(self, n: usize) -> BufferUnordered<Self>
     where
@@ -1577,7 +1577,7 @@ pub trait StreamExt: Stream {
     /// library is activated, and it is activated by default.
     #[cfg(feature = "sink")]
     #[cfg_attr(docsrs, doc(cfg(feature = "sink")))]
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn split<Item>(self) -> (SplitSink<Self, Item>, SplitStream<Self>)
     where

--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -572,8 +572,7 @@ pub trait StreamExt: Stream {
     /// of all the subsequent results of the stream. If the stream is
     /// empty, the default value will be returned.
     ///
-    /// Works with all collections that implement the
-    /// [`Extend`](std::iter::Extend) trait.
+    /// Works with all collections that implement the [`Extend`] trait.
     ///
     /// # Examples
     ///

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -311,7 +311,7 @@ pub trait TryStreamExt: TryStream {
     /// Any successful values produced by this stream will not be passed to the
     /// closure, and will be passed through.
     ///
-    /// The returned value of the closure must implement the [`TryFuture`](futures_core::future::TryFuture) trait
+    /// The returned value of the closure must implement the [`TryFuture`] trait
     /// and can represent some more work to be done before the composed stream
     /// is finished.
     ///
@@ -415,7 +415,7 @@ pub trait TryStreamExt: TryStream {
     /// yielding a future. That future will then be executed to completion
     /// before moving on to the next item.
     ///
-    /// The returned value is a [`Future`](futures_core::future::Future) where the
+    /// The returned value is a [`Future`] where the
     /// [`Output`](futures_core::future::Future::Output) type is
     /// `Result<(), Self::Error>`. If any of the intermediate
     /// futures or the stream returns an error, this future will return
@@ -940,7 +940,7 @@ pub trait TryStreamExt: TryStream {
     /// the subsequent successful results of the stream. If the stream is empty,
     /// the default value will be returned.
     ///
-    /// Works with all collections that implement the [`Extend`](std::iter::Extend) trait.
+    /// Works with all collections that implement the [`Extend`] trait.
     ///
     /// This method is similar to [`concat`](crate::stream::StreamExt::concat), but will
     /// exit early if an error is encountered in the stream.
@@ -977,7 +977,7 @@ pub trait TryStreamExt: TryStream {
 
     /// Attempt to execute several futures from a stream concurrently (unordered).
     ///
-    /// This stream's `Ok` type must be a [`TryFuture`](futures_core::future::TryFuture) with an `Error` type
+    /// This stream's `Ok` type must be a [`TryFuture`] with an `Error` type
     /// that matches the stream's `Error` type.
     ///
     /// This adaptor will buffer up to `n` futures and then return their
@@ -1046,7 +1046,7 @@ pub trait TryStreamExt: TryStream {
 
     /// Attempt to execute several futures from a stream concurrently.
     ///
-    /// This stream's `Ok` type must be a [`TryFuture`](futures_core::future::TryFuture) with an `Error` type
+    /// This stream's `Ok` type must be a [`TryFuture`] with an `Error` type
     /// that matches the stream's `Error` type.
     ///
     /// This adaptor will buffer up to `n` futures and then return their

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -89,10 +89,10 @@ mod try_flatten;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_flatten::TryFlatten;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod try_flatten_unordered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_flatten_unordered::TryFlattenUnordered;
@@ -133,26 +133,26 @@ mod try_take_while;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_take_while::TryTakeWhile;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod try_buffer_unordered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_buffer_unordered::TryBufferUnordered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod try_buffered;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_buffered::TryBuffered;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 mod try_for_each_concurrent;
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::try_for_each_concurrent::TryForEachConcurrent;
@@ -551,7 +551,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(Err(oneshot::Canceled), fut.await);
     /// # })
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn try_for_each_concurrent<Fut, F>(
         self,
@@ -830,7 +830,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(values, vec![Ok(1), Ok(2), Ok(4), Err(3), Err(5)]);
     /// # });
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn try_flatten_unordered(self, limit: impl Into<Option<usize>>) -> TryFlattenUnordered<Self>
     where
@@ -1032,7 +1032,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(buffered.next().await, Some(Err("error in the stream")));
     /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn try_buffer_unordered(self, n: usize) -> TryBufferUnordered<Self>
     where
@@ -1108,7 +1108,7 @@ pub trait TryStreamExt: TryStream {
     /// assert_eq!(buffered.next().await, Some(Err("error in the stream")));
     /// # Ok::<(), Box<dyn std::error::Error>>(()) }).unwrap();
     /// ```
-    #[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+    #[cfg(target_has_atomic = "ptr")]
     #[cfg(feature = "alloc")]
     fn try_buffered(self, n: usize) -> TryBuffered<Self>
     where

--- a/futures-util/src/stream/try_stream/mod.rs
+++ b/futures-util/src/stream/try_stream/mod.rs
@@ -1137,7 +1137,7 @@ pub trait TryStreamExt: TryStream {
     /// Wraps a [`TryStream`] into a stream compatible with libraries using
     /// futures 0.1 `Stream`. Requires the `compat` feature to be enabled.
     /// ```
-    /// # if cfg!(miri) { return; } // Miri does not support epoll
+    /// # if cfg!(miri) { return; } // Miri does not support epoll_create
     /// use futures::future::{FutureExt, TryFutureExt};
     /// # let (tx, rx) = futures::channel::oneshot::channel();
     ///

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -22,22 +22,19 @@ pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError,
 pub use futures_task::noop_waker;
 pub use futures_task::noop_waker_ref;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use futures_task::ArcWake;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use futures_task::waker;
 
-#[cfg_attr(target_os = "none", cfg(target_has_atomic = "ptr"))]
+#[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "alloc")]
 pub use futures_task::{waker_ref, WakerRef};
 
-#[cfg_attr(
-    target_os = "none",
-    cfg(any(target_has_atomic = "ptr", feature = "portable-atomic"))
-)]
+#[cfg(any(target_has_atomic = "ptr", feature = "portable-atomic"))]
 pub use futures_core::task::__internal::AtomicWaker;
 
 mod spawn;

--- a/futures-util/src/task/mod.rs
+++ b/futures-util/src/task/mod.rs
@@ -13,6 +13,10 @@
 #[doc(no_inline)]
 pub use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
+#[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
+#[doc(no_inline)]
+pub use alloc::task::Wake;
+
 pub use futures_task::{FutureObj, LocalFutureObj, LocalSpawn, Spawn, SpawnError, UnsafeFutureObj};
 
 pub use futures_task::noop_waker;

--- a/futures-util/src/task/spawn.rs
+++ b/futures-util/src/task/spawn.rs
@@ -56,8 +56,8 @@ pub trait SpawnExt: Spawn {
     /// Spawns a task that polls the given future to completion and returns a
     /// future that resolves to the spawned future's output.
     ///
-    /// This method returns a [`Result`] that contains a [`RemoteHandle`](crate::future::RemoteHandle), or, if
-    /// spawning fails, a [`SpawnError`]. [`RemoteHandle`](crate::future::RemoteHandle) is a future that
+    /// This method returns a [`Result`] that contains a [`RemoteHandle`], or, if
+    /// spawning fails, a [`SpawnError`]. [`RemoteHandle`] is a future that
     /// resolves to the output of the spawned future.
     ///
     /// ```
@@ -137,8 +137,8 @@ pub trait LocalSpawnExt: LocalSpawn {
     /// Spawns a task that polls the given future to completion and returns a
     /// future that resolves to the spawned future's output.
     ///
-    /// This method returns a [`Result`] that contains a [`RemoteHandle`](crate::future::RemoteHandle), or, if
-    /// spawning fails, a [`SpawnError`]. [`RemoteHandle`](crate::future::RemoteHandle) is a future that
+    /// This method returns a [`Result`] that contains a [`RemoteHandle`], or, if
+    /// spawning fails, a [`SpawnError`]. [`RemoteHandle`] is a future that
     /// resolves to the output of the spawned future.
     ///
     /// ```

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.32", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.32", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.32", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.32", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.32", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.32", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.32", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.33", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.33", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.33", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.33", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/auto_traits.rs
+++ b/futures/tests/auto_traits.rs
@@ -10,6 +10,7 @@ use futures::{
     task::{Context, Poll},
 };
 use static_assertions::{assert_impl_all as assert_impl, assert_not_impl_all as assert_not_impl};
+use std::cell::Cell;
 use std::marker::PhantomPinned;
 use std::{marker::PhantomData, pin::Pin};
 
@@ -1838,6 +1839,7 @@ mod stream {
 
     assert_impl!(futures_unordered::Iter<'_, ()>: Send);
     assert_not_impl!(futures_unordered::Iter<'_, *const ()>: Send);
+    assert_not_impl!(futures_unordered::Iter<'_, Cell<()>>: Send);
     assert_impl!(futures_unordered::Iter<'_, ()>: Sync);
     assert_not_impl!(futures_unordered::Iter<'_, *const ()>: Sync);
     assert_impl!(futures_unordered::Iter<'_, ()>: Unpin);
@@ -1860,6 +1862,7 @@ mod stream {
 
     assert_impl!(futures_unordered::IterPinRef<'_, ()>: Send);
     assert_not_impl!(futures_unordered::IterPinRef<'_, *const ()>: Send);
+    assert_not_impl!(futures_unordered::IterPinRef<'_, Cell<()>>: Send);
     assert_impl!(futures_unordered::IterPinRef<'_, ()>: Sync);
     assert_not_impl!(futures_unordered::IterPinRef<'_, *const ()>: Sync);
     assert_impl!(futures_unordered::IterPinRef<'_, PhantomPinned>: Unpin);

--- a/futures/tests/compat.rs
+++ b/futures/tests/compat.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "compat")]
-#![cfg(not(miri))] // Miri does not support epoll
+#![cfg(not(miri))] // Miri does not support epoll_create
 
 use futures::compat::Future01CompatExt;
 use futures::prelude::*;

--- a/futures/tests/compat_miri.rs
+++ b/futures/tests/compat_miri.rs
@@ -1,0 +1,14 @@
+#![cfg(feature = "compat")]
+use futures::compat::Future01CompatExt;
+use futures::executor::block_on;
+use futures::future::TryFutureExt;
+
+#[test]
+// from https://github.com/rust-lang/futures-rs/issues/2514
+fn miri_compat_two_way() {
+    let fut = async { Ok(()) as Result<(), ()> };
+    let fut = Box::pin(fut);
+    let fut = fut.compat(); // 03as01
+    let fut = fut.compat(); // 01as03
+    block_on(fut).unwrap();
+}

--- a/futures/tests/io_read_to_end.rs
+++ b/futures/tests/io_read_to_end.rs
@@ -48,7 +48,7 @@ fn issue2310() {
     impl Drop for VecWrapper {
         fn drop(&mut self) {
             // Observe uninitialized bytes
-            println!("{:?}", &self.inner);
+            println!("{:?}", self.inner);
             // Overwrite heap contents
             for b in &mut self.inner {
                 *b = 0x90;

--- a/futures/tests/io_read_until.rs
+++ b/futures/tests/io_read_until.rs
@@ -26,10 +26,10 @@ fn read_until() {
     let mut v = Vec::new();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 3);
     assert_eq!(v, b"123");
-    v.truncate(0);
+    v.clear();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 1);
     assert_eq!(v, b"3");
-    v.truncate(0);
+    v.clear();
     assert_eq!(block_on(buf.read_until(b'3', &mut v)).unwrap(), 0);
     assert_eq!(v, []);
 }

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -8,7 +8,7 @@ use futures_test::task::noop_context;
 use futures_test::{assert_stream_done, assert_stream_next, assert_stream_pending};
 use std::iter::FromIterator;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 #[test]
 fn is_terminated() {
@@ -428,4 +428,83 @@ fn panic_on_drop_fut() {
     }
 
     FuturesUnordered::default().push(BadFuture);
+}
+
+#[test]
+fn into_iter_after_poll_doesnt_leak() {
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+
+    struct DetectDrop;
+    impl Drop for DetectDrop {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct PendingFuture {
+        _guard: DetectDrop,
+        ready: bool,
+    }
+
+    impl Unpin for PendingFuture {}
+
+    impl Future for PendingFuture {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.ready {
+                Poll::Ready(())
+            } else {
+                self.ready = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+
+    DROPPED.store(false, Ordering::SeqCst);
+
+    let mut fu = FuturesUnordered::new();
+    fu.push(PendingFuture { _guard: DetectDrop, ready: false });
+
+    let mut cx = noop_context();
+    let _ = fu.poll_next_unpin(&mut cx);
+    assert!(!DROPPED.load(Ordering::SeqCst));
+
+    let collected: Vec<_> = fu.into_iter().collect();
+    assert_eq!(collected.len(), 1);
+    drop(collected);
+
+    assert!(DROPPED.load(Ordering::SeqCst));
+}
+
+#[test]
+fn into_iter_partial_doesnt_leak() {
+    static DROP_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    struct Counted;
+    impl Drop for Counted {
+        fn drop(&mut self) {
+            DROP_COUNT.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct CountedFuture(Counted);
+    impl Unpin for CountedFuture {}
+    impl Future for CountedFuture {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Pending
+        }
+    }
+
+    DROP_COUNT.store(0, Ordering::SeqCst);
+
+    let fu: FuturesUnordered<_> = (0..4).map(|_| CountedFuture(Counted)).collect();
+
+    let mut into_iter = fu.into_iter();
+    let _ = into_iter.next();
+    let _ = into_iter.next();
+    drop(into_iter);
+
+    assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 4);
 }


### PR DESCRIPTION


Changes:

* Fix `ReadLine`'s soundness issue regarding to exception safety. (#3020)
* Fix unsound `Send` impl for `IterPinRef` and `Iter`. (#3003)
* Fix stacked borrows violation in compat01as03 implementation. (#3012)
* Fix memory leak in `FuturesUnordered::IntoIter`. (#3005)
* Add `portable-atomic-alloc` feature and use it in `FuturesUnordered`. (#3007)
* Re-export `alloc::task::Wake`. (#3010)
* Update `spin` to 0.12. (#3014)

Backports:


* #3020
* #3003
* #3012
* #3005
* #3007
* #3010
* #3014
- #3017
- #3021
- (and various CI/lint/style related commit from my PRs)