### PR TITLE
ci: Test AArch64 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           - os: ubuntu-latest
           - os: macos-latest
           - os: windows-latest
+          - os: windows-11-arm
           - os: ubuntu-24.04-arm
           - os: ubuntu-24.04-arm
             target: armv7-unknown-linux-gnueabihf

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -52,7 +52,6 @@ optional = true
 [dev-dependencies]
 futures = { path = "../futures", features = ["async-await", "thread-pool"] }
 futures-test = { path = "../futures-test" }
-tokio = "0.1.11"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -30,7 +30,6 @@ futures-test = { path = "../futures-test" }
 assert_matches = "1.3.0"
 pin-project = "1.0.11"
 static_assertions = "1"
-tokio = "0.1.11"
 
 [features]
 default = ["std", "async-await", "executor"]


### PR DESCRIPTION
Unblocked by #3036 (when I tried this before, it didn't work because the compat feature depended on old winapi via old tokio).