### PR TITLE
Preserve cloned FuturesUnordered waker identity

### DIFF
--- a/futures-task/src/noop_waker.rs
+++ b/futures-task/src/noop_waker.rs
@@ -5,6 +5,7 @@ use core::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
+#[inline(always)]
 unsafe fn noop_clone(_data: *const ()) -> RawWaker {
     noop_raw_waker()
 }

--- a/futures-test/src/task/panic_waker.rs
+++ b/futures-test/src/task/panic_waker.rs
@@ -2,6 +2,7 @@ use core::ptr::null;
 
 use futures_core::task::{RawWaker, RawWakerVTable, Waker};
 
+#[inline(always)]
 unsafe fn clone_panic_waker(_data: *const ()) -> RawWaker {
     raw_panic_waker()
 }

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -250,6 +250,7 @@ mod waker_ref {
         let _arc_clone: mem::ManuallyDrop<_> = arc.clone();
     }
 
+    #[inline(always)]
     unsafe fn clone_arc_raw<T: ArcWake>(data: *const ()) -> RawWaker {
         unsafe { increase_refcount::<T>(data) }
         RawWaker::new(data, waker_vtable::<T>())

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -514,3 +514,22 @@ fn into_iter_partial_doesnt_leak() {
 
     assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 4);
 }
+
+#[test]
+fn cloned_child_waker_preserves_identity() {
+    struct CheckWakerClone;
+
+    impl Future for CheckWakerClone {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            let clone = cx.waker().clone();
+            assert!(cx.waker().will_wake(&clone));
+            Poll::Ready(())
+        }
+    }
+
+    let output =
+        block_on_stream(FuturesUnordered::from_iter([CheckWakerClone])).collect::<Vec<_>>();
+    assert_eq!(output, [()]);
+}


### PR DESCRIPTION
Applies the same fix as #2865 to the private `waker_ref` implementation used by `FuturesUnordered`.

See also rust-lang/rust#121622.
