### PR TITLE
chore(macro): bump `syn` to v3

### DIFF
--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1.0"
-syn = { version = "2.0.52", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Following the [release of a new major version of `syn`](https://github.com/dtolnay/syn/releases/tag/3.0.0), this bumps the version used by `futures-macro`, with the goal of eventually removing the duplicated dependency in binaries (and therefore reducing compile times).

`syn` v3 [advertises an MSRV of 1.71](https://crates.io/crates/syn/3.0.0/code/Cargo.toml#L14), so this shouldn't affect the MSRV of this crate.

`syn` v3 of course contains breaking changes: I've been through the changelog but didn't find anything relevant (but there are quite a few of them so I could have missed some). I've run `cargo test --all-features` but didn't do any other kind of testing.

Closes #3034