### PR TITLE
Document that Mutex requires the std feature

### DIFF
--- a/futures-util/src/lock/mod.rs
+++ b/futures-util/src/lock/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use self::bilock::BiLock;
 pub use self::bilock::{BiLock, BiLockAcquire, BiLockGuard, ReuniteError};
 #[cfg(target_has_atomic = "ptr")]
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use self::mutex::{
     MappedMutexGuard, Mutex, MutexGuard, MutexLockFuture, OwnedMutexGuard, OwnedMutexLockFuture,
 };


### PR DESCRIPTION
Closes #2985.

docs.rs currently tells users `Mutex` is "Available on *crate feature* `alloc` only", and that claim is wrong in the direction that hurts: enabling `alloc` without `std` produces no `Mutex` at all.

The module is gated on `alloc` (`lib.rs`), but the `Mutex` family inside it is gated on `std` (`lock/mod.rs`) — and the re-export carried no `doc(cfg)` annotation, so rustdoc only showed the module-level banner. `BiLock`, directly above it in the same file, already carries the `#[cfg_attr(docsrs, doc(cfg(...)))]` annotation; this PR applies the same idiom to the `Mutex` re-export.

Verified by building the docs the way docs.rs does (`RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --features std`, nightly): the rendered `struct.Mutex.html` banner now reads **"Available on crate feature `std` only."**

No code change — `#[cfg]` gating is untouched; only the documented availability changes.


LLM usage, per the Rust policy: this change was developed with AI assistance (Claude). I should have disclosed that when I opened it.
