### PR TITLE
Mention the Unpin requirement in StreamExt::by_ref docs

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -1371,6 +1371,13 @@ pub trait StreamExt: Stream {
     /// This is useful to allow applying stream adaptors while still retaining
     /// ownership of the original stream.
     ///
+    /// Note that the returned `&mut Self` only implements `Stream` if
+    /// `Self: Unpin`, so in generic code this method is only useful with an
+    /// additional [`Unpin`] bound. A stream that is not `Unpin` can be pinned
+    /// first, for example with [`pin_mut!`](https://docs.rs/pin-utils/latest/pin_utils/macro.pin_mut.html);
+    /// a `Pin<&mut Self>` obtained that way is `Unpin` and supports the same
+    /// borrow-then-continue pattern.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Closes #2995.

`by_ref` returns `&mut Self`, and `&mut S` only implements `Stream` when `S: Unpin` — so in generic code the combinator needs an `Unpin` bound the documentation never mentioned. The error the compiler produces points at the adaptor chain rather than the missing bound, which is what made the linked issue's example surprising to its author.

This adds a note in the same voice as the `UnwindSafe` note on `catch_unwind` below it: state the bound, and name the standard escape hatch (pin the stream first; `Pin<&mut S>` is `Unpin` regardless of `S`).

Docs-only; `cargo doc --no-deps --features std` builds with no new warnings.


LLM usage, per the Rust policy: this change was developed with AI assistance (Claude). I should have disclosed that when I opened it.
