### PR TITLE
`futures-io`: Use nightly-only `core::io`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,12 @@ jobs:
             target: i686-unknown-linux-gnu
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
+          - os: ubuntu-latest
+            rustflags: "--cfg futures_unstable_core_io"
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      RUSTFLAGS: ${{ env.RUSTFLAGS }} ${{ matrix.rustflags }}
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
@@ -171,7 +175,7 @@ jobs:
       - run: cargo minimal-versions build --workspace --ignore-private --all-features
 
   no-std:
-    name: cargo build --target ${{ matrix.target }}
+    name: RUSTFLAGS=${{ matrix.core_io }} cargo build --target ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -180,8 +184,13 @@ jobs:
         target:
           - thumbv7m-none-eabi
           - thumbv6m-none-eabi
+        core_io:
+          - "--cfg futures_unstable_core_io"
+          - ""
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      RUSTFLAGS: ${{ env.RUSTFLAGS }} ${{ matrix.core_io }}
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ rust_2018_idioms = "warn"
 single_use_lifetimes = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(futures_sanitizer)',
+    ## Enables `no_std` support by using `core::io`.
+    ## Requires at least nightly 2026-07-19.
+    "cfg(futures_unstable_core_io)",
 ] }
 unreachable_pub = "warn"
 # unsafe_op_in_unsafe_fn = "warn" # Set at crate-level instead since https://github.com/rust-lang/rust/pull/100081 is not available on MSRV

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -13,7 +13,8 @@ The `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` traits for the fu
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc"]
+alloc = []
 
 # Unstable features
 # These features are outside of the normal semver guarantees and require the

--- a/futures-io/src/lib.rs
+++ b/futures-io/src/lib.rs
@@ -18,20 +18,27 @@
     clippy::std_instead_of_core
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(futures_unstable_core_io, feature(core_io))]
 
-#[cfg(feature = "std")]
+#[allow(unused_extern_crates)]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", futures_unstable_core_io))]
 mod if_std {
+    #[cfg(feature = "alloc")]
     use alloc::{boxed::Box, vec::Vec};
+    #[cfg(futures_unstable_core_io)]
+    use core::io;
     use core::{
+        cmp,
         ops::DerefMut,
         pin::Pin,
         task::{Context, Poll},
     };
+    #[cfg(not(futures_unstable_core_io))]
     use std::io;
 
     // Re-export some types from `std::io` so that users don't have to deal
@@ -322,6 +329,7 @@ mod if_std {
         };
     }
 
+    #[cfg(feature = "alloc")]
     impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for Box<T> {
         deref_async_read!();
     }
@@ -352,28 +360,27 @@ mod if_std {
         }
     }
 
-    macro_rules! delegate_async_read_to_stdio {
-        () => {
-            fn poll_read(
-                mut self: Pin<&mut Self>,
-                _: &mut Context<'_>,
-                buf: &mut [u8],
-            ) -> Poll<Result<usize>> {
-                Poll::Ready(io::Read::read(&mut *self, buf))
-            }
-
-            fn poll_read_vectored(
-                mut self: Pin<&mut Self>,
-                _: &mut Context<'_>,
-                bufs: &mut [IoSliceMut<'_>],
-            ) -> Poll<Result<usize>> {
-                Poll::Ready(io::Read::read_vectored(&mut *self, bufs))
-            }
-        };
-    }
-
     impl AsyncRead for &[u8] {
-        delegate_async_read_to_stdio!();
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
+            let amt = cmp::min(buf.len(), self.len());
+            let (a, b) = self.split_at(amt);
+
+            // First check if the amount of bytes we want to read is small:
+            // `copy_from_slice` will generally expand to a call to `memcpy`, and
+            // for a single byte the overhead is significant.
+            if amt == 1 {
+                buf[0] = a[0];
+            } else {
+                buf[..amt].copy_from_slice(a);
+            }
+
+            *self = b;
+            Poll::Ready(Ok(amt))
+        }
     }
 
     macro_rules! deref_async_write {
@@ -404,6 +411,7 @@ mod if_std {
         };
     }
 
+    #[cfg(feature = "alloc")]
     impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for Box<T> {
         deref_async_write!();
     }
@@ -442,6 +450,7 @@ mod if_std {
         }
     }
 
+    #[cfg_attr(not(feature = "alloc"), allow(unused_macros))]
     macro_rules! delegate_async_write_to_stdio {
         () => {
             fn poll_write(
@@ -470,6 +479,7 @@ mod if_std {
         };
     }
 
+    #[cfg(feature = "alloc")]
     impl AsyncWrite for Vec<u8> {
         delegate_async_write_to_stdio!();
     }
@@ -486,6 +496,7 @@ mod if_std {
         };
     }
 
+    #[cfg(feature = "alloc")]
     impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for Box<T> {
         deref_async_seek!();
     }
@@ -520,6 +531,7 @@ mod if_std {
         };
     }
 
+    #[cfg(feature = "alloc")]
     impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
         deref_async_buf_read!();
     }
@@ -542,22 +554,16 @@ mod if_std {
         }
     }
 
-    macro_rules! delegate_async_buf_read_to_stdio {
-        () => {
-            fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
-                Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
-            }
-
-            fn consume(self: Pin<&mut Self>, amt: usize) {
-                io::BufRead::consume(self.get_mut(), amt)
-            }
-        };
-    }
-
     impl AsyncBufRead for &[u8] {
-        delegate_async_buf_read_to_stdio!();
+        fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+            Poll::Ready(Ok(*self))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            *self = &self[amt..];
+        }
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", futures_unstable_core_io))]
 pub use self::if_std::*;

--- a/futures/tests/no-std/Cargo.toml
+++ b/futures/tests/no-std/Cargo.toml
@@ -12,6 +12,7 @@ futures-util-alloc = ["futures-util/alloc"]
 futures-util-async-await = ["futures-util/async-await"]
 futures-alloc = ["futures/alloc"]
 futures-async-await = ["futures/async-await"]
+futures-io-alloc = ["futures-io/alloc"]
 
 [dependencies]
 futures-core = { path = "../../../futures-core", optional = true, default-features = false }
@@ -19,6 +20,7 @@ futures-task = { path = "../../../futures-task", optional = true, default-featur
 futures-channel = { path = "../../../futures-channel", optional = true, default-features = false }
 futures-util = { path = "../../../futures-util", optional = true, default-features = false }
 futures = { path = "../..", optional = true, default-features = false }
+futures-io = { path = "../../../futures-io", optional = true, default-features = false }
 
 [lints]
 workspace = true

--- a/futures/tests/no-std/src/lib.rs
+++ b/futures/tests/no-std/src/lib.rs
@@ -14,6 +14,9 @@ pub use futures_channel::oneshot as _;
 #[cfg(feature = "futures-core-alloc")]
 #[cfg(target_has_atomic = "ptr")]
 pub use futures_core::task::__internal::AtomicWaker as _;
+#[cfg(feature = "futures-io")]
+#[cfg(futures_unstable_core_io)]
+pub use futures_io::{AsyncRead as _, AsyncWrite as _};
 #[cfg(feature = "futures-task-alloc")]
 #[cfg(target_has_atomic = "ptr")]
 pub use futures_task::ArcWake as _;


### PR DESCRIPTION
# Description

Implements `no_std` support behind a new rustflag `futures_unstable_nightly_core_io` by relying on the unstable nightly `core_io` feature. This allows targets such as `wasm32v1-none` to use the async traits in this crate. Please see [rust-lang/rust#154046](https://github.com/rust-lang/rust/issues/154046) for details on tracking issue.

---

## Notes

* No AI tooling of any kind was used during the making of this PR.