### PR TITLE
docs: fix select link in select_with_strategy

### DIFF
--- a/futures-util/src/stream/select_with_strategy.rs
+++ b/futures-util/src/stream/select_with_strategy.rs
@@ -116,7 +116,7 @@ pin_project! {
 ///
 /// ### Round Robin
 /// This example shows how to select from both streams round robin.
-/// Note: this special case is provided by [`stream::select`](crate::stream::select()).
+/// Note: this special case is provided by [`stream::select`](fn@crate::stream::select).
 ///
 /// ```rust
 /// # futures::executor::block_on(async {


### PR DESCRIPTION
Fix the invalid intra-doc link to `stream::select` in the round-robin example by linking to the function item path without call syntax.

Fixes #2935