### PR TITLE
channel: document the buffer-size panic

### DIFF
--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -379,6 +379,11 @@ impl SenderTask {
 ///
 /// The [`Receiver`] returned implements the [`Stream`] trait, while [`Sender`]
 /// implements `Sink`.
+///
+/// # Panics
+///
+/// This function panics if `buffer` is `usize::MAX / 4` or larger, the
+/// maximum buffer size permitted by the implementation.
 pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
     // Check that the requested buffer size does not exceed the maximum buffer
     // size permitted by the system.

--- a/futures-channel/src/mpsc/mod.rs
+++ b/futures-channel/src/mpsc/mod.rs
@@ -382,8 +382,8 @@ impl SenderTask {
 ///
 /// # Panics
 ///
-/// This function panics if `buffer` is `usize::MAX / 4` or larger, the
-/// maximum buffer size permitted by the implementation.
+/// This function panics if `buffer >= usize::MAX / 4`; the largest
+/// permitted buffer size is `usize::MAX / 4 - 1`.
 pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
     // Check that the requested buffer size does not exceed the maximum buffer
     // size permitted by the system.


### PR DESCRIPTION
`mpsc::channel` asserts `buffer < MAX_BUFFER` ("requested buffer size too large"), but the panic is not documented. This PR adds a `# Panics` section stating the bound (`usize::MAX / 4`, i.e. `MAX_CAPACITY >> 1` where `MAX_CAPACITY` excludes the `is_open` bit). The bound was verified empirically: `channel::<u8>(usize::MAX / 4 - 1)` is accepted, `channel::<u8>(usize::MAX / 4)` panics. futures-channel tests pass.

Found by running Kani's [autoharness](https://model-checking.github.io/kani/reference/experimental/autoharness.html) (model-checking/kani#3832) over futures-channel 0.3.33, which reported the assertion reachable for unconstrained buffer sizes.
