### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - '[0-9]+.[0-9]+'
   schedule:
     - cron: '0 2 * * 0'

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rust-lang/futures-rs/actions?query=branch%3Amaster">
-    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/rust-lang/futures-rs/ci.yml?branch=master">
+  <a href="https://github.com/rust-lang/futures-rs/actions?query=branch%3Amain">
+    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/rust-lang/futures-rs/ci.yml?branch=main">
   </a>
 
   <a href="https://crates.io/crates/futures">


### PR DESCRIPTION
Per [#t-infra > Renaming default branches from master to main](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/Renaming.20default.20branches.20from.20master.20to.20main/with/542920517).

Blocked on the actual branch name update.