### PR TITLE
Document cancel safety of StreamExt::next

### DIFF
--- a/futures-util/src/stream/stream/mod.rs
+++ b/futures-util/src/stream/stream/mod.rs
@@ -235,6 +235,12 @@ pub trait StreamExt: Stream {
     /// pinning it to the stack using the `pin_mut!` macro from the `pin_utils`
     /// crate.
     ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `next` is used as an event in a
+    /// `select!` statement and some other branch completes first, then it is
+    /// guaranteed that no item was removed from this stream.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Adds a cancel safety section to StreamExt::next documenting that dropping the returned future before it completes does not remove an item from the stream, so it is safe to use in a select! branch. Closes #2701, where taiki-e said a PR to document this would be accepted.