### PR TITLE
Release 0.3.34 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,7 @@ jobs:
         if: matrix.sanitizer == 'memory'
       - run: |
           printf 'TARGET=x86_64-unknown-linux-gnutsan\n' >>"${GITHUB_ENV}"
+          printf 'TSAN_OPTIONS=enable_adaptive_delay=1\n' >>"${GITHUB_ENV}"
         if: matrix.sanitizer == 'thread'
       - name: Install Rust
         uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - '[0-9]+.[0-9]+'
   schedule:
     - cron: '0 1 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
@@ -80,7 +80,7 @@ jobs:
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
           - '1.36'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack
@@ -116,7 +116,7 @@ jobs:
           # When updating this, the reminder to update the minimum required version in README.md and Cargo.toml.
           - '1.71'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack
@@ -150,7 +150,7 @@ jobs:
           - beta
           - nightly
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack
@@ -164,7 +164,7 @@ jobs:
   minimal-versions:
     name: cargo minimal-versions build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust, cargo-hack, and cargo-minimal-versions
@@ -185,7 +185,7 @@ jobs:
           - thumbv7m-none-eabi
           - thumbv6m-none-eabi
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack
@@ -218,7 +218,7 @@ jobs:
   bench:
     name: cargo bench
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
@@ -231,7 +231,7 @@ jobs:
   features:
     name: cargo hack check --feature-powerset
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and cargo-hack
@@ -255,7 +255,7 @@ jobs:
   miri:
     name: cargo miri test
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust
@@ -284,7 +284,7 @@ jobs:
           - memory
           - thread
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - run: |
@@ -312,7 +312,7 @@ jobs:
 
   tidy:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
       - name: Install Rust and zizmor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Releases may yanked if there is a security bug, a soundness bug, or a regression
 Note: In this file, do not use the hard wrap in the middle of a sentence for compatibility with GitHub comment style markdown rendering.
 -->
 
+# 0.3.34 - 2026-08-11
+
+* Preserve cloned waker identity. (#3032)
+* Updato `syn` to 3. (#3028)
+
 # 0.3.33 - 2026-07-18
 
 * Fix `ReadLine`'s soundness issue regarding to exception safety. (#3020)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rust-lang/futures-rs/actions?query=branch%3Amaster">
-    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/rust-lang/futures-rs/ci.yml?branch=master">
+  <a href="https://github.com/rust-lang/futures-rs/actions?query=branch%3Amain">
+    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/rust-lang/futures-rs/ci.yml?branch=main">
   </a>
 
   <a href="https://crates.io/crates/futures">

--- a/futures-channel/Cargo.toml
+++ b/futures-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -23,8 +23,8 @@ unstable = []
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.34", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.34", default-features = false, optional = true }
 
 [dev-dependencies]
 futures = { path = "../futures", default-features = true }

--- a/futures-core/Cargo.toml
+++ b/futures-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-executor/Cargo.toml
+++ b/futures-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -17,9 +17,9 @@ std = ["futures-core/std", "futures-task/std", "futures-util/std"]
 thread-pool = ["std"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.33", default-features = false }
+futures-core = { path = "../futures-core", version = "0.3.34", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.34", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.34", default-features = false }
 
 [dev-dependencies]
 futures = { path = "../futures", features = ["thread-pool"] }

--- a/futures-io/Cargo.toml
+++ b/futures-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -19,7 +19,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1.0"
-syn = { version = "2.0.52", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 
 [lints]
 workspace = true

--- a/futures-macro/Cargo.toml
+++ b/futures-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"

--- a/futures-sink/Cargo.toml
+++ b/futures-sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and core-msrv job in .github/workflows/ci.yml
 rust-version = "1.36"

--- a/futures-task/Cargo.toml
+++ b/futures-task/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"

--- a/futures-task/src/noop_waker.rs
+++ b/futures-task/src/noop_waker.rs
@@ -3,6 +3,7 @@
 use core::ptr::null;
 use core::task::{RawWaker, RawWakerVTable, Waker};
 
+#[inline(always)]
 unsafe fn noop_clone(_data: *const ()) -> RawWaker {
     noop_raw_waker()
 }

--- a/futures-test/Cargo.toml
+++ b/futures-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-test"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -12,13 +12,13 @@ Common utilities for testing components built off futures-rs.
 """
 
 [dependencies]
-futures-core = { version = "0.3.33", path = "../futures-core", default-features = false }
-futures-task = { version = "0.3.33", path = "../futures-task", default-features = false }
-futures-io = { version = "0.3.33", path = "../futures-io", default-features = false }
-futures-util = { version = "0.3.33", path = "../futures-util", default-features = false }
-futures-executor = { version = "0.3.33", path = "../futures-executor", default-features = false }
-futures-sink = { version = "0.3.33", path = "../futures-sink", default-features = false }
-futures-macro = { version = "=0.3.33", path = "../futures-macro", default-features = false }
+futures-core = { version = "0.3.34", path = "../futures-core", default-features = false }
+futures-task = { version = "0.3.34", path = "../futures-task", default-features = false }
+futures-io = { version = "0.3.34", path = "../futures-io", default-features = false }
+futures-util = { version = "0.3.34", path = "../futures-util", default-features = false }
+futures-executor = { version = "0.3.34", path = "../futures-executor", default-features = false }
+futures-sink = { version = "0.3.34", path = "../futures-sink", default-features = false }
+futures-macro = { version = "=0.3.34", path = "../futures-macro", default-features = false }
 pin-project = "1.0.11"
 
 [dev-dependencies]

--- a/futures-test/src/task/panic_waker.rs
+++ b/futures-test/src/task/panic_waker.rs
@@ -1,6 +1,7 @@
 use core::ptr::null;
 use futures_core::task::{RawWaker, RawWakerVTable, Waker};
 
+#[inline(always)]
 unsafe fn clone_panic_waker(_data: *const ()) -> RawWaker {
     raw_panic_waker()
 }

--- a/futures-util/Cargo.toml
+++ b/futures-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -37,12 +37,12 @@ write-all-vectored = ["io"]
 cfg-target-has-atomic = []
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.33", default-features = false, features = ["std"], optional = true }
-futures-io = { path = "../futures-io", version = "0.3.33", default-features = false, features = ["std"], optional = true }
-futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false, optional = true }
-futures-macro = { path = "../futures-macro", version = "=0.3.33", default-features = false, optional = true }
+futures-core = { path = "../futures-core", version = "0.3.34", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.34", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.34", default-features = false, features = ["std"], optional = true }
+futures-io = { path = "../futures-io", version = "0.3.34", default-features = false, features = ["std"], optional = true }
+futures-sink = { path = "../futures-sink", version = "0.3.34", default-features = false, optional = true }
+futures-macro = { path = "../futures-macro", version = "=0.3.34", default-features = false, optional = true }
 slab = { version = "0.4.7", default-features = false, optional = true }
 memchr = { version = "2.2", optional = true }
 futures_01 = { version = "0.1.25", optional = true, package = "futures" }

--- a/futures-util/src/compat/compat01as03.rs
+++ b/futures-util/src/compat/compat01as03.rs
@@ -66,6 +66,7 @@ pub trait Future01CompatExt: Future01 {
     /// [`Future<Output = Result<T, E>>`](futures_core::future::Future).
     ///
     /// ```
+    /// # if cfg!(miri) { return; } // 0.1 task_impl uses ptr2int
     /// # futures::executor::block_on(async {
     /// # // TODO: These should be all using `futures::compat`, but that runs up against Cargo
     /// # // feature issues
@@ -92,6 +93,7 @@ pub trait Stream01CompatExt: Stream01 {
     /// [`Stream<Item = Result<T, E>>`](futures_core::stream::Stream).
     ///
     /// ```
+    /// # if cfg!(miri) { return; } // 0.1 task_impl uses ptr2int
     /// # futures::executor::block_on(async {
     /// use futures::stream::StreamExt;
     /// use futures_util::compat::Stream01CompatExt;
@@ -121,6 +123,7 @@ pub trait Sink01CompatExt: Sink01 {
     /// [`Sink<T, Error = E>`](futures_sink::Sink).
     ///
     /// ```
+    /// # if cfg!(miri) { return; } // 0.1 task_impl uses ptr2int
     /// # futures::executor::block_on(async {
     /// use futures::{sink::SinkExt, stream::StreamExt};
     /// use futures_util::compat::{Stream01CompatExt, Sink01CompatExt};

--- a/futures-util/src/compat/compat03as01.rs
+++ b/futures-util/src/compat/compat03as01.rs
@@ -163,6 +163,7 @@ impl Current {
             current as *const Current as *const ()
         }
 
+        #[inline(always)]
         unsafe fn clone(ptr: *const ()) -> RawWaker {
             // Lazily create the `Arc` only when the waker is actually cloned.
             // FIXME: remove `transmute` when a `Waker` -> `RawWaker` conversion

--- a/futures-util/src/stream/futures_unordered/task.rs
+++ b/futures-util/src/stream/futures_unordered/task.rs
@@ -247,6 +247,7 @@ mod waker_ref {
         let _arc_clone: mem::ManuallyDrop<_> = arc.clone();
     }
 
+    #[inline(always)]
     unsafe fn clone_arc_raw<T: ArcWake>(data: *const ()) -> RawWaker {
         unsafe { increase_refcount::<T>(data) }
         RawWaker::new(data, waker_vtable::<T>())

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 edition = "2018"
 # NB: Sync with "Usage" section in README.md and util-msrv job in .github/workflows/ci.yml
 rust-version = "1.71"
@@ -16,13 +16,13 @@ composability, and iterator-like interfaces.
 categories = ["asynchronous"]
 
 [dependencies]
-futures-core = { path = "../futures-core", version = "0.3.33", default-features = false }
-futures-task = { path = "../futures-task", version = "0.3.33", default-features = false }
-futures-channel = { path = "../futures-channel", version = "0.3.33", default-features = false, features = ["sink"] }
-futures-executor = { path = "../futures-executor", version = "0.3.33", default-features = false, optional = true }
-futures-io = { path = "../futures-io", version = "0.3.33", default-features = false }
-futures-sink = { path = "../futures-sink", version = "0.3.33", default-features = false }
-futures-util = { path = "../futures-util", version = "0.3.33", default-features = false, features = ["sink"] }
+futures-core = { path = "../futures-core", version = "0.3.34", default-features = false }
+futures-task = { path = "../futures-task", version = "0.3.34", default-features = false }
+futures-channel = { path = "../futures-channel", version = "0.3.34", default-features = false, features = ["sink"] }
+futures-executor = { path = "../futures-executor", version = "0.3.34", default-features = false, optional = true }
+futures-io = { path = "../futures-io", version = "0.3.34", default-features = false }
+futures-sink = { path = "../futures-sink", version = "0.3.34", default-features = false }
+futures-util = { path = "../futures-util", version = "0.3.34", default-features = false, features = ["sink"] }
 
 [dev-dependencies]
 futures-executor = { path = "../futures-executor", features = ["thread-pool"] }

--- a/futures/tests/compat_miri.rs
+++ b/futures/tests/compat_miri.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "compat")]
+#![cfg(not(miri))] // 0.1 task_impl uses ptr2int
 use futures::compat::Future01CompatExt;
 use futures::executor::block_on;
 use futures::future::TryFutureExt;

--- a/futures/tests/stream_futures_unordered.rs
+++ b/futures/tests/stream_futures_unordered.rs
@@ -508,3 +508,22 @@ fn into_iter_partial_doesnt_leak() {
 
     assert_eq!(DROP_COUNT.load(Ordering::SeqCst), 4);
 }
+
+#[test]
+fn cloned_child_waker_preserves_identity() {
+    struct CheckWakerClone;
+
+    impl Future for CheckWakerClone {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            let clone = cx.waker().clone();
+            assert!(cx.waker().will_wake(&clone));
+            Poll::Ready(())
+        }
+    }
+
+    let output =
+        block_on_stream(FuturesUnordered::from_iter([CheckWakerClone])).collect::<Vec<_>>();
+    assert_eq!(output, [()]);
+}


### PR DESCRIPTION
Changes:
* Preserve cloned waker identity. (#3032)
* Updato `syn` to 3. (#3028)

Backports
* #3028
* #3032
* and some CI related changes